### PR TITLE
feat(api): Score CRUD + バージョン別集計エンドポイントを実装 (#13)

### DIFF
--- a/packages/core/src/schema/runs.test.ts
+++ b/packages/core/src/schema/runs.test.ts
@@ -17,7 +17,7 @@ describe("runs スキーマ型定義", () => {
         prompt_version_id: number;
         test_case_id: number;
         conversation: string;
-        is_best: number;
+        is_best: boolean;
         created_at: number;
         model: string;
         temperature: number;
@@ -44,8 +44,8 @@ describe("runs スキーマ型定義", () => {
       expectTypeOf<Run["conversation"]>().toEqualTypeOf<string>();
     });
 
-    it("Run の is_best は number 型（0=通常, 1=ベスト回答）", () => {
-      expectTypeOf<Run["is_best"]>().toEqualTypeOf<number>();
+    it("Run の is_best は boolean 型", () => {
+      expectTypeOf<Run["is_best"]>().toEqualTypeOf<boolean>();
     });
 
     it("Run の project_id は number 型", () => {
@@ -92,7 +92,7 @@ describe("runs スキーマ型定義", () => {
     });
 
     it("NewRun の is_best はデフォルト値があるためオプショナル", () => {
-      expectTypeOf<NewRun["is_best"]>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<NewRun["is_best"]>().toEqualTypeOf<boolean | undefined>();
     });
 
     it("ベスト回答フラグを立てた NewRun を作成できる", () => {
@@ -104,7 +104,7 @@ describe("runs スキーマ型定義", () => {
           { role: "user", content: "質問です" },
           { role: "assistant", content: "詳細な回答です" },
         ]),
-        is_best: 1,
+        is_best: true,
         created_at: Date.now(),
         model: "claude-opus-4-5",
         temperature: 0.7,

--- a/packages/core/src/schema/runs.ts
+++ b/packages/core/src/schema/runs.ts
@@ -22,7 +22,7 @@ export const runs = sqliteTable("runs", {
     .notNull()
     .references(() => test_cases.id),
   conversation: text("conversation").notNull(),
-  is_best: integer("is_best").notNull().default(0),
+  is_best: integer("is_best", { mode: "boolean" }).notNull().default(false),
   created_at: integer("created_at").notNull(),
   // 実行時設定スナップショット（project_settings からコピー）
   model: text("model").notNull(),

--- a/packages/core/src/schema/scores.test.ts
+++ b/packages/core/src/schema/scores.test.ts
@@ -14,7 +14,7 @@ describe("scores スキーマ型定義", () => {
       type RequiredFields = {
         id: number;
         run_id: number;
-        is_discarded: number;
+        is_discarded: boolean;
         created_at: number;
         updated_at: number;
       };
@@ -39,8 +39,8 @@ describe("scores スキーマ型定義", () => {
       expectTypeOf<Score["judge_reason"]>().toEqualTypeOf<string | null>();
     });
 
-    it("Score の is_discarded は number 型（0=有効, 1=廃棄）", () => {
-      expectTypeOf<Score["is_discarded"]>().toEqualTypeOf<number>();
+    it("Score の is_discarded は boolean 型", () => {
+      expectTypeOf<Score["is_discarded"]>().toEqualTypeOf<boolean>();
     });
 
     it("Score の run_id は number 型", () => {
@@ -68,7 +68,7 @@ describe("scores スキーマ型定義", () => {
     });
 
     it("NewScore の is_discarded はデフォルト値があるためオプショナル", () => {
-      expectTypeOf<NewScore["is_discarded"]>().toEqualTypeOf<number | undefined>();
+      expectTypeOf<NewScore["is_discarded"]>().toEqualTypeOf<boolean | undefined>();
     });
 
     it("NewScore の human_score はオプショナル（null許容）", () => {
@@ -118,7 +118,7 @@ describe("scores スキーマ型定義", () => {
       const discardedScore: NewScore = {
         run_id: 3,
         human_score: 2,
-        is_discarded: 1,
+        is_discarded: true,
         created_at: now,
         updated_at: now,
       };

--- a/packages/core/src/schema/scores.ts
+++ b/packages/core/src/schema/scores.ts
@@ -20,7 +20,7 @@ export const scores = sqliteTable("scores", {
   human_comment: text("human_comment"),
   judge_score: integer("judge_score"),
   judge_reason: text("judge_reason"),
-  is_discarded: integer("is_discarded").notNull().default(0),
+  is_discarded: integer("is_discarded", { mode: "boolean" }).notNull().default(false),
   created_at: integer("created_at").notNull(),
   updated_at: integer("updated_at").notNull(),
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
 import { createRunsRouter } from "./routes/runs.js";
+import { createScoresRouter, createVersionSummaryRouter } from "./routes/scores.js";
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
 const app = new Hono();
@@ -25,7 +26,9 @@ app.get("/health", (c) => {
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
+app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
+app.route("/api/runs", createScoresRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -31,7 +31,7 @@ type MockRun = {
   prompt_version_id: number;
   test_case_id: number;
   conversation: string;
-  is_best: number;
+  is_best: boolean;
   created_at: number;
   model: string;
   temperature: number;
@@ -59,7 +59,7 @@ const sampleRun: MockRun = {
   prompt_version_id: 1,
   test_case_id: 1,
   conversation: JSON.stringify(sampleConversation),
-  is_best: 0,
+  is_best: false,
   created_at: 1000000,
   model: "claude-sonnet-4-6",
   temperature: 0.7,
@@ -217,14 +217,14 @@ describe("POST /api/projects/:projectId/runs", () => {
     expect(body.conversation).toEqual(sampleConversation);
   });
 
-  it("is_bestが0で初期化される", async () => {
-    const created = { ...sampleRun, is_best: 0 };
+  it("is_bestがfalseで初期化される", async () => {
+    const created = { ...sampleRun, is_best: false };
 
     const db = {
       insert: () => ({
-        values: (values: { is_best: number }) => ({
+        values: (values: { is_best: boolean }) => ({
           returning: () => {
-            expect(values.is_best).toBe(0);
+            expect(values.is_best).toBe(false);
             return Promise.resolve([created]);
           },
         }),
@@ -247,7 +247,7 @@ describe("POST /api/projects/:projectId/runs", () => {
 
     expect(res.status).toBe(201);
     const body = (await res.json()) as MockRun;
-    expect(body.is_best).toBe(0);
+    expect(body.is_best).toBe(false);
   });
 
   it("conversationが空配列のとき400を返す", async () => {
@@ -333,8 +333,8 @@ describe("GET /api/projects/:projectId/runs/:id", () => {
 });
 
 describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
-  it("存在するIDに対して200でis_best=1のRunを返す", async () => {
-    const updated = { ...sampleRun, is_best: 1 };
+  it("存在するIDに対して200でis_best=trueのRunを返す", async () => {
+    const updated = { ...sampleRun, is_best: true };
 
     const db = {
       select: () => ({
@@ -358,14 +358,14 @@ describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
-    expect(body.is_best).toBe(1);
+    expect(body.is_best).toBe(true);
   });
 
   it("同一バージョン×テストケースの既存フラグが解除される", async () => {
-    const updated = { ...sampleRun, is_best: 1 };
+    const updated = { ...sampleRun, is_best: true };
 
     let updateCallCount = 0;
-    const capturedSets: Array<{ is_best: number }> = [];
+    const capturedSets: Array<{ is_best: boolean }> = [];
 
     const db = {
       select: () => ({
@@ -374,7 +374,7 @@ describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
         }),
       }),
       update: () => ({
-        set: (values: { is_best: number }) => {
+        set: (values: { is_best: boolean }) => {
           capturedSets.push(values);
           updateCallCount++;
           return {
@@ -392,10 +392,10 @@ describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
     });
 
     expect(res.status).toBe(200);
-    // updateが2回呼ばれる: 1回目は既存フラグ解除(is_best=0), 2回目はフラグ設定(is_best=1)
+    // updateが2回呼ばれる: 1回目は既存フラグ解除(is_best=false), 2回目はフラグ設定(is_best=true)
     expect(updateCallCount).toBe(2);
-    expect(capturedSets[0]?.is_best).toBe(0);
-    expect(capturedSets[1]?.is_best).toBe(1);
+    expect(capturedSets[0]?.is_best).toBe(false);
+    expect(capturedSets[1]?.is_best).toBe(true);
   });
 
   it("存在しないIDに対して404を返す", async () => {

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -94,7 +94,7 @@ export function createRunsRouter(db: DB) {
         prompt_version_id: body.prompt_version_id,
         test_case_id: body.test_case_id,
         conversation: JSON.stringify(body.conversation),
-        is_best: 0,
+        is_best: false,
         model: body.model,
         temperature: body.temperature,
         api_provider: body.api_provider,
@@ -162,7 +162,7 @@ export function createRunsRouter(db: DB) {
     // 同一 prompt_version_id × test_case_id の既存フラグを解除
     await db
       .update(runs)
-      .set({ is_best: 0 })
+      .set({ is_best: false })
       .where(
         and(
           eq(runs.project_id, projectId),
@@ -174,7 +174,7 @@ export function createRunsRouter(db: DB) {
     // 対象Runにベスト回答フラグを設定
     const updateResult = await db
       .update(runs)
-      .set({ is_best: 1 })
+      .set({ is_best: true })
       .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
       .returning();
 

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -20,8 +20,9 @@ const createRunSchema = z.object({
   api_provider: z.string().min(1, "api_providerは1文字以上必要です"),
 });
 
-/** 文字列を整数に変換する。無効な場合は null を返す */
-function parseIntParam(value: string): number | null {
+/** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
+function parseIntParam(value: string | undefined): number | null {
+  if (value === undefined) return null;
   const parsed = Number(value);
   return Number.isNaN(parsed) ? null : parsed;
 }

--- a/packages/server/src/routes/scores.test.ts
+++ b/packages/server/src/routes/scores.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Score CRUD + バージョン別集計エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createScoresRouter, createVersionSummaryRouter } from "./scores.js";
+
+// ---- 型定義 ----
+
+type MockRun = {
+  id: number;
+  project_id: number;
+  prompt_version_id: number;
+  test_case_id: number;
+  conversation: string;
+  is_best: number;
+  created_at: number;
+  model: string;
+  temperature: number;
+  api_provider: string;
+};
+
+type MockScore = {
+  id: number;
+  run_id: number;
+  human_score: number | null;
+  human_comment: string | null;
+  judge_score: number | null;
+  judge_reason: string | null;
+  is_discarded: number;
+  created_at: number;
+  updated_at: number;
+};
+
+// ---- ヘルパー ----
+
+function buildScoresApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/runs", createScoresRouter(db as DB));
+  return app;
+}
+
+function buildSummaryApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db as DB));
+  return app;
+}
+
+/**
+ * select().from().where() を n 回呼べるモックを作成する
+ * 各呼び出しに対して results[i] を返す
+ */
+function makeSelectMock(results: unknown[][]) {
+  let callIndex = 0;
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          const result = results[callIndex] ?? [];
+          callIndex++;
+          return Promise.resolve(result);
+        },
+      }),
+    }),
+  };
+}
+
+// ---- テストデータ ----
+
+const sampleRun: MockRun = {
+  id: 1,
+  project_id: 1,
+  prompt_version_id: 1,
+  test_case_id: 1,
+  conversation: JSON.stringify([{ role: "user", content: "test" }]),
+  is_best: 0,
+  created_at: 1000000,
+  model: "claude-sonnet-4-6",
+  temperature: 0.7,
+  api_provider: "anthropic",
+};
+
+const sampleScore: MockScore = {
+  id: 1,
+  run_id: 1,
+  human_score: 4,
+  human_comment: "良い回答",
+  judge_score: null,
+  judge_reason: null,
+  is_discarded: 0,
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+// ---- POST /api/runs/:runId/score テスト ----
+
+describe("POST /api/runs/:runId/score", () => {
+  it("Run が存在しスコア未登録の場合、201でスコアを返す", async () => {
+    const created = { ...sampleScore };
+
+    const db = {
+      // 1回目: Run の存在確認 → Run を返す / 2回目: 既存スコア確認 → 空
+      ...makeSelectMock([[sampleRun], []]),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        human_score: 4,
+        human_comment: "良い回答",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockScore;
+    expect(body.human_score).toBe(4);
+    expect(body.run_id).toBe(1);
+    expect(body.is_discarded).toBe(0);
+  });
+
+  it("スコアが既に存在する場合は 409 を返す", async () => {
+    const db = {
+      // 1回目: Run の存在確認 → Run を返す / 2回目: 既存スコア確認 → 既存あり
+      ...makeSelectMock([[sampleRun], [sampleScore]]),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        human_score: 3,
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Score already exists for this Run");
+  });
+
+  it("Run が存在しない場合は 404 を返す", async () => {
+    const db = {
+      // 1回目: Run の存在確認 → 存在しない
+      ...makeSelectMock([[]]),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/999/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        human_score: 3,
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
+  });
+
+  it("数値以外の runId に対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/abc/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid runId");
+  });
+
+  it("human_score が範囲外（1〜5以外）の場合は 400 を返す", async () => {
+    const db = {};
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 6 }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("スコアフィールドなしで作成する場合（全フィールド任意）、201 で返す", async () => {
+    const created = { ...sampleScore, human_score: null, human_comment: null };
+
+    const db = {
+      // 1回目: Run の存在確認 → Run を返す / 2回目: 既存スコア確認 → 空
+      ...makeSelectMock([[sampleRun], []]),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("is_discarded が 0 で初期化される", async () => {
+    const created = { ...sampleScore, is_discarded: 0 };
+
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      ...makeSelectMock([[sampleRun], []]),
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    await app.request("/api/runs/1/score", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    expect(capturedValues.is_discarded).toBe(0);
+  });
+});
+
+// ---- PATCH /api/runs/:runId/score テスト ----
+
+describe("PATCH /api/runs/:runId/score", () => {
+  it("存在するスコアを更新して 200 で返す", async () => {
+    const updated = { ...sampleScore, human_score: 5, updated_at: 2000000 };
+
+    const db = {
+      // 1回目: Run の存在確認 / 2回目: スコアの存在確認
+      ...makeSelectMock([[sampleRun], [sampleScore]]),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 5 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockScore;
+    expect(body.human_score).toBe(5);
+  });
+
+  it("is_discarded フラグを更新できる", async () => {
+    const updated = { ...sampleScore, is_discarded: 1, updated_at: 2000000 };
+
+    let capturedUpdateData: Record<string, unknown> = {};
+
+    const db = {
+      ...makeSelectMock([[sampleRun], [sampleScore]]),
+      update: () => ({
+        set: (data: Record<string, unknown>) => {
+          capturedUpdateData = data;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_discarded: 1 }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedUpdateData.is_discarded).toBe(1);
+    const body = (await res.json()) as MockScore;
+    expect(body.is_discarded).toBe(1);
+  });
+
+  it("Run が存在しない場合は 404 を返す", async () => {
+    const db = {
+      // 1回目: Run の存在確認 → 存在しない
+      ...makeSelectMock([[]]),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/999/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
+  });
+
+  it("スコアが存在しない場合は 404 を返す", async () => {
+    const db = {
+      // 1回目: Run の存在確認 → Run を返す / 2回目: スコア確認 → 存在しない
+      ...makeSelectMock([[sampleRun], []]),
+    };
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/1/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Score not found for this Run");
+  });
+
+  it("数値以外の runId に対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildScoresApp(db);
+    const res = await app.request("/api/runs/abc/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid runId");
+  });
+
+  it("updated_at が更新時刻に設定される", async () => {
+    const updated = { ...sampleScore, updated_at: 9999999 };
+
+    let capturedUpdateData: Record<string, unknown> = {};
+
+    const db = {
+      ...makeSelectMock([[sampleRun], [sampleScore]]),
+      update: () => ({
+        set: (data: Record<string, unknown>) => {
+          capturedUpdateData = data;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildScoresApp(db);
+    await app.request("/api/runs/1/score", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ human_score: 3 }),
+    });
+
+    // updated_at は現在時刻（数値）で設定される
+    expect(typeof capturedUpdateData.updated_at).toBe("number");
+    expect(capturedUpdateData.updated_at).toBeGreaterThan(0);
+  });
+});
+
+// ---- GET /api/projects/:projectId/prompt-versions/:id/summary テスト ----
+
+describe("GET /api/projects/:projectId/prompt-versions/:id/summary", () => {
+  it("Run が存在しない場合は runCount=0、スコアは null を返す", async () => {
+    const db = {
+      // 1回目: versionRuns の取得 → 空
+      ...makeSelectMock([[]]),
+    };
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/summary");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      versionId: number;
+      avgHumanScore: null;
+      avgJudgeScore: null;
+      runCount: number;
+      scoredCount: number;
+    };
+    expect(body.versionId).toBe(1);
+    expect(body.runCount).toBe(0);
+    expect(body.scoredCount).toBe(0);
+    expect(body.avgHumanScore).toBeNull();
+    expect(body.avgJudgeScore).toBeNull();
+  });
+
+  it("is_discarded=false のスコアのみ集計する", async () => {
+    // Run が3件ある
+    const versionRuns = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+    // is_discarded=0 のスコア（DBクエリで is_discarded=0 にフィルタ済み）
+    const validScores = [
+      { id: 1, run_id: 1, human_score: 4, judge_score: null, is_discarded: 0 },
+      { id: 2, run_id: 2, human_score: 2, judge_score: 5, is_discarded: 0 },
+      // run_id=3 はスコア未評価
+    ];
+
+    const db = {
+      // 1回目: versionRuns の取得 / 2回目: is_discarded=0 のスコア取得
+      ...makeSelectMock([versionRuns, validScores]),
+    };
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/summary");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      versionId: number;
+      avgHumanScore: number | null;
+      avgJudgeScore: number | null;
+      runCount: number;
+      scoredCount: number;
+    };
+
+    expect(body.versionId).toBe(1);
+    expect(body.runCount).toBe(3);
+    // Run1(4) + Run2(2) の平均 = 3
+    expect(body.avgHumanScore).toBe(3);
+    // judge_score は Run2 のみ = 5
+    expect(body.avgJudgeScore).toBe(5);
+    // is_discarded=0 のスコアが 2 件
+    expect(body.scoredCount).toBe(2);
+  });
+
+  it("run_id が対象バージョン外のスコアは集計に含まれない", async () => {
+    // バージョン1の Run（id=1 のみ）
+    const versionRuns = [{ id: 1 }];
+
+    // is_discarded=0 のスコア（run_id=2 は別バージョンのRunだが is_discarded=0）
+    const validScores = [
+      { id: 1, run_id: 1, human_score: 5, judge_score: null, is_discarded: 0 },
+      { id: 2, run_id: 2, human_score: 1, judge_score: null, is_discarded: 0 },
+    ];
+
+    const db = {
+      // 1回目: versionRuns の取得 / 2回目: is_discarded=0 のスコア取得
+      ...makeSelectMock([versionRuns, validScores]),
+    };
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/summary");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      avgHumanScore: number | null;
+      runCount: number;
+      scoredCount: number;
+    };
+
+    // run_id=2 は versionRuns に含まれないためフィルタされる
+    expect(body.runCount).toBe(1);
+    expect(body.scoredCount).toBe(1);
+    // Run1 のみ集計: human_score=5
+    expect(body.avgHumanScore).toBe(5);
+  });
+
+  it("human_score が全て null の場合、avgHumanScore は null を返す", async () => {
+    const versionRuns = [{ id: 1 }];
+
+    const validScores = [
+      { id: 1, run_id: 1, human_score: null, judge_score: null, is_discarded: 0 },
+    ];
+
+    const db = {
+      ...makeSelectMock([versionRuns, validScores]),
+    };
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/summary");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      avgHumanScore: number | null;
+      avgJudgeScore: number | null;
+      scoredCount: number;
+    };
+
+    expect(body.avgHumanScore).toBeNull();
+    expect(body.avgJudgeScore).toBeNull();
+    // スコアレコードは存在するので scoredCount=1
+    expect(body.scoredCount).toBe(1);
+  });
+
+  it("数値以外の projectId に対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/abc/prompt-versions/1/summary");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid ID");
+  });
+
+  it("数値以外のバージョンIDに対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/abc/summary");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid ID");
+  });
+
+  it("複数 Run の avgHumanScore が正確に計算される", async () => {
+    const versionRuns = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+
+    // human_score: 1, 3, 5 → 平均 = 3.0（id=4のRunはスコアなし）
+    const validScores = [
+      { id: 1, run_id: 1, human_score: 1, judge_score: null, is_discarded: 0 },
+      { id: 2, run_id: 2, human_score: 3, judge_score: null, is_discarded: 0 },
+      { id: 3, run_id: 3, human_score: 5, judge_score: null, is_discarded: 0 },
+    ];
+
+    const db = {
+      ...makeSelectMock([versionRuns, validScores]),
+    };
+
+    const app = buildSummaryApp(db);
+    const res = await app.request("/api/projects/1/prompt-versions/1/summary");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      runCount: number;
+      scoredCount: number;
+      avgHumanScore: number | null;
+    };
+
+    expect(body.runCount).toBe(4);
+    expect(body.scoredCount).toBe(3);
+    expect(body.avgHumanScore).toBe(3);
+  });
+});

--- a/packages/server/src/routes/scores.test.ts
+++ b/packages/server/src/routes/scores.test.ts
@@ -193,14 +193,14 @@ describe("POST /api/runs/:runId/score", () => {
     expect(body.error).toBe("Invalid runId");
   });
 
-  it("human_score が範囲外（1〜5以外）の場合は 400 を返す", async () => {
+  it("human_score が範囲外（1〜100以外）の場合は 400 を返す", async () => {
     const db = {};
 
     const app = buildScoresApp(db);
     const res = await app.request("/api/runs/1/score", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ human_score: 6 }),
+      body: JSON.stringify({ human_score: 101 }),
     });
 
     expect(res.status).toBe(400);

--- a/packages/server/src/routes/scores.test.ts
+++ b/packages/server/src/routes/scores.test.ts
@@ -26,7 +26,7 @@ type MockRun = {
   prompt_version_id: number;
   test_case_id: number;
   conversation: string;
-  is_best: number;
+  is_best: boolean;
   created_at: number;
   model: string;
   temperature: number;
@@ -40,7 +40,7 @@ type MockScore = {
   human_comment: string | null;
   judge_score: number | null;
   judge_reason: string | null;
-  is_discarded: number;
+  is_discarded: boolean;
   created_at: number;
   updated_at: number;
 };
@@ -86,7 +86,7 @@ const sampleRun: MockRun = {
   prompt_version_id: 1,
   test_case_id: 1,
   conversation: JSON.stringify([{ role: "user", content: "test" }]),
-  is_best: 0,
+  is_best: false,
   created_at: 1000000,
   model: "claude-sonnet-4-6",
   temperature: 0.7,
@@ -100,7 +100,7 @@ const sampleScore: MockScore = {
   human_comment: "良い回答",
   judge_score: null,
   judge_reason: null,
-  is_discarded: 0,
+  is_discarded: false,
   created_at: 1000000,
   updated_at: 1000000,
 };
@@ -135,7 +135,7 @@ describe("POST /api/runs/:runId/score", () => {
     const body = (await res.json()) as MockScore;
     expect(body.human_score).toBe(4);
     expect(body.run_id).toBe(1);
-    expect(body.is_discarded).toBe(0);
+    expect(body.is_discarded).toBe(false);
   });
 
   it("スコアが既に存在する場合は 409 を返す", async () => {
@@ -229,8 +229,8 @@ describe("POST /api/runs/:runId/score", () => {
     expect(res.status).toBe(201);
   });
 
-  it("is_discarded が 0 で初期化される", async () => {
-    const created = { ...sampleScore, is_discarded: 0 };
+  it("is_discarded が false で初期化される", async () => {
+    const created = { ...sampleScore, is_discarded: false };
 
     let capturedValues: Record<string, unknown> = {};
 
@@ -253,7 +253,7 @@ describe("POST /api/runs/:runId/score", () => {
       body: JSON.stringify({ human_score: 3 }),
     });
 
-    expect(capturedValues.is_discarded).toBe(0);
+    expect(capturedValues.is_discarded).toBe(false);
   });
 });
 
@@ -288,7 +288,7 @@ describe("PATCH /api/runs/:runId/score", () => {
   });
 
   it("is_discarded フラグを更新できる", async () => {
-    const updated = { ...sampleScore, is_discarded: 1, updated_at: 2000000 };
+    const updated = { ...sampleScore, is_discarded: true, updated_at: 2000000 };
 
     let capturedUpdateData: Record<string, unknown> = {};
 
@@ -310,13 +310,13 @@ describe("PATCH /api/runs/:runId/score", () => {
     const res = await app.request("/api/runs/1/score", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ is_discarded: 1 }),
+      body: JSON.stringify({ is_discarded: true }),
     });
 
     expect(res.status).toBe(200);
-    expect(capturedUpdateData.is_discarded).toBe(1);
+    expect(capturedUpdateData.is_discarded).toBe(true);
     const body = (await res.json()) as MockScore;
-    expect(body.is_discarded).toBe(1);
+    expect(body.is_discarded).toBe(true);
   });
 
   it("Run が存在しない場合は 404 を返す", async () => {
@@ -435,8 +435,8 @@ describe("GET /api/projects/:projectId/prompt-versions/:id/summary", () => {
 
     // is_discarded=0 のスコア（DBクエリで is_discarded=0 にフィルタ済み）
     const validScores = [
-      { id: 1, run_id: 1, human_score: 4, judge_score: null, is_discarded: 0 },
-      { id: 2, run_id: 2, human_score: 2, judge_score: 5, is_discarded: 0 },
+      { id: 1, run_id: 1, human_score: 4, judge_score: null, is_discarded: false },
+      { id: 2, run_id: 2, human_score: 2, judge_score: 5, is_discarded: false },
       // run_id=3 はスコア未評価
     ];
 
@@ -473,8 +473,8 @@ describe("GET /api/projects/:projectId/prompt-versions/:id/summary", () => {
 
     // is_discarded=0 のスコア（run_id=2 は別バージョンのRunだが is_discarded=0）
     const validScores = [
-      { id: 1, run_id: 1, human_score: 5, judge_score: null, is_discarded: 0 },
-      { id: 2, run_id: 2, human_score: 1, judge_score: null, is_discarded: 0 },
+      { id: 1, run_id: 1, human_score: 5, judge_score: null, is_discarded: false },
+      { id: 2, run_id: 2, human_score: 1, judge_score: null, is_discarded: false },
     ];
 
     const db = {
@@ -503,7 +503,7 @@ describe("GET /api/projects/:projectId/prompt-versions/:id/summary", () => {
     const versionRuns = [{ id: 1 }];
 
     const validScores = [
-      { id: 1, run_id: 1, human_score: null, judge_score: null, is_discarded: 0 },
+      { id: 1, run_id: 1, human_score: null, judge_score: null, is_discarded: false },
     ];
 
     const db = {
@@ -553,9 +553,9 @@ describe("GET /api/projects/:projectId/prompt-versions/:id/summary", () => {
 
     // human_score: 1, 3, 5 → 平均 = 3.0（id=4のRunはスコアなし）
     const validScores = [
-      { id: 1, run_id: 1, human_score: 1, judge_score: null, is_discarded: 0 },
-      { id: 2, run_id: 2, human_score: 3, judge_score: null, is_discarded: 0 },
-      { id: 3, run_id: 3, human_score: 5, judge_score: null, is_discarded: 0 },
+      { id: 1, run_id: 1, human_score: 1, judge_score: null, is_discarded: false },
+      { id: 2, run_id: 2, human_score: 3, judge_score: null, is_discarded: false },
+      { id: 3, run_id: 3, human_score: 5, judge_score: null, is_discarded: false },
     ];
 
     const db = {

--- a/packages/server/src/routes/scores.ts
+++ b/packages/server/src/routes/scores.ts
@@ -5,17 +5,20 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
+const MIN_SCORE = 1;
+const MAX_SCORE = 100;
+
 const createScoreSchema = z.object({
-  human_score: z.number().int().min(1).max(5).optional(),
+  human_score: z.number().int().min(MIN_SCORE).max(MAX_SCORE).optional(),
   human_comment: z.string().optional(),
-  judge_score: z.number().int().min(1).max(5).optional(),
+  judge_score: z.number().int().min(MIN_SCORE).max(MAX_SCORE).optional(),
   judge_reason: z.string().optional(),
 });
 
 const updateScoreSchema = z.object({
-  human_score: z.number().int().min(1).max(5).nullable().optional(),
+  human_score: z.number().int().min(MIN_SCORE).max(MAX_SCORE).nullable().optional(),
   human_comment: z.string().nullable().optional(),
-  judge_score: z.number().int().min(1).max(5).nullable().optional(),
+  judge_score: z.number().int().min(MIN_SCORE).max(MAX_SCORE).nullable().optional(),
   judge_reason: z.string().nullable().optional(),
   is_discarded: z.number().int().min(0).max(1).optional(),
 });

--- a/packages/server/src/routes/scores.ts
+++ b/packages/server/src/routes/scores.ts
@@ -20,7 +20,7 @@ const updateScoreSchema = z.object({
   human_comment: z.string().nullable().optional(),
   judge_score: z.number().int().min(MIN_SCORE).max(MAX_SCORE).nullable().optional(),
   judge_reason: z.string().nullable().optional(),
-  is_discarded: z.number().int().min(0).max(1).optional(),
+  is_discarded: z.boolean().optional(),
 });
 
 /** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
@@ -72,7 +72,7 @@ export function createScoresRouter(db: DB) {
         human_comment: body.human_comment ?? null,
         judge_score: body.judge_score ?? null,
         judge_reason: body.judge_reason ?? null,
-        is_discarded: 0,
+        is_discarded: false,
         created_at: now,
         updated_at: now,
       })
@@ -112,7 +112,7 @@ export function createScoresRouter(db: DB) {
       human_comment?: string | null;
       judge_score?: number | null;
       judge_reason?: string | null;
-      is_discarded?: number;
+      is_discarded?: boolean;
       updated_at: number;
     } = { updated_at: Date.now() };
 
@@ -189,8 +189,8 @@ export function createVersionSummaryRouter(db: DB) {
       .from(scores)
       .where(
         and(
-          // is_discarded = 0 のみ
-          eq(scores.is_discarded, 0),
+          // is_discarded = false のみ
+          eq(scores.is_discarded, false),
         ),
       );
 

--- a/packages/server/src/routes/scores.ts
+++ b/packages/server/src/routes/scores.ts
@@ -1,0 +1,229 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { runs, scores } from "@prompt-reviewer/core";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createScoreSchema = z.object({
+  human_score: z.number().int().min(1).max(5).optional(),
+  human_comment: z.string().optional(),
+  judge_score: z.number().int().min(1).max(5).optional(),
+  judge_reason: z.string().optional(),
+});
+
+const updateScoreSchema = z.object({
+  human_score: z.number().int().min(1).max(5).nullable().optional(),
+  human_comment: z.string().nullable().optional(),
+  judge_score: z.number().int().min(1).max(5).nullable().optional(),
+  judge_reason: z.string().nullable().optional(),
+  is_discarded: z.number().int().min(0).max(1).optional(),
+});
+
+/** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
+function parseIntParam(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * スコア CRUD + バージョン別集計エンドポイントのルーター
+ *
+ * POST   /api/runs/:runId/score          - スコア作成（1 Run に 1 Score）
+ * PATCH  /api/runs/:runId/score          - スコア更新
+ * GET    /api/projects/:projectId/prompt-versions/:versionId/summary - バージョン別集計
+ */
+export function createScoresRouter(db: DB) {
+  const runsRouter = new Hono<{ Variables: Record<string, unknown> }>();
+
+  // POST /api/runs/:runId/score - スコア作成
+  // 既存スコアがある場合は 409 Conflict を返す
+  runsRouter.post("/:runId/score", zValidator("json", createScoreSchema), async (c) => {
+    const runId = parseIntParam(c.req.param("runId"));
+
+    if (runId === null) {
+      return c.json({ error: "Invalid runId" }, 400);
+    }
+
+    // Run の存在確認
+    const [run] = await db.select().from(runs).where(eq(runs.id, runId));
+    if (!run) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    // 既存スコアの確認（1 Run につき 1 Score）
+    const [existing] = await db.select().from(scores).where(eq(scores.run_id, runId));
+    if (existing) {
+      return c.json({ error: "Score already exists for this Run" }, 409);
+    }
+
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const result = await db
+      .insert(scores)
+      .values({
+        run_id: runId,
+        human_score: body.human_score ?? null,
+        human_comment: body.human_comment ?? null,
+        judge_score: body.judge_score ?? null,
+        judge_reason: body.judge_reason ?? null,
+        is_discarded: 0,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    const created = result[0];
+    if (!created) {
+      return c.json({ error: "Failed to create Score" }, 500);
+    }
+
+    return c.json(created, 201);
+  });
+
+  // PATCH /api/runs/:runId/score - スコア更新
+  runsRouter.patch("/:runId/score", zValidator("json", updateScoreSchema), async (c) => {
+    const runId = parseIntParam(c.req.param("runId"));
+
+    if (runId === null) {
+      return c.json({ error: "Invalid runId" }, 400);
+    }
+
+    // Run の存在確認
+    const [run] = await db.select().from(runs).where(eq(runs.id, runId));
+    if (!run) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    // スコアの存在確認
+    const [existing] = await db.select().from(scores).where(eq(scores.run_id, runId));
+    if (!existing) {
+      return c.json({ error: "Score not found for this Run" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const updateData: {
+      human_score?: number | null;
+      human_comment?: string | null;
+      judge_score?: number | null;
+      judge_reason?: string | null;
+      is_discarded?: number;
+      updated_at: number;
+    } = { updated_at: Date.now() };
+
+    if (body.human_score !== undefined) updateData.human_score = body.human_score;
+    if (body.human_comment !== undefined) updateData.human_comment = body.human_comment;
+    if (body.judge_score !== undefined) updateData.judge_score = body.judge_score;
+    if (body.judge_reason !== undefined) updateData.judge_reason = body.judge_reason;
+    if (body.is_discarded !== undefined) updateData.is_discarded = body.is_discarded;
+
+    const updateResult = await db
+      .update(scores)
+      .set(updateData)
+      .where(eq(scores.run_id, runId))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update Score" }, 500);
+    }
+
+    return c.json(updated);
+  });
+
+  return runsRouter;
+}
+
+/**
+ * バージョン別集計エンドポイントのルーター
+ * GET /api/projects/:projectId/prompt-versions/:id/summary
+ */
+export function createVersionSummaryRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/projects/:projectId/prompt-versions/:id/summary - バージョン別集計
+  // is_discarded=true のスコアは集計から除外する
+  router.get("/:id/summary", async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+    const versionId = parseIntParam(c.req.param("id"));
+
+    if (projectId === null || versionId === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    // バージョンに紐づく全 Run を取得（project_id + prompt_version_id でフィルタ）
+    const versionRuns = await db
+      .select({ id: runs.id })
+      .from(runs)
+      .where(and(eq(runs.project_id, projectId), eq(runs.prompt_version_id, versionId)));
+
+    const runCount = versionRuns.length;
+
+    if (runCount === 0) {
+      return c.json({
+        versionId,
+        avgHumanScore: null,
+        avgJudgeScore: null,
+        runCount: 0,
+        scoredCount: 0,
+      });
+    }
+
+    const runIds = versionRuns.map((r) => r.id);
+
+    // is_discarded=false のスコアのみ集計対象
+    // runIds に含まれる score を取得
+    const validScores = await db
+      .select({
+        id: scores.id,
+        run_id: scores.run_id,
+        human_score: scores.human_score,
+        judge_score: scores.judge_score,
+        is_discarded: scores.is_discarded,
+      })
+      .from(scores)
+      .where(
+        and(
+          // is_discarded = 0 のみ
+          eq(scores.is_discarded, 0),
+        ),
+      );
+
+    // runIds でフィルタ（SQLite の IN 演算子の代わりにアプリ側でフィルタ）
+    const filteredScores = validScores.filter((s) => runIds.includes(s.run_id));
+
+    const scoredCount = filteredScores.length;
+
+    // avgHumanScore: human_score が null でないものの平均
+    const humanScores = filteredScores
+      .map((s) => s.human_score)
+      .filter((v): v is number => v !== null);
+
+    const avgHumanScore =
+      humanScores.length > 0
+        ? humanScores.reduce((sum, v) => sum + v, 0) / humanScores.length
+        : null;
+
+    // avgJudgeScore: judge_score が null でないものの平均
+    const judgeScores = filteredScores
+      .map((s) => s.judge_score)
+      .filter((v): v is number => v !== null);
+
+    const avgJudgeScore =
+      judgeScores.length > 0
+        ? judgeScores.reduce((sum, v) => sum + v, 0) / judgeScores.length
+        : null;
+
+    return c.json({
+      versionId,
+      avgHumanScore,
+      avgJudgeScore,
+      runCount,
+      scoredCount,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## 概要

Issue #13「Score CRUD + バージョン別集計エンドポイント」の実装。

## 実装内容

### 新規エンドポイント

- `POST /api/runs/:runId/score` — スコア作成（同一 Run にスコアが既存の場合は 409 Conflict）
- `PATCH /api/runs/:runId/score` — スコア更新（is_discarded フラグの設定も可能）
- `GET /api/projects/:projectId/prompt-versions/:id/summary` — バージョン別集計
  - `is_discarded=1` のスコアを集計から除外
  - `avgHumanScore`, `avgJudgeScore`, `runCount`, `scoredCount` を返す

### 修正

- `runs.ts` の `parseIntParam` 関数のシグネチャを `string | undefined` 対応に変更（TypeScript 型安全性向上）

## テスト計画

- [x] `POST /api/runs/:runId/score` — 201 作成 / 409 重複 / 404 Run なし / 400 無効 ID・範囲外スコア
- [x] `PATCH /api/runs/:runId/score` — 200 更新 / is_discarded フラグ更新 / 404 Run・Score なし / 400 無効 ID
- [x] `GET /api/projects/:projectId/prompt-versions/:id/summary` — Run なし / is_discarded 除外 / 別バージョン Run 除外 / null 平均 / 複数 Run 平均計算 / 400 無効 ID

## 完了条件の確認

- [x] `is_discarded=true` のスコアは集計から除外される
- [x] 集計値（avgHumanScore, avgJudgeScore, runCount, scoredCount）が正しく計算される
- [x] Vitest でテストが書かれている（20 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)