### PR TITLE
feat(api): ProjectSettings CRUD エンドポイントを実装 (#14)

### DIFF
--- a/packages/core/drizzle/0004_project_settings.sql
+++ b/packages/core/drizzle/0004_project_settings.sql
@@ -1,0 +1,11 @@
+-- project_settings テーブルを新規作成
+-- プロジェクトごとのLLM設定（model / temperature / api_provider）を管理する
+CREATE TABLE `project_settings` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `project_id` integer NOT NULL REFERENCES `projects`(`id`),
+  `model` text NOT NULL DEFAULT 'claude-opus-4-5',
+  `temperature` real NOT NULL DEFAULT 0.7,
+  `api_provider` text NOT NULL DEFAULT 'anthropic',
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);

--- a/packages/core/drizzle/meta/0004_snapshot.json
+++ b/packages/core/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,530 @@
+{
+  "id": "a7b53b3a-b43e-403c-bb64-404274bdda61",
+  "prevId": "2fa779e7-beb6-44c9-a8fe-9206c41cf69d",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "tableTo": "prompt_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "columnsFrom": [
+            "prompt_version_id"
+          ],
+          "tableTo": "prompt_versions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "tableTo": "test_cases",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_reason": {
+          "name": "judge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_run_id_runs_id_fk": {
+          "name": "scores_run_id_runs_id_fk",
+          "tableFrom": "scores",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "tableTo": "runs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775865439087,
       "tag": "0003_mute_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1744509600000,
+      "tag": "0004_project_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server";
 import { db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
 import { createRunsRouter } from "./routes/runs.js";
@@ -29,6 +30,7 @@ app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
+app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/packages/server/src/routes/project-settings.test.ts
+++ b/packages/server/src/routes/project-settings.test.ts
@@ -1,0 +1,423 @@
+/**
+ * ProjectSettings CRUD エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createProjectSettingsRouter } from "./project-settings.js";
+
+// ---- 型定義 ----
+
+type MockSettings = {
+  id: number;
+  project_id: number;
+  model: string;
+  temperature: number;
+  api_provider: string;
+  created_at: number;
+  updated_at: number;
+};
+
+// ---- ヘルパー ----
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db as DB));
+  return app;
+}
+
+/**
+ * select().from().where() を n 回呼べるモックを作成する
+ * 各呼び出しに対して results[i] を返す
+ */
+function makeSelectMock(results: unknown[][]) {
+  let callIndex = 0;
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          const result = results[callIndex] ?? [];
+          callIndex++;
+          return Promise.resolve(result);
+        },
+      }),
+    }),
+  };
+}
+
+// ---- テストデータ ----
+
+const sampleSettings: MockSettings = {
+  id: 1,
+  project_id: 1,
+  model: "claude-opus-4-5",
+  temperature: 0.7,
+  api_provider: "anthropic",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+// ---- GET /api/projects/:projectId/settings テスト ----
+
+describe("GET /api/projects/:projectId/settings", () => {
+  it("設定が存在しない場合に 404 を返す", async () => {
+    const db = {
+      ...makeSelectMock([[]]),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Settings not found");
+  });
+
+  it("設定が存在する場合に 200 で設定を返す", async () => {
+    const db = {
+      ...makeSelectMock([[sampleSettings]]),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockSettings;
+    expect(body.project_id).toBe(1);
+    expect(body.model).toBe("claude-opus-4-5");
+    expect(body.temperature).toBe(0.7);
+    expect(body.api_provider).toBe("anthropic");
+  });
+
+  it("数値以外の projectId に対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/abc/settings");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid projectId");
+  });
+});
+
+// ---- PUT /api/projects/:projectId/settings テスト ----
+
+describe("PUT /api/projects/:projectId/settings", () => {
+  it("設定が存在しない場合に新規作成して 201 を返す", async () => {
+    const created: MockSettings = {
+      id: 1,
+      project_id: 1,
+      model: "gpt-4o",
+      temperature: 0.5,
+      api_provider: "openai",
+      created_at: 2000000,
+      updated_at: 2000000,
+    };
+
+    const db = {
+      // select で既存設定を確認 → 存在しない
+      ...makeSelectMock([[]]),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        temperature: 0.5,
+        api_provider: "openai",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockSettings;
+    expect(body.model).toBe("gpt-4o");
+    expect(body.temperature).toBe(0.5);
+    expect(body.api_provider).toBe("openai");
+    expect(body.project_id).toBe(1);
+  });
+
+  it("設定が存在する場合に更新して 200 を返す", async () => {
+    const updated: MockSettings = {
+      ...sampleSettings,
+      model: "claude-haiku-4-5",
+      temperature: 1.0,
+      updated_at: 3000000,
+    };
+
+    const db = {
+      // select で既存設定を確認 → 存在する
+      ...makeSelectMock([[sampleSettings]]),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5",
+        temperature: 1.0,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockSettings;
+    expect(body.model).toBe("claude-haiku-4-5");
+    expect(body.temperature).toBe(1.0);
+  });
+
+  it("temperature が 0 未満の場合は 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: -0.1,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("temperature が 2 を超える場合は 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 2.1,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("api_provider が不正な値の場合は 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 0.7,
+        api_provider: "google",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("model が空文字の場合は 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外の projectId に対して 400 を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/abc/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid projectId");
+  });
+
+  it("新規作成時に project_id・created_at・updated_at が設定される", async () => {
+    let capturedValues: Record<string, unknown> = {};
+
+    const created: MockSettings = {
+      id: 1,
+      project_id: 2,
+      model: "claude-opus-4-5",
+      temperature: 0.7,
+      api_provider: "anthropic",
+      created_at: 4000000,
+      updated_at: 4000000,
+    };
+
+    const db = {
+      ...makeSelectMock([[]]),
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    await app.request("/api/projects/2/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(capturedValues.project_id).toBe(2);
+    expect(typeof capturedValues.created_at).toBe("number");
+    expect(typeof capturedValues.updated_at).toBe("number");
+    expect(capturedValues.created_at).toBeGreaterThan(0);
+  });
+
+  it("更新時に updated_at が現在時刻で更新される", async () => {
+    let capturedUpdateData: Record<string, unknown> = {};
+
+    const updated: MockSettings = {
+      ...sampleSettings,
+      updated_at: 9999999,
+    };
+
+    const db = {
+      ...makeSelectMock([[sampleSettings]]),
+      update: () => ({
+        set: (data: Record<string, unknown>) => {
+          capturedUpdateData = data;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(typeof capturedUpdateData.updated_at).toBe("number");
+    expect(capturedUpdateData.updated_at).toBeGreaterThan(0);
+  });
+
+  it("temperature が境界値（0）の場合は正常に処理される", async () => {
+    const created: MockSettings = {
+      ...sampleSettings,
+      temperature: 0,
+    };
+
+    const db = {
+      ...makeSelectMock([[]]),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 0,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockSettings;
+    expect(body.temperature).toBe(0);
+  });
+
+  it("temperature が境界値（2）の場合は正常に処理される", async () => {
+    const created: MockSettings = {
+      ...sampleSettings,
+      temperature: 2,
+    };
+
+    const db = {
+      ...makeSelectMock([[]]),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-opus-4-5",
+        temperature: 2,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockSettings;
+    expect(body.temperature).toBe(2);
+  });
+});

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -89,27 +89,27 @@ export function createProjectSettingsRouter(db: DB) {
       }
 
       return c.json(updated);
+    } else {
+      // 新規作成
+      const insertResult = await db
+        .insert(project_settings)
+        .values({
+          project_id: projectId,
+          model: body.model,
+          temperature: body.temperature,
+          api_provider: body.api_provider,
+          created_at: now,
+          updated_at: now,
+        })
+        .returning();
+
+      const created = insertResult[0];
+      if (!created) {
+        return c.json({ error: "Failed to create Settings" }, 500);
+      }
+
+      return c.json(created, 201);
     }
-
-    // 新規作成
-    const insertResult = await db
-      .insert(project_settings)
-      .values({
-        project_id: projectId,
-        model: body.model,
-        temperature: body.temperature,
-        api_provider: body.api_provider,
-        created_at: now,
-        updated_at: now,
-      })
-      .returning();
-
-    const created = insertResult[0];
-    if (!created) {
-      return c.json({ error: "Failed to create Settings" }, 500);
-    }
-
-    return c.json(created, 201);
   });
 
   return router;

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -1,0 +1,116 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { project_settings } from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const upsertSettingsSchema = z.object({
+  model: z.string().min(1, "modelは1文字以上必要です"),
+  temperature: z
+    .number()
+    .min(0, "temperatureは0以上が必要です")
+    .max(2, "temperatureは2以下が必要です"),
+  api_provider: z.enum(["anthropic", "openai"], {
+    error: 'api_providerは "anthropic" または "openai" である必要があります',
+  }),
+});
+
+/** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
+function parseIntParam(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * ProjectSettings CRUD エンドポイントのルーター
+ *
+ * GET /api/projects/:projectId/settings  - 設定取得（存在しなければ404）
+ * PUT /api/projects/:projectId/settings  - 設定のupsert（存在しなければ作成、あれば更新）
+ */
+export function createProjectSettingsRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/projects/:projectId/settings - 設定取得
+  router.get("/", async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const [settings] = await db
+      .select()
+      .from(project_settings)
+      .where(eq(project_settings.project_id, projectId));
+
+    if (!settings) {
+      return c.json({ error: "Settings not found" }, 404);
+    }
+
+    return c.json(settings);
+  });
+
+  // PUT /api/projects/:projectId/settings - 設定のupsert
+  // 設定が存在しなければ作成、存在すれば更新する
+  router.put("/", zValidator("json", upsertSettingsSchema), async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    // 既存設定の確認
+    const [existing] = await db
+      .select()
+      .from(project_settings)
+      .where(eq(project_settings.project_id, projectId));
+
+    if (existing) {
+      // 更新
+      const updateResult = await db
+        .update(project_settings)
+        .set({
+          model: body.model,
+          temperature: body.temperature,
+          api_provider: body.api_provider,
+          updated_at: now,
+        })
+        .where(eq(project_settings.project_id, projectId))
+        .returning();
+
+      const updated = updateResult[0];
+      if (!updated) {
+        return c.json({ error: "Failed to update Settings" }, 500);
+      }
+
+      return c.json(updated);
+    }
+
+    // 新規作成
+    const insertResult = await db
+      .insert(project_settings)
+      .values({
+        project_id: projectId,
+        model: body.model,
+        temperature: body.temperature,
+        api_provider: body.api_provider,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    const created = insertResult[0];
+    if (!created) {
+      return c.json({ error: "Failed to create Settings" }, 500);
+    }
+
+    return c.json(created, 201);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## 概要

Issue #14 の対応。プロジェクトごとのLLM設定（model / temperature / api_provider）を管理するCRUDエンドポイントを実装。

## 変更内容

- `GET /api/projects/:projectId/settings` — 設定取得（未設定時は404）
- `PUT /api/projects/:projectId/settings` — 設定のupsert（未存在時は201作成、既存時は200更新）
- `packages/core/drizzle/0004_project_settings.sql` — project_settings テーブル作成マイグレーション
- `packages/core/drizzle/meta/0004_snapshot.json` — Drizzleスナップショット追加
- `packages/core/drizzle/meta/_journal.json` — ジャーナルにエントリ追加

## バリデーション

| フィールド | ルール |
|---|---|
| `model` | string、1文字以上 |
| `temperature` | number、0〜2の範囲 |
| `api_provider` | `"anthropic"` または `"openai"` のいずれか |

## テスト計画

- [x] GET: 設定が存在しない場合に404を返す
- [x] GET: 設定が存在する場合に200で設定を返す
- [x] GET: 数値以外のprojectIdに対して400を返す
- [x] PUT: 設定が存在しない場合に新規作成して201を返す
- [x] PUT: 設定が存在する場合に更新して200を返す
- [x] PUT: temperatureが0未満の場合は400を返す
- [x] PUT: temperatureが2を超える場合は400を返す
- [x] PUT: api_providerが不正な値の場合は400を返す
- [x] PUT: modelが空文字の場合は400を返す
- [x] PUT: 数値以外のprojectIdに対して400を返す
- [x] PUT: 新規作成時にproject_id・created_at・updated_atが設定される
- [x] PUT: 更新時にupdated_atが現在時刻で更新される
- [x] PUT: temperature境界値（0）が正常に処理される
- [x] PUT: temperature境界値（2）が正常に処理される

全14テスト、全177テスト（既存含む）パス確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)