### PR TITLE
feat(core): TestCaseスキーマ定義 - マルチターン対応

### DIFF
--- a/packages/core/drizzle/0001_cloudy_lucky_pierre.sql
+++ b/packages/core/drizzle/0001_cloudy_lucky_pierre.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `test_cases` ADD `title` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `test_cases` ADD `context_content` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `test_cases` ADD `display_order` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `test_cases` ADD `updated_at` integer NOT NULL;--> statement-breakpoint
+ALTER TABLE `test_cases` DROP COLUMN `context_refs`;

--- a/packages/core/drizzle/meta/0001_snapshot.json
+++ b/packages/core/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,399 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fdb82acf-0ce1-4d6d-9fdd-5fe455b3eb04",
+  "prevId": "1ef03141-5c01-4e02-8ee1-56f234cd7e86",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["parent_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["prompt_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775803166462,
       "tag": "0000_acoustic_talkback",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1775824988379,
+      "tag": "0001_cloudy_lucky_pierre",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import * as schema from "../schema/index.js";
+import * as schema from "../schema/index";
 
 const dbPath = process.env.DB_PATH ?? "./dev.db";
 const sqlite = new Database(dbPath);

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -2,4 +2,4 @@
  * drizzle.config.ts が参照するスキーマのエントリポイント
  * 実際の定義は src/schema/ 以下に分割されている
  */
-export * from "../schema/index.js";
+export * from "../schema/index";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,6 @@
  * @prompt-reviewer/core のパブリックAPI
  * スキーマ型定義とDBクライアントをエクスポートする
  */
-export * from "./schema/index.js";
-export { db } from "./db/client.js";
-export type { DB } from "./db/client.js";
+export * from "./schema/index";
+export { db } from "./db/client";
+export type { DB } from "./db/client";

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -2,7 +2,7 @@
  * スキーマのエクスポートエントリポイント
  * 全テーブル定義と型定義をまとめてエクスポートする
  */
-export * from "./projects.js";
-export * from "./test-cases.js";
-export * from "./prompt-versions.js";
-export * from "./runs.js";
+export * from "./projects";
+export * from "./test-cases";
+export * from "./prompt-versions";
+export * from "./runs";

--- a/packages/core/src/schema/prompt-versions.ts
+++ b/packages/core/src/schema/prompt-versions.ts
@@ -1,5 +1,5 @@
 import { type AnySQLiteColumn, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { projects } from "./projects.js";
+import { projects } from "./projects";
 
 /**
  * プロンプトバージョンテーブル

--- a/packages/core/src/schema/runs.ts
+++ b/packages/core/src/schema/runs.ts
@@ -1,6 +1,6 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { prompt_versions } from "./prompt-versions.js";
-import { test_cases } from "./test-cases.js";
+import { prompt_versions } from "./prompt-versions";
+import { test_cases } from "./test-cases";
 
 /**
  * 実行結果テーブル

--- a/packages/core/src/schema/test-cases.test.ts
+++ b/packages/core/src/schema/test-cases.test.ts
@@ -1,0 +1,108 @@
+/**
+ * TestCase スキーマの型定義テスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * ここではDBへの実際の接続なしにスキーマの型安全性のみを検証する。
+ * マイグレーションの動作検証は `pnpm run migrate` で別途確認済み。
+ */
+import { describe, expectTypeOf, it } from "vitest";
+import type { NewTestCase, TestCase, Turn } from "./test-cases.js";
+
+describe("test_cases スキーマ型定義", () => {
+  describe("TestCase 型", () => {
+    it("TestCase 型は必須フィールドを持つ", () => {
+      type RequiredFields = {
+        id: number;
+        project_id: number;
+        title: string;
+        turns: string;
+        context_content: string;
+        display_order: number;
+        created_at: number;
+        updated_at: number;
+      };
+      expectTypeOf<
+        Pick<
+          TestCase,
+          | "id"
+          | "project_id"
+          | "title"
+          | "turns"
+          | "context_content"
+          | "display_order"
+          | "created_at"
+          | "updated_at"
+        >
+      >().toMatchTypeOf<RequiredFields>();
+    });
+
+    it("TestCase の expected_description はオプショナル（null許容）", () => {
+      expectTypeOf<TestCase["expected_description"]>().toEqualTypeOf<string | null>();
+    });
+
+    it("TestCase の turns は string 型（JSONシリアライズ済み）", () => {
+      expectTypeOf<TestCase["turns"]>().toEqualTypeOf<string>();
+    });
+
+    it("TestCase の context_content は string 型", () => {
+      expectTypeOf<TestCase["context_content"]>().toEqualTypeOf<string>();
+    });
+
+    it("TestCase の display_order は number 型", () => {
+      expectTypeOf<TestCase["display_order"]>().toEqualTypeOf<number>();
+    });
+
+    it("TestCase の title は string 型", () => {
+      expectTypeOf<TestCase["title"]>().toEqualTypeOf<string>();
+    });
+  });
+
+  describe("NewTestCase 型", () => {
+    it("NewTestCase は id なしで作成できる（AutoIncrement）", () => {
+      const newTestCase: NewTestCase = {
+        project_id: 1,
+        title: "マルチターンテストケース",
+        turns: JSON.stringify([
+          { role: "user", content: "こんにちは" },
+          { role: "assistant", content: "こんにちは！" },
+        ]),
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      };
+      expectTypeOf(newTestCase).toMatchTypeOf<NewTestCase>();
+    });
+
+    it("NewTestCase の context_content はデフォルト値があるためオプショナル", () => {
+      expectTypeOf<NewTestCase["context_content"]>().toEqualTypeOf<string | undefined>();
+    });
+
+    it("NewTestCase の display_order はデフォルト値があるためオプショナル", () => {
+      expectTypeOf<NewTestCase["display_order"]>().toEqualTypeOf<number | undefined>();
+    });
+
+    it("NewTestCase の expected_description はオプショナル", () => {
+      expectTypeOf<NewTestCase["expected_description"]>().toEqualTypeOf<
+        string | null | undefined
+      >();
+    });
+  });
+
+  describe("Turn 型", () => {
+    it("Turn の role は user または assistant のみ許容", () => {
+      expectTypeOf<Turn["role"]>().toEqualTypeOf<"user" | "assistant">();
+    });
+
+    it("Turn の content は string 型", () => {
+      expectTypeOf<Turn["content"]>().toEqualTypeOf<string>();
+    });
+
+    it("Turn 配列としてマルチターン会話を表現できる", () => {
+      const turns: Turn[] = [
+        { role: "user", content: "質問です" },
+        { role: "assistant", content: "回答です" },
+        { role: "user", content: "フォローアップ質問" },
+      ];
+      expectTypeOf(turns).toEqualTypeOf<Turn[]>();
+    });
+  });
+});

--- a/packages/core/src/schema/test-cases.ts
+++ b/packages/core/src/schema/test-cases.ts
@@ -1,21 +1,36 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { projects } from "./projects.js";
+import { projects } from "./projects";
 
 /**
  * テストケーステーブル
  * システムプロンプトを評価するためのマルチターン入力ケースを管理する
+ *
+ * turns: JSON文字列として保存するマルチターン会話 [{role, content}]
+ * context_content: {{context}} プレースホルダーに挿入するテキスト
  */
 export const test_cases = sqliteTable("test_cases", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   project_id: integer("project_id")
     .notNull()
     .references(() => projects.id),
+  title: text("title").notNull(),
   turns: text("turns").notNull(),
-  context_refs: text("context_refs").notNull().default("[]"),
+  context_content: text("context_content").notNull().default(""),
   expected_description: text("expected_description"),
+  display_order: integer("display_order").notNull().default(0),
   created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
 });
 
 // Drizzle推論型のエクスポート
 export type TestCase = typeof test_cases.$inferSelect;
 export type NewTestCase = typeof test_cases.$inferInsert;
+
+/**
+ * turnsカラムのJSONスキーマ型
+ * text型で保存されるため、アプリケーション側でパース/シリアライズを行う
+ */
+export type Turn = {
+  role: "user" | "assistant";
+  content: string;
+};


### PR DESCRIPTION
## 概要

Issue #6 の実装。`test_cases`テーブルのスキーマを更新し、マルチターン会話に対応した完全な定義を行った。

## 変更内容

### スキーマ変更（`packages/core/src/schema/test-cases.ts`）
- `title`フィールドを追加（`text NOT NULL`）
- `context_refs`を`context_content`にリネーム（配列JSONからテキストに変更）
- `display_order`フィールドを追加（`integer DEFAULT 0 NOT NULL`）
- `updated_at`フィールドを追加（`integer NOT NULL`）
- `Turn`型を追加（マルチターン会話の型定義: `{role: "user" | "assistant", content: string}`）

### マイグレーション（`packages/core/drizzle/0001_cloudy_lucky_pierre.sql`）
```sql
ALTER TABLE `test_cases` ADD `title` text NOT NULL;
ALTER TABLE `test_cases` ADD `context_content` text DEFAULT '' NOT NULL;
ALTER TABLE `test_cases` ADD `display_order` integer DEFAULT 0 NOT NULL;
ALTER TABLE `test_cases` ADD `updated_at` integer NOT NULL;
ALTER TABLE `test_cases` DROP COLUMN `context_refs`;
```

### テスト（`packages/core/src/schema/test-cases.test.ts`）
- DB接続なしの`expectTypeOf`による型検証（13テストケース）
- `TestCase`型・`NewTestCase`型・`Turn`型の検証

### インポートパス修正
- `drizzle-kit`（CJS実行）との互換性のため、スキーマファイル内の相対インポートパスから`.js`拡張子を除去
- 対象ファイル: `test-cases.ts`, `prompt-versions.ts`, `runs.ts`, `index.ts`, `client.ts`, `schema.ts`, `index.ts`（core）

## 完了条件の確認

- [x] マルチターン会話を JSON カラムに保存できる（`turns text NOT NULL`、`Turn[]`型をJSON.stringify/parseで扱う）
- [x] マイグレーションが適用できる（`pnpm run migrate`で確認済み）
- [x] 型定義がエクスポートされている（`TestCase`, `NewTestCase`, `Turn`を`@prompt-reviewer/core`からエクスポート）

## テスト結果

```
✓ packages/core/src/schema/test-cases.test.ts (13 tests)
✓ packages/core/src/schema/projects.test.ts (8 tests)

Test Files  2 passed (2)
Tests       21 passed (21)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)