### PR TITLE
feat(api): Run 作成・取得・ベスト回答フラグ API (#12)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
+import { createRunsRouter } from "./routes/runs.js";
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
 const app = new Hono();
@@ -24,6 +25,7 @@ app.get("/health", (c) => {
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
+app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Run CRUD + ベスト回答フラグ エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createRunsRouter } from "./runs.js";
+
+// ---- 型定義 ----
+
+type MockConversationMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type MockRun = {
+  id: number;
+  project_id: number;
+  prompt_version_id: number;
+  test_case_id: number;
+  conversation: string;
+  is_best: number;
+  created_at: number;
+  model: string;
+  temperature: number;
+  api_provider: string;
+};
+
+// ---- ヘルパー ----
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/runs", createRunsRouter(db as DB));
+  return app;
+}
+
+// ---- テストデータ ----
+
+const sampleConversation: MockConversationMessage[] = [
+  { role: "user", content: "こんにちは" },
+  { role: "assistant", content: "こんにちは！どのようにお手伝いできますか？" },
+];
+
+const sampleRun: MockRun = {
+  id: 1,
+  project_id: 1,
+  prompt_version_id: 1,
+  test_case_id: 1,
+  conversation: JSON.stringify(sampleConversation),
+  is_best: 0,
+  created_at: 1000000,
+  model: "claude-sonnet-4-6",
+  temperature: 0.7,
+  api_provider: "anthropic",
+};
+
+// ---- テスト ----
+
+describe("GET /api/projects/:projectId/runs", () => {
+  it("Run一覧を200で返す", async () => {
+    const runs = [sampleRun, { ...sampleRun, id: 2 }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(runs),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body).toHaveLength(2);
+  });
+
+  it("Runが0件のとき空配列を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body).toHaveLength(0);
+  });
+
+  it("conversationがJSONパースされて返される", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleRun]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body.at(0)?.conversation).toEqual(sampleConversation);
+  });
+
+  it("prompt_version_idでフィルタリングできる", async () => {
+    const filteredRuns = [sampleRun];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(filteredRuns),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs?prompt_version_id=1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body).toHaveLength(1);
+    expect(body.at(0)?.prompt_version_id).toBe(1);
+  });
+
+  it("test_case_idでフィルタリングできる", async () => {
+    const filteredRuns = [sampleRun];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(filteredRuns),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs?test_case_id=1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body).toHaveLength(1);
+    expect(body.at(0)?.test_case_id).toBe(1);
+  });
+
+  it("数値以外のprompt_version_idに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs?prompt_version_id=abc");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid prompt_version_id");
+  });
+
+  it("数値以外のtest_case_idに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs?test_case_id=abc");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid test_case_id");
+  });
+});
+
+describe("POST /api/projects/:projectId/runs", () => {
+  it("バリデーション通過時に201でRunを返す", async () => {
+    const created = { ...sampleRun };
+
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        conversation: sampleConversation,
+        model: "claude-sonnet-4-6",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
+    expect(body.model).toBe("claude-sonnet-4-6");
+    expect(body.conversation).toEqual(sampleConversation);
+  });
+
+  it("is_bestが0で初期化される", async () => {
+    const created = { ...sampleRun, is_best: 0 };
+
+    const db = {
+      insert: () => ({
+        values: (values: { is_best: number }) => ({
+          returning: () => {
+            expect(values.is_best).toBe(0);
+            return Promise.resolve([created]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        conversation: sampleConversation,
+        model: "claude-sonnet-4-6",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockRun;
+    expect(body.is_best).toBe(0);
+  });
+
+  it("conversationが空配列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        conversation: [],
+        model: "claude-sonnet-4-6",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("必須フィールドが未指定のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversation: sampleConversation,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/projects/:projectId/runs/:id", () => {
+  it("存在するIDに対して200でRunを返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleRun]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
+    expect(body.id).toBe(1);
+    expect(body.conversation).toEqual(sampleConversation);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/999");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/abc");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
+  it("存在するIDに対して200でis_best=1のRunを返す", async () => {
+    const updated = { ...sampleRun, is_best: 1 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleRun]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/best", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
+    expect(body.is_best).toBe(1);
+  });
+
+  it("同一バージョン×テストケースの既存フラグが解除される", async () => {
+    const updated = { ...sampleRun, is_best: 1 };
+
+    let updateCallCount = 0;
+    const capturedSets: Array<{ is_best: number }> = [];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleRun]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { is_best: number }) => {
+          capturedSets.push(values);
+          updateCallCount++;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/best", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(200);
+    // updateが2回呼ばれる: 1回目は既存フラグ解除(is_best=0), 2回目はフラグ設定(is_best=1)
+    expect(updateCallCount).toBe(2);
+    expect(capturedSets[0]?.is_best).toBe(0);
+    expect(capturedSets[1]?.is_best).toBe(1);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/999/best", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/abc/best", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -20,14 +20,25 @@ const createRunSchema = z.object({
   api_provider: z.string().min(1, "api_providerは1文字以上必要です"),
 });
 
+/** 文字列を整数に変換する。無効な場合は null を返す */
+function parseIntParam(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** JSON 文字列を ConversationMessage[] に変換する */
+function parseConversation(json: string): ConversationMessage[] {
+  return JSON.parse(json) as ConversationMessage[];
+}
+
 export function createRunsRouter(db: DB) {
   const router = new Hono();
 
   // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
   router.get("/", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
+    const projectId = parseIntParam(c.req.param("projectId"));
 
-    if (Number.isNaN(projectId)) {
+    if (projectId === null) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
@@ -37,16 +48,16 @@ export function createRunsRouter(db: DB) {
     const conditions = [eq(runs.project_id, projectId)];
 
     if (promptVersionIdParam !== undefined) {
-      const promptVersionId = Number(promptVersionIdParam);
-      if (Number.isNaN(promptVersionId)) {
+      const promptVersionId = parseIntParam(promptVersionIdParam);
+      if (promptVersionId === null) {
         return c.json({ error: "Invalid prompt_version_id" }, 400);
       }
       conditions.push(eq(runs.prompt_version_id, promptVersionId));
     }
 
     if (testCaseIdParam !== undefined) {
-      const testCaseId = Number(testCaseIdParam);
-      if (Number.isNaN(testCaseId)) {
+      const testCaseId = parseIntParam(testCaseIdParam);
+      if (testCaseId === null) {
         return c.json({ error: "Invalid test_case_id" }, 400);
       }
       conditions.push(eq(runs.test_case_id, testCaseId));
@@ -60,16 +71,16 @@ export function createRunsRouter(db: DB) {
     return c.json(
       result.map((run) => ({
         ...run,
-        conversation: JSON.parse(run.conversation) as ConversationMessage[],
+        conversation: parseConversation(run.conversation),
       })),
     );
   });
 
   // POST /api/projects/:projectId/runs - 新規Run作成
   router.post("/", zValidator("json", createRunSchema), async (c) => {
-    const projectId = Number(c.req.param("projectId"));
+    const projectId = parseIntParam(c.req.param("projectId"));
 
-    if (Number.isNaN(projectId)) {
+    if (projectId === null) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
@@ -98,7 +109,7 @@ export function createRunsRouter(db: DB) {
     return c.json(
       {
         ...created,
-        conversation: JSON.parse(created.conversation) as ConversationMessage[],
+        conversation: parseConversation(created.conversation),
       },
       201,
     );
@@ -106,10 +117,10 @@ export function createRunsRouter(db: DB) {
 
   // GET /api/projects/:projectId/runs/:id - 特定Run取得
   router.get("/:id", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
-    const id = Number(c.req.param("id"));
+    const projectId = parseIntParam(c.req.param("projectId"));
+    const id = parseIntParam(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (projectId === null || id === null) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
@@ -124,17 +135,17 @@ export function createRunsRouter(db: DB) {
 
     return c.json({
       ...run,
-      conversation: JSON.parse(run.conversation) as ConversationMessage[],
+      conversation: parseConversation(run.conversation),
     });
   });
 
   // PATCH /api/projects/:projectId/runs/:id/best - ベスト回答フラグ更新
   // バージョン×テストケースごとに1件のみ設定できる（既存フラグは自動解除）
   router.patch("/:id/best", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
-    const id = Number(c.req.param("id"));
+    const projectId = parseIntParam(c.req.param("projectId"));
+    const id = parseIntParam(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (projectId === null || id === null) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
@@ -173,7 +184,7 @@ export function createRunsRouter(db: DB) {
 
     return c.json({
       ...updated,
-      conversation: JSON.parse(updated.conversation) as ConversationMessage[],
+      conversation: parseConversation(updated.conversation),
     });
   });
 

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -1,0 +1,181 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { runs } from "@prompt-reviewer/core";
+import type { ConversationMessage } from "@prompt-reviewer/core";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const conversationMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string().min(1, "contentは1文字以上必要です"),
+});
+
+const createRunSchema = z.object({
+  prompt_version_id: z.number().int().positive("prompt_version_idは正の整数が必要です"),
+  test_case_id: z.number().int().positive("test_case_idは正の整数が必要です"),
+  conversation: z.array(conversationMessageSchema).min(1, "conversationは1件以上必要です"),
+  model: z.string().min(1, "modelは1文字以上必要です"),
+  temperature: z.number().min(0).max(2),
+  api_provider: z.string().min(1, "api_providerは1文字以上必要です"),
+});
+
+export function createRunsRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
+  router.get("/", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+
+    if (Number.isNaN(projectId)) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const promptVersionIdParam = c.req.query("prompt_version_id");
+    const testCaseIdParam = c.req.query("test_case_id");
+
+    const conditions = [eq(runs.project_id, projectId)];
+
+    if (promptVersionIdParam !== undefined) {
+      const promptVersionId = Number(promptVersionIdParam);
+      if (Number.isNaN(promptVersionId)) {
+        return c.json({ error: "Invalid prompt_version_id" }, 400);
+      }
+      conditions.push(eq(runs.prompt_version_id, promptVersionId));
+    }
+
+    if (testCaseIdParam !== undefined) {
+      const testCaseId = Number(testCaseIdParam);
+      if (Number.isNaN(testCaseId)) {
+        return c.json({ error: "Invalid test_case_id" }, 400);
+      }
+      conditions.push(eq(runs.test_case_id, testCaseId));
+    }
+
+    const result = await db
+      .select()
+      .from(runs)
+      .where(and(...conditions));
+
+    return c.json(
+      result.map((run) => ({
+        ...run,
+        conversation: JSON.parse(run.conversation) as ConversationMessage[],
+      })),
+    );
+  });
+
+  // POST /api/projects/:projectId/runs - 新規Run作成
+  router.post("/", zValidator("json", createRunSchema), async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+
+    if (Number.isNaN(projectId)) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    const result = await db
+      .insert(runs)
+      .values({
+        project_id: projectId,
+        prompt_version_id: body.prompt_version_id,
+        test_case_id: body.test_case_id,
+        conversation: JSON.stringify(body.conversation),
+        is_best: 0,
+        model: body.model,
+        temperature: body.temperature,
+        api_provider: body.api_provider,
+        created_at: Date.now(),
+      })
+      .returning();
+
+    const created = result[0];
+    if (!created) {
+      return c.json({ error: "Failed to create Run" }, 500);
+    }
+
+    return c.json(
+      {
+        ...created,
+        conversation: JSON.parse(created.conversation) as ConversationMessage[],
+      },
+      201,
+    );
+  });
+
+  // GET /api/projects/:projectId/runs/:id - 特定Run取得
+  router.get("/:id", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [run] = await db
+      .select()
+      .from(runs)
+      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)));
+
+    if (!run) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    return c.json({
+      ...run,
+      conversation: JSON.parse(run.conversation) as ConversationMessage[],
+    });
+  });
+
+  // PATCH /api/projects/:projectId/runs/:id/best - ベスト回答フラグ更新
+  // バージョン×テストケースごとに1件のみ設定できる（既存フラグは自動解除）
+  router.patch("/:id/best", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(runs)
+      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)));
+
+    if (!existing) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    // 同一 prompt_version_id × test_case_id の既存フラグを解除
+    await db
+      .update(runs)
+      .set({ is_best: 0 })
+      .where(
+        and(
+          eq(runs.project_id, projectId),
+          eq(runs.prompt_version_id, existing.prompt_version_id),
+          eq(runs.test_case_id, existing.test_case_id),
+        ),
+      );
+
+    // 対象Runにベスト回答フラグを設定
+    const updateResult = await db
+      .update(runs)
+      .set({ is_best: 1 })
+      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update Run" }, 500);
+    }
+
+    return c.json({
+      ...updated,
+      conversation: JSON.parse(updated.conversation) as ConversationMessage[],
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `GET /api/projects/:projectId/runs` — Run一覧取得（`prompt_version_id` / `test_case_id` クエリパラメータでフィルタ可能）
- `POST /api/projects/:projectId/runs` — 新規Run作成（`conversation` はJSON配列でリクエスト、DBにはテキストとして保存）
- `GET /api/projects/:projectId/runs/:id` — 特定Run取得
- `PATCH /api/projects/:projectId/runs/:id/best` — ベスト回答フラグ更新（同一 `prompt_version_id × test_case_id` の既存フラグを自動解除してから対象にフラグを設定）

## Test plan

- [x] 全テスト143件パス（`npx vitest run`）
- [x] `pnpm run typecheck` パス
- [x] `pnpm run check` で `runs.ts` / `runs.test.ts` に固有のエラーなし

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)