### PR TITLE
feat(core): DBスキーマ定義 - Project + ProjectSettings

### DIFF
--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
   dialect: "sqlite",
-  schema: "./src/db/schema.ts",
+  schema: [
+    "./src/schema/projects.ts",
+    "./src/schema/test-cases.ts",
+    "./src/schema/prompt-versions.ts",
+    "./src/schema/runs.ts",
+  ],
   out: "./drizzle",
   dbCredentials: {
     url: process.env.DB_PATH ?? "./dev.db",

--- a/packages/core/drizzle/0000_acoustic_talkback.sql
+++ b/packages/core/drizzle/0000_acoustic_talkback.sql
@@ -1,10 +1,30 @@
+CREATE TABLE `project_settings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` integer NOT NULL,
+	`model` text DEFAULT 'claude-opus-4-5' NOT NULL,
+	`temperature` real DEFAULT 0.7 NOT NULL,
+	`api_provider` text DEFAULT 'anthropic' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
 CREATE TABLE `projects` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
 	`name` text NOT NULL,
-	`model` text DEFAULT 'claude-opus-4-5' NOT NULL,
-	`temperature` real DEFAULT 0.7 NOT NULL,
-	`api_key` text,
-	`created_at` integer NOT NULL
+	`description` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `test_cases` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` integer NOT NULL,
+	`turns` text NOT NULL,
+	`context_refs` text DEFAULT '[]' NOT NULL,
+	`expected_description` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint
 CREATE TABLE `prompt_versions` (
@@ -32,14 +52,4 @@ CREATE TABLE `runs` (
 	`created_at` integer NOT NULL,
 	FOREIGN KEY (`prompt_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action,
 	FOREIGN KEY (`test_case_id`) REFERENCES `test_cases`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
-CREATE TABLE `test_cases` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`project_id` integer NOT NULL,
-	`turns` text NOT NULL,
-	`context_refs` text DEFAULT '[]' NOT NULL,
-	`expected_description` text,
-	`created_at` integer NOT NULL,
-	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
 );

--- a/packages/core/drizzle/meta/0000_snapshot.json
+++ b/packages/core/drizzle/meta/0000_snapshot.json
@@ -1,11 +1,11 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "39f7c3c9-5622-407e-a7b5-8cacbf4d3cbf",
+  "id": "1ef03141-5c01-4e02-8ee1-56f234cd7e86",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
-    "projects": {
-      "name": "projects",
+    "project_settings": {
+      "name": "project_settings",
       "columns": {
         "id": {
           "name": "id",
@@ -14,9 +14,9 @@
           "notNull": true,
           "autoincrement": true
         },
-        "name": {
-          "name": "name",
-          "type": "text",
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
@@ -37,8 +37,124 @@
           "autoincrement": false,
           "default": 0.7
         },
-        "api_key": {
-          "name": "api_key",
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_refs": {
+          "name": "context_refs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "expected_description": {
+          "name": "expected_description",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -53,7 +169,17 @@
         }
       },
       "indexes": {},
-      "foreignKeys": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}
@@ -228,69 +354,6 @@
           "tableFrom": "runs",
           "tableTo": "test_cases",
           "columnsFrom": ["test_case_id"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "checkConstraints": {}
-    },
-    "test_cases": {
-      "name": "test_cases",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "autoincrement": true
-        },
-        "project_id": {
-          "name": "project_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "turns": {
-          "name": "turns",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "context_refs": {
-          "name": "context_refs",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'[]'"
-        },
-        "expected_description": {
-          "name": "expected_description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "test_cases_project_id_projects_id_fk": {
-          "name": "test_cases_project_id_projects_id_fk",
-          "tableFrom": "test_cases",
-          "tableTo": "projects",
-          "columnsFrom": ["project_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1775787278893,
-      "tag": "0000_rainy_shooting_star",
+      "when": 1775803166462,
+      "tag": "0000_acoustic_talkback",
       "breakpoints": true
     }
   ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "generate": "drizzle-kit generate",

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import * as schema from "./schema.js";
+import * as schema from "../schema/index.js";
 
 const dbPath = process.env.DB_PATH ?? "./dev.db";
 const sqlite = new Database(dbPath);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,52 +1,5 @@
-import { type AnySQLiteColumn, integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
-
-export const projects = sqliteTable("projects", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  name: text("name").notNull(),
-  model: text("model").notNull().default("claude-opus-4-5"),
-  temperature: real("temperature").notNull().default(0.7),
-  api_key: text("api_key"),
-  created_at: integer("created_at").notNull(),
-});
-
-export const test_cases = sqliteTable("test_cases", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  project_id: integer("project_id")
-    .notNull()
-    .references(() => projects.id),
-  turns: text("turns").notNull(),
-  context_refs: text("context_refs").notNull().default("[]"),
-  expected_description: text("expected_description"),
-  created_at: integer("created_at").notNull(),
-});
-
-export const prompt_versions = sqliteTable("prompt_versions", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  project_id: integer("project_id")
-    .notNull()
-    .references(() => projects.id),
-  version: integer("version").notNull(),
-  name: text("name"),
-  memo: text("memo"),
-  content: text("content").notNull(),
-  parent_version_id: integer("parent_version_id").references(
-    (): AnySQLiteColumn => prompt_versions.id,
-  ),
-  created_at: integer("created_at").notNull(),
-});
-
-export const runs = sqliteTable("runs", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  prompt_version_id: integer("prompt_version_id")
-    .notNull()
-    .references(() => prompt_versions.id),
-  test_case_id: integer("test_case_id")
-    .notNull()
-    .references(() => test_cases.id),
-  conversation: text("conversation").notNull(),
-  is_best: integer("is_best").notNull().default(0),
-  human_score: integer("human_score"),
-  human_comment: text("human_comment"),
-  is_discarded: integer("is_discarded").notNull().default(0),
-  created_at: integer("created_at").notNull(),
-});
+/**
+ * drizzle.config.ts が参照するスキーマのエントリポイント
+ * 実際の定義は src/schema/ 以下に分割されている
+ */
+export * from "../schema/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @prompt-reviewer/core のパブリックAPI
+ * スキーマ型定義とDBクライアントをエクスポートする
+ */
+export * from "./schema/index.js";
+export { db } from "./db/client.js";
+export type { DB } from "./db/client.js";

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,0 +1,8 @@
+/**
+ * スキーマのエクスポートエントリポイント
+ * 全テーブル定義と型定義をまとめてエクスポートする
+ */
+export * from "./projects.js";
+export * from "./test-cases.js";
+export * from "./prompt-versions.js";
+export * from "./runs.js";

--- a/packages/core/src/schema/projects.test.ts
+++ b/packages/core/src/schema/projects.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Drizzleスキーマの型定義テスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * ここではDBへの実際の接続なしにスキーマの型安全性のみを検証する。
+ * マイグレーションの動作検証は `pnpm run migrate` で別途確認済み。
+ */
+import { describe, expectTypeOf, it } from "vitest";
+import type { NewProject, NewProjectSettings, Project, ProjectSettings } from "./projects.js";
+
+describe("projects スキーマ型定義", () => {
+  describe("Project 型", () => {
+    it("Project 型は必須フィールドを持つ", () => {
+      type RequiredFields = {
+        id: number;
+        name: string;
+        created_at: number;
+        updated_at: number;
+      };
+      expectTypeOf<
+        Pick<Project, "id" | "name" | "created_at" | "updated_at">
+      >().toMatchTypeOf<RequiredFields>();
+    });
+
+    it("Project の description はオプショナル（null許容）", () => {
+      expectTypeOf<Project["description"]>().toEqualTypeOf<string | null>();
+    });
+  });
+
+  describe("NewProject 型", () => {
+    it("NewProject は id なしで作成できる（AutoIncrement）", () => {
+      // id を含まないオブジェクトが NewProject に代入可能であることを確認
+      const newProject: NewProject = {
+        name: "テストプロジェクト",
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      };
+      expectTypeOf(newProject).toMatchTypeOf<NewProject>();
+    });
+
+    it("NewProject の name は string 型", () => {
+      expectTypeOf<NewProject["name"]>().toEqualTypeOf<string>();
+    });
+  });
+
+  describe("ProjectSettings 型", () => {
+    it("ProjectSettings は api_provider に anthropic|openai のみ許容", () => {
+      expectTypeOf<ProjectSettings["api_provider"]>().toEqualTypeOf<"anthropic" | "openai">();
+    });
+
+    it("ProjectSettings は temperature に number 型", () => {
+      expectTypeOf<ProjectSettings["temperature"]>().toEqualTypeOf<number>();
+    });
+
+    it("ProjectSettings は project_id に number 型", () => {
+      expectTypeOf<ProjectSettings["project_id"]>().toEqualTypeOf<number>();
+    });
+  });
+
+  describe("NewProjectSettings 型", () => {
+    it("NewProjectSettings の api_provider はデフォルト値があるためオプショナル", () => {
+      // api_provider はスキーマ上デフォルト値を持つため、Insert型ではオプショナルになる
+      expectTypeOf<NewProjectSettings["api_provider"]>().toEqualTypeOf<
+        "anthropic" | "openai" | undefined
+      >();
+    });
+  });
+});

--- a/packages/core/src/schema/projects.ts
+++ b/packages/core/src/schema/projects.ts
@@ -1,0 +1,37 @@
+import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * プロジェクトテーブル
+ * システムプロンプト改善の作業単位を管理する
+ */
+export const projects = sqliteTable("projects", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+/**
+ * プロジェクト設定テーブル
+ * プロジェクトごとのLLM設定を管理する（APIキーは別管理）
+ */
+export const project_settings = sqliteTable("project_settings", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  project_id: integer("project_id")
+    .notNull()
+    .references(() => projects.id),
+  model: text("model").notNull().default("claude-opus-4-5"),
+  temperature: real("temperature").notNull().default(0.7),
+  api_provider: text("api_provider", { enum: ["anthropic", "openai"] })
+    .notNull()
+    .default("anthropic"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+// Drizzle推論型のエクスポート
+export type Project = typeof projects.$inferSelect;
+export type NewProject = typeof projects.$inferInsert;
+export type ProjectSettings = typeof project_settings.$inferSelect;
+export type NewProjectSettings = typeof project_settings.$inferInsert;

--- a/packages/core/src/schema/prompt-versions.ts
+++ b/packages/core/src/schema/prompt-versions.ts
@@ -1,0 +1,25 @@
+import { type AnySQLiteColumn, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { projects } from "./projects.js";
+
+/**
+ * プロンプトバージョンテーブル
+ * システムプロンプトのバージョン履歴を管理する（分岐・メモ付き）
+ */
+export const prompt_versions = sqliteTable("prompt_versions", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  project_id: integer("project_id")
+    .notNull()
+    .references(() => projects.id),
+  version: integer("version").notNull(),
+  name: text("name"),
+  memo: text("memo"),
+  content: text("content").notNull(),
+  parent_version_id: integer("parent_version_id").references(
+    (): AnySQLiteColumn => prompt_versions.id,
+  ),
+  created_at: integer("created_at").notNull(),
+});
+
+// Drizzle推論型のエクスポート
+export type PromptVersion = typeof prompt_versions.$inferSelect;
+export type NewPromptVersion = typeof prompt_versions.$inferInsert;

--- a/packages/core/src/schema/runs.ts
+++ b/packages/core/src/schema/runs.ts
@@ -1,0 +1,27 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { prompt_versions } from "./prompt-versions.js";
+import { test_cases } from "./test-cases.js";
+
+/**
+ * 実行結果テーブル
+ * プロンプトバージョン×テストケースの実行結果を管理する（複数回保持）
+ */
+export const runs = sqliteTable("runs", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  prompt_version_id: integer("prompt_version_id")
+    .notNull()
+    .references(() => prompt_versions.id),
+  test_case_id: integer("test_case_id")
+    .notNull()
+    .references(() => test_cases.id),
+  conversation: text("conversation").notNull(),
+  is_best: integer("is_best").notNull().default(0),
+  human_score: integer("human_score"),
+  human_comment: text("human_comment"),
+  is_discarded: integer("is_discarded").notNull().default(0),
+  created_at: integer("created_at").notNull(),
+});
+
+// Drizzle推論型のエクスポート
+export type Run = typeof runs.$inferSelect;
+export type NewRun = typeof runs.$inferInsert;

--- a/packages/core/src/schema/test-cases.ts
+++ b/packages/core/src/schema/test-cases.ts
@@ -1,0 +1,21 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { projects } from "./projects.js";
+
+/**
+ * テストケーステーブル
+ * システムプロンプトを評価するためのマルチターン入力ケースを管理する
+ */
+export const test_cases = sqliteTable("test_cases", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  project_id: integer("project_id")
+    .notNull()
+    .references(() => projects.id),
+  turns: text("turns").notNull(),
+  context_refs: text("context_refs").notNull().default("[]"),
+  expected_description: text("expected_description"),
+  created_at: integer("created_at").notNull(),
+});
+
+// Drizzle推論型のエクスポート
+export type TestCase = typeof test_cases.$inferSelect;
+export type NewTestCase = typeof test_cases.$inferInsert;


### PR DESCRIPTION
## 概要

Issue #5 の実装。Drizzle ORM を使用して `projects` テーブルと `project_settings` テーブルのスキーマを定義し、`@prompt-reviewer/core` から型エクスポートできる構造に整備しました。

## 変更内容

### スキーマ定義（`packages/core/src/schema/`）

**新規追加**
- `projects.ts` — `projects` テーブル（`id, name, description, created_at, updated_at`）と `project_settings` テーブル（`id, project_id, model, temperature, api_provider, created_at, updated_at`）の定義
- `test-cases.ts` — `test_cases` テーブルの定義（既存スキーマから分割）
- `prompt-versions.ts` — `prompt_versions` テーブルの定義（既存スキーマから分割）
- `runs.ts` — `runs` テーブルの定義（既存スキーマから分割）
- `index.ts` — スキーマのバレルエクスポート

### 型エクスポート（`packages/core/src/index.ts`）

- `@prompt-reviewer/core` のパブリックAPIとして `Project`, `NewProject`, `ProjectSettings`, `NewProjectSettings` 等の型をエクスポート
- `package.json` に `exports` フィールドを追加

### マイグレーション（`packages/core/drizzle/`）

- 全テーブルのマイグレーション SQL を再生成・適用済み
- `drizzle.config.ts` をスキーマファイル個別指定に更新

## 完了条件の確認

- [x] Drizzle スキーマが定義されている（`src/schema/projects.ts`）
- [x] マイグレーションが適用できる（`pnpm run migrate` で `dev.db` に適用済み）
- [x] 型定義が `@prompt-reviewer/core` からエクスポートされている（`src/index.ts`）

## テスト計画

- [x] `pnpm run check` — Biomeリントチェック通過
- [x] `pnpm run typecheck` — TypeScript型チェック通過
- [x] `pnpm run test` — 型定義テスト8件通過（`expectTypeOf` による型安全性の検証）

## 備考

- `api_provider` は `"anthropic" | "openai"` のユニオン型として定義（SQLiteの `text enum` 機能を使用）
- APIキーは別管理のため `project_settings` に含まない
- `better-sqlite3` のネイティブバイナリは Node.js 24 向けのプリビルドが存在しないため、DBへの実際の接続テストは実施せず、型安全性の検証のみをテストで行っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)