### PR TITLE
[API] PromptVersion CRUD + 分岐エンドポイント (#11)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import { db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createProjectsRouter } from "./routes/projects.js";
+import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
 const app = new Hono();
@@ -22,6 +23,7 @@ app.get("/health", (c) => {
 
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
+app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -1,0 +1,498 @@
+/**
+ * PromptVersion CRUD + 分岐エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createPromptVersionsRouter } from "./prompt-versions.js";
+
+// ---- 型定義 ----
+
+type MockPromptVersion = {
+  id: number;
+  project_id: number;
+  version: number;
+  name: string | null;
+  memo: string | null;
+  content: string;
+  parent_version_id: number | null;
+  created_at: number;
+};
+
+// ---- ヘルパー ----
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db as DB));
+  return app;
+}
+
+// ---- テストデータ ----
+
+const sampleVersion: MockPromptVersion = {
+  id: 1,
+  project_id: 1,
+  version: 1,
+  name: "初期バージョン",
+  memo: null,
+  content: "あなたは親切なアシスタントです。",
+  parent_version_id: null,
+  created_at: 1000000,
+};
+
+// ---- テスト ----
+
+describe("GET /api/projects/:projectId/prompt-versions", () => {
+  it("バージョン一覧を200で返す", async () => {
+    const versions = [sampleVersion, { ...sampleVersion, id: 2, version: 2, name: "v2" }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(versions),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.version).toBe(1);
+    expect(body.at(1)?.version).toBe(2);
+  });
+
+  it("バージョンが0件のとき空配列を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion[];
+    expect(body).toHaveLength(0);
+  });
+});
+
+describe("POST /api/projects/:projectId/prompt-versions", () => {
+  it("バリデーション通過時に201でバージョンを返す", async () => {
+    const created = { ...sampleVersion };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([{ maxVersion: 0 }]),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "あなたは親切なアシスタントです。", name: "初期バージョン" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.content).toBe("あなたは親切なアシスタントです。");
+    expect(body.name).toBe("初期バージョン");
+  });
+
+  it("version番号が既存の最大値+1で採番される", async () => {
+    const created = { ...sampleVersion, id: 3, version: 3 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([{ maxVersion: 2 }]),
+        }),
+      }),
+      insert: () => ({
+        values: (values: { version: number }) => ({
+          returning: () => {
+            // 採番された version が 3 になっているか検証
+            expect(values.version).toBe(3);
+            return Promise.resolve([created]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "新しいプロンプト" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.version).toBe(3);
+  });
+
+  it("プロジェクト内にバージョンが0件の場合、version=1 で採番される", async () => {
+    const created = { ...sampleVersion, version: 1 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([{ maxVersion: null }]),
+        }),
+      }),
+      insert: () => ({
+        values: (values: { version: number }) => ({
+          returning: () => {
+            expect(values.version).toBe(1);
+            return Promise.resolve([created]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "初めてのプロンプト" }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("content が空文字列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("content が未指定のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "名前だけ" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
+  it("存在するIDに対して200でバージョンを返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.id).toBe(1);
+    expect(body.content).toBe("あなたは親切なアシスタントです。");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/999");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/abc");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/projects/:projectId/prompt-versions/:id", () => {
+  it("存在するIDに対して200で更新されたバージョンを返す", async () => {
+    const updated = { ...sampleVersion, content: "更新されたプロンプト", name: "v1-updated" };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新されたプロンプト", name: "v1-updated" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.content).toBe("更新されたプロンプト");
+    expect(body.name).toBe("v1-updated");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("content が空文字列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
+  it("分岐作成時に parent_version_id が正しく設定される", async () => {
+    const branched: MockPromptVersion = {
+      ...sampleVersion,
+      id: 2,
+      version: 2,
+      name: "分岐バージョン",
+      parent_version_id: 1,
+    };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      insert: () => ({
+        values: (values: { parent_version_id: number; version: number }) => ({
+          returning: () => {
+            // parent_version_id が親の id (1) に設定されていることを確認
+            expect(values.parent_version_id).toBe(1);
+            return Promise.resolve([branched]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "分岐バージョン" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.parent_version_id).toBe(1);
+    expect(body.name).toBe("分岐バージョン");
+  });
+
+  it("分岐作成時に親のcontentが引き継がれる", async () => {
+    const branched: MockPromptVersion = {
+      ...sampleVersion,
+      id: 2,
+      version: 2,
+      content: sampleVersion.content,
+      parent_version_id: 1,
+    };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      insert: () => ({
+        values: (values: { content: string }) => ({
+          returning: () => {
+            // 親の content が引き継がれていることを確認
+            expect(values.content).toBe(sampleVersion.content);
+            return Promise.resolve([branched]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.content).toBe(sampleVersion.content);
+  });
+
+  it("分岐作成時に version 番号が自動採番される", async () => {
+    const branched: MockPromptVersion = {
+      ...sampleVersion,
+      id: 2,
+      version: 2,
+      parent_version_id: 1,
+    };
+
+    // select が2回呼ばれる: 1回目は親バージョン取得, 2回目は maxVersion 取得
+    let selectCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // 親バージョン取得
+              return Promise.resolve([sampleVersion]);
+            }
+            // maxVersion 取得
+            return Promise.resolve([{ maxVersion: 1 }]);
+          },
+        }),
+      }),
+      insert: () => ({
+        values: (values: { version: number }) => ({
+          returning: () => {
+            expect(values.version).toBe(2);
+            return Promise.resolve([branched]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.version).toBe(2);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/999/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/abc/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -1,0 +1,197 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { prompt_versions } from "@prompt-reviewer/core";
+import { and, eq, max } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createPromptVersionSchema = z.object({
+  content: z.string().min(1, "contentは1文字以上必要です"),
+  name: z.string().optional(),
+  memo: z.string().optional(),
+});
+
+const updatePromptVersionSchema = z.object({
+  content: z.string().min(1, "contentは1文字以上必要です").optional(),
+  name: z.string().nullable().optional(),
+  memo: z.string().nullable().optional(),
+});
+
+const branchPromptVersionSchema = z.object({
+  name: z.string().optional(),
+  memo: z.string().optional(),
+});
+
+export function createPromptVersionsRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/projects/:projectId/prompt-versions - バージョン一覧取得
+  router.get("/", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+
+    if (Number.isNaN(projectId)) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const result = await db
+      .select()
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId));
+
+    return c.json(result);
+  });
+
+  // POST /api/projects/:projectId/prompt-versions - 新規バージョン作成
+  router.post("/", zValidator("json", createPromptVersionSchema), async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+
+    if (Number.isNaN(projectId)) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    // version 番号を自動採番（プロジェクト内の最大 version + 1）
+    const [maxResult] = await db
+      .select({ maxVersion: max(prompt_versions.version) })
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId));
+
+    const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
+
+    const result = await db
+      .insert(prompt_versions)
+      .values({
+        project_id: projectId,
+        version: nextVersion,
+        content: body.content,
+        name: body.name ?? null,
+        memo: body.memo ?? null,
+        parent_version_id: null,
+        created_at: Date.now(),
+      })
+      .returning();
+
+    const created = result[0];
+    if (!created) {
+      return c.json({ error: "Failed to create PromptVersion" }, 500);
+    }
+
+    return c.json(created, 201);
+  });
+
+  // GET /api/projects/:projectId/prompt-versions/:id - 特定バージョン取得
+  router.get("/:id", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [version] = await db
+      .select()
+      .from(prompt_versions)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+
+    if (!version) {
+      return c.json({ error: "PromptVersion not found" }, 404);
+    }
+
+    return c.json(version);
+  });
+
+  // PATCH /api/projects/:projectId/prompt-versions/:id - バージョン更新
+  router.patch("/:id", zValidator("json", updatePromptVersionSchema), async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(prompt_versions)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+
+    if (!existing) {
+      return c.json({ error: "PromptVersion not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const updateData: {
+      content?: string;
+      name?: string | null;
+      memo?: string | null;
+    } = {};
+
+    if (body.content !== undefined) updateData.content = body.content;
+    if (body.name !== undefined) updateData.name = body.name;
+    if (body.memo !== undefined) updateData.memo = body.memo;
+
+    const updateResult = await db
+      .update(prompt_versions)
+      .set(updateData)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update PromptVersion" }, 500);
+    }
+
+    return c.json(updated);
+  });
+
+  // POST /api/projects/:projectId/prompt-versions/:id/branch - 分岐バージョン作成
+  router.post("/:id/branch", zValidator("json", branchPromptVersionSchema), async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [parent] = await db
+      .select()
+      .from(prompt_versions)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+
+    if (!parent) {
+      return c.json({ error: "PromptVersion not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+
+    // version 番号を自動採番（プロジェクト内の最大 version + 1）
+    const [maxResult] = await db
+      .select({ maxVersion: max(prompt_versions.version) })
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId));
+
+    const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
+
+    const result = await db
+      .insert(prompt_versions)
+      .values({
+        project_id: projectId,
+        version: nextVersion,
+        content: parent.content,
+        name: body.name ?? null,
+        memo: body.memo ?? null,
+        parent_version_id: parent.id,
+        created_at: Date.now(),
+      })
+      .returning();
+
+    const created = result[0];
+    if (!created) {
+      return c.json({ error: "Failed to create branch PromptVersion" }, 500);
+    }
+
+    return c.json(created, 201);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## 概要

- `GET /api/projects/:projectId/prompt-versions` — バージョン一覧取得
- `POST /api/projects/:projectId/prompt-versions` — 新規バージョン作成（version自動採番）
- `GET /api/projects/:projectId/prompt-versions/:id` — 特定バージョン取得
- `PATCH /api/projects/:projectId/prompt-versions/:id` — バージョン更新
- `POST /api/projects/:projectId/prompt-versions/:id/branch` — 分岐バージョン作成

## 完了条件の確認

- [x] 分岐作成時に `parent_version_id` が正しく設定される（テストで検証）
- [x] `version` 番号がプロジェクト内最大値+1で自動採番される（テストで検証）
- [x] Vitestユニットテスト19件追加・全パス（`packages/server/src/routes/prompt-versions.test.ts`）

## テスト計画

| テストケース | 内容 |
|---|---|
| GET 一覧 | 複数件/0件の返却 |
| POST 新規 | バリデーション/version採番/空配列時のversion=1 |
| GET 単件 | 存在/不存在/不正ID |
| PATCH 更新 | 存在/不存在/空content/不正ID |
| POST 分岐 | parent_version_id設定/content引き継ぎ/version採番/不存在/不正ID |

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)