### PR TITLE
feat(api): Project CRUD エンドポイントを実装

### DIFF
--- a/packages/core/src/__test-stubs__/index.ts
+++ b/packages/core/src/__test-stubs__/index.ts
@@ -1,0 +1,10 @@
+/**
+ * テスト用スタブ: @prompt-reviewer/core のスキーマ型定義のみをエクスポート
+ * DB接続（better-sqlite3）を含む client.ts はエクスポートしない。
+ * vitest.config.ts のエイリアスでこのファイルを指定することで、
+ * ネイティブバイナリのビルドエラーを回避する。
+ */
+export * from "../schema/index.js";
+
+// DB型のみエクスポート（実際のDBインスタンスは含まない）
+export type { DB } from "../db/client.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
     "lib": ["ES2022"],
     "types": ["node"]
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,8 +9,11 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
+    "@hono/zod-validator": "^0.7.6",
     "@prompt-reviewer/core": "workspace:*",
-    "hono": "^4.7.9"
+    "drizzle-orm": "^0.44.7",
+    "hono": "^4.7.9",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "@hono/node-server";
+import { db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createProjectsRouter } from "./routes/projects.js";
 
 const app = new Hono();
 
@@ -16,6 +18,8 @@ app.use(
 app.get("/health", (c) => {
   return c.json({ status: "ok" });
 });
+
+app.route("/api/projects", createProjectsRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/packages/server/src/routes/projects.test.ts
+++ b/packages/server/src/routes/projects.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Project CRUD エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createProjectsRouter } from "./projects.js";
+
+// ---- モックDBの型定義 ----
+
+type MockProject = {
+  id: number;
+  name: string;
+  description: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+/**
+ * Drizzle の select().from().where() チェーンを模倣するモックビルダー
+ */
+function createMockDb(initialProjects: MockProject[] = []) {
+  let store = [...initialProjects];
+  let nextId = Math.max(0, ...store.map((p) => p.id)) + 1;
+
+  const mockDb = {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockImplementation(() => Promise.resolve([...store])),
+        where: vi.fn().mockImplementation((condition: unknown) => {
+          // condition は eq(projects.id, id) の形式。
+          // テスト用に id を直接取り出す方法がないため、
+          // where のモックは呼び出し元のコンテキストから id を受け取る仕組みにする。
+          // 実装上は _whereId を使う。
+          return Promise.resolve([] as MockProject[]);
+        }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockImplementation(() => {
+          return Promise.resolve([] as MockProject[]);
+        }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockImplementation(() => Promise.resolve([] as MockProject[])),
+        }),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockImplementation(() => Promise.resolve()),
+    }),
+    _store: store,
+  };
+
+  return {
+    mockDb,
+    store: () => store,
+    setStore: (s: MockProject[]) => {
+      store = s;
+    },
+    getNextId: () => nextId++,
+  };
+}
+
+/**
+ * テスト用にルーターを組み立てる。
+ * DBモックを渡して各エンドポイントの動作を検証する。
+ */
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects", createProjectsRouter(db as DB));
+  return app;
+}
+
+// ---- テストデータ ----
+
+const sampleProject: MockProject = {
+  id: 1,
+  name: "テストプロジェクト",
+  description: "説明文",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+// ---- テスト ----
+
+describe("GET /api/projects", () => {
+  it("プロジェクト一覧を200で返す", async () => {
+    const projects = [sampleProject, { ...sampleProject, id: 2, name: "別プロジェクト" }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve(projects),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockProject[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.name).toBe("テストプロジェクト");
+    expect(body.at(1)?.name).toBe("別プロジェクト");
+  });
+
+  it("プロジェクトが0件のとき空配列を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockProject[];
+    expect(body).toHaveLength(0);
+  });
+});
+
+describe("POST /api/projects", () => {
+  it("バリデーション通過時に201でプロジェクトを返す", async () => {
+    const created = { ...sampleProject };
+
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストプロジェクト", description: "説明文" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockProject;
+    expect(body.name).toBe("テストプロジェクト");
+    expect(body.description).toBe("説明文");
+  });
+
+  it("name が空文字列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("name が未指定のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "説明だけ" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("description 省略時も正常に作成できる", async () => {
+    const created = { ...sampleProject, description: null };
+
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストプロジェクト" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockProject;
+    expect(body.name).toBe("テストプロジェクト");
+    expect(body.description).toBeNull();
+  });
+});
+
+describe("GET /api/projects/:id", () => {
+  it("存在するIDに対して200でプロジェクトを返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleProject]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockProject;
+    expect(body.id).toBe(1);
+    expect(body.name).toBe("テストプロジェクト");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/999");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/abc");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/projects/:id", () => {
+  it("存在するIDに対して200で更新されたプロジェクトを返す", async () => {
+    const updated = { ...sampleProject, name: "更新後の名前", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleProject]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後の名前" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockProject;
+    expect(body.name).toBe("更新後の名前");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project not found");
+  });
+
+  it("name が空文字列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/projects/:id", () => {
+  it("存在するIDに対して204を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleProject]),
+        }),
+      }),
+      delete: () => ({
+        where: () => Promise.resolve(),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/999", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/abc", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,0 +1,118 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { projects } from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createProjectSchema = z.object({
+  name: z.string().min(1, "名前は1文字以上必要です"),
+  description: z.string().optional(),
+});
+
+const updateProjectSchema = z.object({
+  name: z.string().min(1, "名前は1文字以上必要です").optional(),
+  description: z.string().nullable().optional(),
+});
+
+export function createProjectsRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/projects - 全プロジェクト一覧取得
+  router.get("/", async (c) => {
+    const result = await db.select().from(projects).orderBy(projects.id);
+    return c.json(result);
+  });
+
+  // POST /api/projects - 新規プロジェクト作成
+  router.post("/", zValidator("json", createProjectSchema), async (c) => {
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [project] = await db
+      .insert(projects)
+      .values({
+        name: body.name,
+        description: body.description ?? null,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    return c.json(project, 201);
+  });
+
+  // GET /api/projects/:id - 特定プロジェクト取得
+  router.get("/:id", async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [project] = await db.select().from(projects).where(eq(projects.id, id));
+
+    if (!project) {
+      return c.json({ error: "Project not found" }, 404);
+    }
+
+    return c.json(project);
+  });
+
+  // PATCH /api/projects/:id - プロジェクト更新
+  router.patch("/:id", zValidator("json", updateProjectSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    const [existing] = await db.select().from(projects).where(eq(projects.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Project not found" }, 404);
+    }
+
+    const updateData: { name?: string; description?: string | null; updated_at: number } = {
+      updated_at: Date.now(),
+    };
+
+    if (body.name !== undefined) {
+      updateData.name = body.name;
+    }
+    if (body.description !== undefined) {
+      updateData.description = body.description;
+    }
+
+    const [updated] = await db
+      .update(projects)
+      .set(updateData)
+      .where(eq(projects.id, id))
+      .returning();
+
+    return c.json(updated);
+  });
+
+  // DELETE /api/projects/:id - プロジェクト削除
+  router.delete("/:id", async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(projects).where(eq(projects.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Project not found" }, 404);
+    }
+
+    await db.delete(projects).where(eq(projects.id, id));
+
+    return c.body(null, 204);
+  });
+
+  return router;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,21 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.13(hono@4.12.12)
+      '@hono/zod-validator':
+        specifier: ^0.7.6
+        version: 0.7.6(hono@4.12.12)(zod@4.3.6)
       '@prompt-reviewer/core':
         specifier: workspace:*
         version: link:../core
+      drizzle-orm:
+        specifier: ^0.44.7
+        version: 0.44.7(@libsql/client@0.17.2)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)
       hono:
         specifier: ^4.7.9
         version: 4.12.12
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^25.5.2
@@ -986,6 +995,12 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2087,6 +2102,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@babel/code-frame@7.29.0':
@@ -2611,6 +2629,11 @@ snapshots:
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
+
+  '@hono/zod-validator@0.7.6(hono@4.12.12)(zod@4.3.6)':
+    dependencies:
+      hono: 4.12.12
+      zod: 4.3.6
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3668,3 +3691,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod@4.3.6: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // テスト時は DB接続を含まないスタブを使用（better-sqlite3 のビルド不要）
+      "@prompt-reviewer/core": resolve(__dirname, "packages/core/src/__test-stubs__/index.ts"),
+    },
+  },
   test: {
     passWithNoTests: true,
     include: ["packages/*/src/**/*.{test,spec}.{ts,tsx}"],


### PR DESCRIPTION
## 概要

Issue #9 の対応として、Hono を使ったProject CRUD APIを実装しました。

- `GET /api/projects` — 全プロジェクト一覧を取得（id順）
- `POST /api/projects` — 新規プロジェクト作成（Zod バリデーション付き）
- `GET /api/projects/:id` — 特定プロジェクトを取得
- `PATCH /api/projects/:id` — プロジェクトを部分更新
- `DELETE /api/projects/:id` — プロジェクトを削除

## 変更ファイル

- `packages/server/src/routes/projects.ts` — ルートハンドラ実装
- `packages/server/src/index.ts` — `/api/projects` ルートを登録
- `packages/server/package.json` — `zod`, `@hono/zod-validator`, `drizzle-orm` を追加
- `packages/core/src/__test-stubs__/index.ts` — テスト用スタブ（DB接続なし）
- `packages/core/tsconfig.json` — `declaration: true` を追加して型宣言ファイルを生成
- `vitest.config.ts` — `@prompt-reviewer/core` のエイリアスをテストスタブへ変更

## テスト計画

- [x] 全エンドポイントが正しいステータスコードを返すことを確認
  - GET /api/projects → 200
  - POST /api/projects（正常）→ 201
  - GET /api/projects/:id（存在する）→ 200
  - PATCH /api/projects/:id（存在する）→ 200
  - DELETE /api/projects/:id（存在する）→ 204
- [x] 存在しないIDに対して404を返すことを確認（GET/PATCH/DELETE）
- [x] Zodバリデーション — `name` 空文字・未指定で400を返すことを確認
- [x] 数値以外のIDに対して400を返すことを確認
- [x] `pnpm test` — 50テスト全件パス
- [x] `pnpm run check` — Biome lintエラーなし
- [x] `pnpm run typecheck` — TypeScriptエラーなし

## 実装上の注意点

`better-sqlite3` はネイティブバイナリのビルドが必要なため、Vitestから直接DB接続するとエラーになります。
そのため、テスト時は `@prompt-reviewer/core` のエイリアスをスキーマ型定義のみを再エクスポートするスタブ（`__test-stubs__/index.ts`）に向けることで、DB接続をスキップしています。
ルートハンドラは `createProjectsRouter(db: DB)` のDI設計にしてあり、テストではインメモリのモックDBを注入しています。

Closes #9