### PR TITLE
feat(ui): テストケース一覧・作成・編集・削除画面の実装

### DIFF
--- a/packages/server/src/routes/test-cases.ts
+++ b/packages/server/src/routes/test-cases.ts
@@ -13,7 +13,7 @@ const turnSchema = z.object({
 
 const createTestCaseSchema = z.object({
   title: z.string().min(1, "タイトルは1文字以上必要です"),
-  turns: z.array(turnSchema).min(1, "turnsは1件以上必要です"),
+  turns: z.array(turnSchema).default([]),
   context_content: z.string().optional(),
   expected_description: z.string().optional(),
   display_order: z.number().int().optional(),
@@ -21,7 +21,7 @@ const createTestCaseSchema = z.object({
 
 const updateTestCaseSchema = z.object({
   title: z.string().min(1, "タイトルは1文字以上必要です").optional(),
-  turns: z.array(turnSchema).min(1, "turnsは1件以上必要です").optional(),
+  turns: z.array(turnSchema).optional(),
   context_content: z.string().optional(),
   expected_description: z.string().nullable().optional(),
   display_order: z.number().int().optional(),

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -127,7 +127,7 @@ export function createTestCase(
   projectId: number,
   data: {
     title: string;
-    turns: Turn[];
+    turns?: Turn[];
     context_content?: string;
     expected_description?: string;
     display_order?: number;

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -49,6 +49,13 @@ export const api = {
     });
   },
 
+  patch<T>(path: string, body: unknown): Promise<T> {
+    return fetchJson<T>(path, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  },
+
   delete<T>(path: string): Promise<T> {
     return fetchJson<T>(path, { method: "DELETE" });
   },
@@ -87,4 +94,62 @@ export function createProject(data: {
 
 export function deleteProject(id: number): Promise<void> {
   return api.delete<void>(`/projects/${id}`);
+}
+
+// TestCase API
+
+export type Turn = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export type TestCase = {
+  id: number;
+  project_id: number;
+  title: string;
+  turns: Turn[];
+  context_content: string;
+  expected_description: string | null;
+  display_order: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export function getTestCases(projectId: number): Promise<TestCase[]> {
+  return api.get<TestCase[]>(`/projects/${projectId}/test-cases`);
+}
+
+export function getTestCase(projectId: number, id: number): Promise<TestCase> {
+  return api.get<TestCase>(`/projects/${projectId}/test-cases/${id}`);
+}
+
+export function createTestCase(
+  projectId: number,
+  data: {
+    title: string;
+    turns: Turn[];
+    context_content?: string;
+    expected_description?: string;
+    display_order?: number;
+  },
+): Promise<TestCase> {
+  return api.post<TestCase>(`/projects/${projectId}/test-cases`, data);
+}
+
+export function updateTestCase(
+  projectId: number,
+  id: number,
+  data: {
+    title?: string;
+    turns?: Turn[];
+    context_content?: string;
+    expected_description?: string | null;
+    display_order?: number;
+  },
+): Promise<TestCase> {
+  return api.patch<TestCase>(`/projects/${projectId}/test-cases/${id}`, data);
+}
+
+export function deleteTestCase(projectId: number, id: number): Promise<void> {
+  return api.delete<void>(`/projects/${projectId}/test-cases/${id}`);
 }

--- a/packages/ui/src/pages/TestCasesPage.module.css
+++ b/packages/ui/src/pages/TestCasesPage.module.css
@@ -1,0 +1,483 @@
+/* ==================== Color tokens ==================== */
+.root {
+  --c-bg: #1e1e2e;
+  --c-card: #313244;
+  --c-border: #45475a;
+  --c-text: #cdd6f4;
+  --c-subtext: #a6adc8;
+  --c-accent: #cba6f7;
+  --c-danger: #f38ba8;
+  --c-overlay: #181825;
+  --c-muted: #6c7086;
+  --c-green: #a6e3a1;
+  --c-yellow: #f9e2af;
+}
+
+/* ==================== Page layout ==================== */
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.pageTitle {
+  margin: 0;
+  font-size: 20px;
+  color: var(--c-text);
+}
+
+.pageDescription {
+  color: var(--c-subtext);
+  margin: 0 0 24px;
+}
+
+.statusText {
+  text-align: center;
+  padding: 40px 0;
+}
+
+.loading {
+  color: var(--c-muted);
+}
+
+.error {
+  color: var(--c-danger);
+}
+
+.emptyState {
+  text-align: center;
+  padding: 60px 0;
+  color: var(--c-muted);
+}
+
+.emptyStateTitle {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.emptyStateSubtext {
+  margin: 0;
+  font-size: 14px;
+}
+
+.listContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ==================== Shared buttons ==================== */
+.btnPrimary {
+  padding: 8px 18px;
+  background: var(--c-accent);
+  border: none;
+  border-radius: 8px;
+  color: var(--c-overlay);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btnSecondary {
+  padding: 8px 20px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-subtext);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.btnDanger {
+  padding: 8px 20px;
+  background: var(--c-danger);
+  border: none;
+  border-radius: 8px;
+  color: var(--c-overlay);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btnDisabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* ==================== Modal ==================== */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  z-index: 100;
+  overflow-y: auto;
+  padding: 40px 0;
+}
+
+.modalOverlayCentered {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modalContent {
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 28px;
+  width: 600px;
+  max-width: 90vw;
+}
+
+.modalContentSm {
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 28px;
+  width: 420px;
+  max-width: 90vw;
+}
+
+.modalTitle {
+  margin: 0 0 20px;
+  font-size: 18px;
+  color: var(--c-text);
+}
+
+/* ==================== Form ==================== */
+.formActions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.fieldGroup {
+  margin-bottom: 16px;
+}
+
+.fieldGroupLg {
+  margin-bottom: 24px;
+}
+
+.fieldLabel {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 14px;
+  color: var(--c-subtext);
+}
+
+.requiredMark {
+  color: var(--c-danger);
+  margin-left: 4px;
+}
+
+.fieldInput {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-text);
+  font-size: 14px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.fieldTextarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-text);
+  font-size: 14px;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.fieldTextareaContext {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-text);
+  font-size: 13px;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: monospace;
+}
+
+/* ==================== Input mode toggle ==================== */
+.modeLabel {
+  font-size: 14px;
+  color: var(--c-subtext);
+  margin: 0 0 8px;
+}
+
+.modeToggle {
+  display: flex;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--c-border);
+}
+
+.btnModeBase {
+  flex: 1;
+  padding: 7px 0;
+  border: none;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btnModeRight {
+  border-left: 1px solid var(--c-border);
+}
+
+.btnModeActive {
+  background: var(--c-accent);
+  color: var(--c-overlay);
+  font-weight: 600;
+}
+
+.btnModeInactive {
+  background: transparent;
+  color: var(--c-subtext);
+  font-weight: 400;
+}
+
+.modeHint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+/* ==================== Turn editor ==================== */
+.turnItem {
+  margin-bottom: 12px;
+  padding: 12px;
+  background: var(--c-bg);
+  border-radius: 8px;
+  border: 1px solid var(--c-border);
+}
+
+.turnHeader {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.turnNumber {
+  font-size: 13px;
+  color: var(--c-muted);
+  min-width: 40px;
+}
+
+.turnSelect {
+  padding: 4px 8px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.turnSelectUser {
+  color: var(--c-accent);
+}
+
+.turnSelectAssistant {
+  color: var(--c-green);
+}
+
+.turnControls {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+
+.btnTurnBase {
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.btnTurnMove {
+  color: var(--c-subtext);
+  cursor: pointer;
+}
+
+.btnTurnMoveDisabled {
+  color: var(--c-muted);
+  cursor: not-allowed;
+}
+
+.btnTurnDelete {
+  color: var(--c-danger);
+  cursor: pointer;
+}
+
+.turnTextarea {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-text);
+  font-size: 13px;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.btnAddTurn {
+  padding: 6px 14px;
+  background: transparent;
+  border: 1px dashed var(--c-border);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  font-size: 13px;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 4px;
+}
+
+/* ==================== Test case card ==================== */
+.card {
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--c-text);
+  word-break: break-word;
+  line-height: 1.4;
+}
+
+.cardActions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.btnCardEdit {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-accent);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.btnCardDelete {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-danger);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.badgeRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  padding: 2px 8px;
+  background: var(--c-overlay);
+  border-radius: 4px;
+  font-size: 12px;
+  border: 1px solid var(--c-border);
+}
+
+.badgeTextMode {
+  color: var(--c-accent);
+}
+
+.badgeTurnCount {
+  color: var(--c-subtext);
+}
+
+.badgeUser {
+  color: var(--c-accent);
+}
+
+.badgeAssistant {
+  color: var(--c-green);
+}
+
+.badgeExpected {
+  color: var(--c-yellow);
+}
+
+.preview {
+  margin: 0;
+  font-size: 13px;
+  color: var(--c-muted);
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.previewMono {
+  font-family: monospace;
+}
+
+/* ==================== Delete dialog ==================== */
+.deleteDescription {
+  margin: 0 0 8px;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+.deleteName {
+  margin: 0 0 20px;
+  color: var(--c-text);
+  font-weight: 600;
+  font-size: 15px;
+  padding: 8px 12px;
+  background: var(--c-card);
+  border-radius: 6px;
+}
+
+.deleteWarning {
+  margin: 0 0 24px;
+  color: var(--c-danger);
+  font-size: 13px;
+}

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -52,7 +52,6 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
   }
 
   function handleRemoveTurn(index: number) {
-    if (turns.length <= 1) return;
     onChange(turns.filter((_, i) => i !== index));
   }
 
@@ -155,15 +154,14 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
               <button
                 type="button"
                 onClick={() => handleRemoveTurn(index)}
-                disabled={turns.length <= 1}
                 style={{
                   padding: "2px 8px",
                   background: "transparent",
                   border: `1px solid ${colors.border}`,
                   borderRadius: "4px",
-                  color: turns.length <= 1 ? colors.muted : colors.danger,
+                  color: colors.danger,
                   fontSize: "12px",
-                  cursor: turns.length <= 1 ? "not-allowed" : "pointer",
+                  cursor: "pointer",
                 }}
               >
                 削除
@@ -215,23 +213,32 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
 }
 
 // テストケースフォームの状態型
+type InputMode = "turns" | "context";
+
 type TestCaseFormData = {
   title: string;
+  inputMode: InputMode;
   turns: Turn[];
+  context_content: string;
   expected_description: string;
 };
 
 function getInitialFormData(testCase?: TestCase): TestCaseFormData {
   if (testCase) {
+    const inputMode: InputMode = testCase.turns.length === 0 ? "context" : "turns";
     return {
       title: testCase.title,
+      inputMode,
       turns: testCase.turns,
+      context_content: testCase.context_content ?? "",
       expected_description: testCase.expected_description ?? "",
     };
   }
   return {
     title: "",
+    inputMode: "turns",
     turns: [createEmptyTurn()],
+    context_content: "",
     expected_description: "",
   };
 }
@@ -254,13 +261,15 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
     e.preventDefault();
     const trimmedTitle = formData.title.trim();
     if (!trimmedTitle) return;
-    const validTurns = formData.turns.filter((t) => t.content.trim());
-    if (validTurns.length === 0) return;
-    onSubmit({ ...formData, title: trimmedTitle, turns: validTurns });
+    if (formData.inputMode === "turns") {
+      const validTurns = formData.turns.filter((t) => t.content.trim());
+      onSubmit({ ...formData, title: trimmedTitle, turns: validTurns, context_content: "" });
+    } else {
+      onSubmit({ ...formData, title: trimmedTitle, turns: [] });
+    }
   }
 
-  const isSubmittable =
-    formData.title.trim() !== "" && formData.turns.some((t) => t.content.trim() !== "");
+  const isSubmittable = formData.title.trim() !== "";
 
   return (
     <div
@@ -336,25 +345,113 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
             />
           </div>
 
-          {/* ターン */}
+          {/* 入力モード切替 */}
           <div style={{ marginBottom: "16px" }}>
             <p
               style={{
-                display: "block",
-                marginBottom: "8px",
                 fontSize: "14px",
                 color: colors.subtext,
                 margin: "0 0 8px",
               }}
             >
-              会話ターン
-              <span style={{ color: colors.danger, marginLeft: "4px" }}>*</span>
+              入力モード
             </p>
-            <TurnEditor
-              turns={formData.turns}
-              onChange={(turns) => setFormData((prev) => ({ ...prev, turns }))}
-            />
+            <div style={{ display: "flex", borderRadius: "8px", overflow: "hidden", border: `1px solid ${colors.border}` }}>
+              <button
+                type="button"
+                onClick={() => setFormData((prev) => ({ ...prev, inputMode: "turns" }))}
+                style={{
+                  flex: 1,
+                  padding: "7px 0",
+                  background: formData.inputMode === "turns" ? colors.accent : "transparent",
+                  border: "none",
+                  color: formData.inputMode === "turns" ? colors.overlay : colors.subtext,
+                  fontSize: "13px",
+                  fontWeight: formData.inputMode === "turns" ? 600 : 400,
+                  cursor: "pointer",
+                }}
+              >
+                ターン形式
+              </button>
+              <button
+                type="button"
+                onClick={() => setFormData((prev) => ({ ...prev, inputMode: "context" }))}
+                style={{
+                  flex: 1,
+                  padding: "7px 0",
+                  background: formData.inputMode === "context" ? colors.accent : "transparent",
+                  border: "none",
+                  borderLeft: `1px solid ${colors.border}`,
+                  color: formData.inputMode === "context" ? colors.overlay : colors.subtext,
+                  fontSize: "13px",
+                  fontWeight: formData.inputMode === "context" ? 600 : 400,
+                  cursor: "pointer",
+                }}
+              >
+                テキスト形式
+              </button>
+            </div>
+            <p style={{ margin: "6px 0 0", fontSize: "12px", color: colors.muted }}>
+              {formData.inputMode === "turns"
+                ? "会話をターンごとに分けて入力します（ターンは任意）。"
+                : "会話履歴をまとめてテキストとして入力します（context_content）。"}
+            </p>
           </div>
+
+          {/* 入力内容 */}
+          {formData.inputMode === "turns" ? (
+            <div style={{ marginBottom: "16px" }}>
+              <p
+                style={{
+                  fontSize: "14px",
+                  color: colors.subtext,
+                  margin: "0 0 8px",
+                }}
+              >
+                会話ターン（任意）
+              </p>
+              <TurnEditor
+                turns={formData.turns}
+                onChange={(turns) => setFormData((prev) => ({ ...prev, turns }))}
+              />
+            </div>
+          ) : (
+            <div style={{ marginBottom: "16px" }}>
+              <label
+                htmlFor="test-case-context"
+                style={{
+                  display: "block",
+                  marginBottom: "6px",
+                  fontSize: "14px",
+                  color: colors.subtext,
+                }}
+              >
+                コンテキスト（任意）
+              </label>
+              <textarea
+                id="test-case-context"
+                value={formData.context_content}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, context_content: e.target.value }))
+                }
+                placeholder="会話履歴や参照テキストをまとめて入力..."
+                rows={6}
+                style={{
+                  width: "100%",
+                  padding: "10px 12px",
+                  background: colors.card,
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: "8px",
+                  color: colors.text,
+                  fontSize: "13px",
+                  outline: "none",
+                  resize: "vertical",
+                  boxSizing: "border-box",
+                  fontFamily: "monospace",
+                }}
+              />
+            </div>
+          )}
 
           {/* 期待記述 */}
           <div style={{ marginBottom: "24px" }}>
@@ -546,6 +643,7 @@ type TestCaseCardProps = {
 };
 
 function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
+  const isContextMode = testCase.turns.length === 0;
   const userTurns = testCase.turns.filter((t) => t.role === "user").length;
   const assistantTurns = testCase.turns.filter((t) => t.role === "assistant").length;
 
@@ -617,19 +715,7 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
 
       {/* ターン情報バッジ */}
       <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
-        <span
-          style={{
-            padding: "2px 8px",
-            background: colors.overlay,
-            borderRadius: "4px",
-            fontSize: "12px",
-            color: colors.subtext,
-            border: `1px solid ${colors.border}`,
-          }}
-        >
-          計 {testCase.turns.length} ターン
-        </span>
-        {userTurns > 0 && (
+        {isContextMode ? (
           <span
             style={{
               padding: "2px 8px",
@@ -640,22 +726,51 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
               border: `1px solid ${colors.border}`,
             }}
           >
-            user × {userTurns}
+            テキスト形式
           </span>
-        )}
-        {assistantTurns > 0 && (
-          <span
-            style={{
-              padding: "2px 8px",
-              background: colors.overlay,
-              borderRadius: "4px",
-              fontSize: "12px",
-              color: colors.green,
-              border: `1px solid ${colors.border}`,
-            }}
-          >
-            assistant × {assistantTurns}
-          </span>
+        ) : (
+          <>
+            <span
+              style={{
+                padding: "2px 8px",
+                background: colors.overlay,
+                borderRadius: "4px",
+                fontSize: "12px",
+                color: colors.subtext,
+                border: `1px solid ${colors.border}`,
+              }}
+            >
+              計 {testCase.turns.length} ターン
+            </span>
+            {userTurns > 0 && (
+              <span
+                style={{
+                  padding: "2px 8px",
+                  background: colors.overlay,
+                  borderRadius: "4px",
+                  fontSize: "12px",
+                  color: colors.accent,
+                  border: `1px solid ${colors.border}`,
+                }}
+              >
+                user × {userTurns}
+              </span>
+            )}
+            {assistantTurns > 0 && (
+              <span
+                style={{
+                  padding: "2px 8px",
+                  background: colors.overlay,
+                  borderRadius: "4px",
+                  fontSize: "12px",
+                  color: colors.green,
+                  border: `1px solid ${colors.border}`,
+                }}
+              >
+                assistant × {assistantTurns}
+              </span>
+            )}
+          </>
         )}
         {testCase.expected_description && (
           <span
@@ -673,23 +788,41 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
         )}
       </div>
 
-      {/* 最初のターンのプレビュー */}
-      {testCase.turns[0] && (
-        <p
-          style={{
-            margin: 0,
-            fontSize: "13px",
-            color: colors.muted,
-            lineHeight: 1.5,
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-          }}
-        >
-          {testCase.turns[0].content}
-        </p>
-      )}
+      {/* プレビュー */}
+      {isContextMode
+        ? testCase.context_content && (
+            <p
+              style={{
+                margin: 0,
+                fontSize: "13px",
+                color: colors.muted,
+                lineHeight: 1.5,
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                fontFamily: "monospace",
+              }}
+            >
+              {testCase.context_content}
+            </p>
+          )
+        : testCase.turns[0] && (
+            <p
+              style={{
+                margin: 0,
+                fontSize: "13px",
+                color: colors.muted,
+                lineHeight: 1.5,
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              {testCase.turns[0].content}
+            </p>
+          )}
     </div>
   );
 }
@@ -720,6 +853,7 @@ export function TestCasesPage() {
       createTestCase(projectId, {
         title: data.title,
         turns: data.turns,
+        context_content: data.context_content || undefined,
         expected_description: data.expected_description || undefined,
       }),
     onSuccess: () => {
@@ -733,6 +867,7 @@ export function TestCasesPage() {
       updateTestCase(projectId, tcId, {
         title: data.title,
         turns: data.turns,
+        context_content: data.context_content,
         expected_description: data.expected_description || null,
       }),
     onSuccess: () => {

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -914,7 +914,7 @@ export function TestCasesPage() {
       </div>
 
       <p style={{ color: colors.subtext, marginBottom: "24px", margin: "0 0 24px" }}>
-        プロジェクトのテストケース一覧です。マルチターンの会話と期待記述を管理します。
+        プロジェクトのテストケース一覧です。参照情報と期待記述を管理します。
       </p>
 
       {isLoading && (

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -1,15 +1,856 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { useParams } from "react-router";
+import {
+  type TestCase,
+  type Turn,
+  createTestCase,
+  deleteTestCase,
+  getTestCases,
+  updateTestCase,
+} from "../lib/api";
 
-export function TestCasesPage() {
-  const { id } = useParams<{ id: string }>();
+const colors = {
+  bg: "#1e1e2e",
+  card: "#313244",
+  border: "#45475a",
+  text: "#cdd6f4",
+  subtext: "#a6adc8",
+  accent: "#cba6f7",
+  danger: "#f38ba8",
+  overlay: "#181825",
+  surface: "#45475a",
+  muted: "#6c7086",
+  green: "#a6e3a1",
+  yellow: "#f9e2af",
+};
+
+// ターン操作ユーティリティ
+function createEmptyTurn(): Turn {
+  return { role: "user", content: "" };
+}
+
+// ターン編集フォームコンポーネント
+type TurnEditorProps = {
+  turns: Turn[];
+  onChange: (turns: Turn[]) => void;
+};
+
+function TurnEditor({ turns, onChange }: TurnEditorProps) {
+  function handleRoleChange(index: number, role: "user" | "assistant") {
+    const updated = turns.map((t, i) => (i === index ? { ...t, role } : t));
+    onChange(updated);
+  }
+
+  function handleContentChange(index: number, content: string) {
+    const updated = turns.map((t, i) => (i === index ? { ...t, content } : t));
+    onChange(updated);
+  }
+
+  function handleAddTurn() {
+    onChange([...turns, createEmptyTurn()]);
+  }
+
+  function handleRemoveTurn(index: number) {
+    if (turns.length <= 1) return;
+    onChange(turns.filter((_, i) => i !== index));
+  }
+
+  function handleMoveUp(index: number) {
+    if (index === 0) return;
+    const updated = turns.map((t, i) => {
+      if (i === index - 1) return turns[index] ?? t;
+      if (i === index) return turns[index - 1] ?? t;
+      return t;
+    });
+    onChange(updated);
+  }
+
+  function handleMoveDown(index: number) {
+    if (index === turns.length - 1) return;
+    const updated = turns.map((t, i) => {
+      if (i === index) return turns[index + 1] ?? t;
+      if (i === index + 1) return turns[index] ?? t;
+      return t;
+    });
+    onChange(updated);
+  }
 
   return (
     <div>
-      <h2 style={{ margin: "0 0 16px", fontSize: "20px" }}>テストケース管理</h2>
-      <p style={{ color: "#a6adc8" }}>
-        プロジェクト <code style={{ color: "#cba6f7" }}>{id}</code> のテストケース一覧。
+      {turns.map((turn, index) => (
+        <div
+          key={`turn-${
+            // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
+            index
+          }`}
+          style={{
+            marginBottom: "12px",
+            padding: "12px",
+            background: colors.bg,
+            borderRadius: "8px",
+            border: `1px solid ${colors.border}`,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: "8px",
+              alignItems: "center",
+              marginBottom: "8px",
+            }}
+          >
+            <span style={{ fontSize: "13px", color: colors.muted, minWidth: "40px" }}>
+              #{index + 1}
+            </span>
+            <select
+              value={turn.role}
+              onChange={(e) => handleRoleChange(index, e.target.value as "user" | "assistant")}
+              style={{
+                padding: "4px 8px",
+                background: colors.card,
+                border: `1px solid ${colors.border}`,
+                borderRadius: "6px",
+                color: turn.role === "user" ? colors.accent : colors.green,
+                fontSize: "13px",
+                cursor: "pointer",
+              }}
+            >
+              <option value="user">user</option>
+              <option value="assistant">assistant</option>
+            </select>
+            <div style={{ marginLeft: "auto", display: "flex", gap: "4px" }}>
+              <button
+                type="button"
+                onClick={() => handleMoveUp(index)}
+                disabled={index === 0}
+                style={{
+                  padding: "2px 8px",
+                  background: "transparent",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: "4px",
+                  color: index === 0 ? colors.muted : colors.subtext,
+                  fontSize: "12px",
+                  cursor: index === 0 ? "not-allowed" : "pointer",
+                }}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={() => handleMoveDown(index)}
+                disabled={index === turns.length - 1}
+                style={{
+                  padding: "2px 8px",
+                  background: "transparent",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: "4px",
+                  color: index === turns.length - 1 ? colors.muted : colors.subtext,
+                  fontSize: "12px",
+                  cursor: index === turns.length - 1 ? "not-allowed" : "pointer",
+                }}
+              >
+                ↓
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRemoveTurn(index)}
+                disabled={turns.length <= 1}
+                style={{
+                  padding: "2px 8px",
+                  background: "transparent",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: "4px",
+                  color: turns.length <= 1 ? colors.muted : colors.danger,
+                  fontSize: "12px",
+                  cursor: turns.length <= 1 ? "not-allowed" : "pointer",
+                }}
+              >
+                削除
+              </button>
+            </div>
+          </div>
+          <textarea
+            value={turn.content}
+            onChange={(e) => handleContentChange(index, e.target.value)}
+            placeholder={
+              turn.role === "user" ? "ユーザーの入力を記述..." : "アシスタントの期待応答を記述..."
+            }
+            rows={3}
+            style={{
+              width: "100%",
+              padding: "8px 10px",
+              background: colors.card,
+              border: `1px solid ${colors.border}`,
+              borderRadius: "6px",
+              color: colors.text,
+              fontSize: "13px",
+              outline: "none",
+              resize: "vertical",
+              boxSizing: "border-box",
+              fontFamily: "inherit",
+            }}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAddTurn}
+        style={{
+          padding: "6px 14px",
+          background: "transparent",
+          border: `1px dashed ${colors.border}`,
+          borderRadius: "6px",
+          color: colors.subtext,
+          fontSize: "13px",
+          cursor: "pointer",
+          width: "100%",
+          marginTop: "4px",
+        }}
+      >
+        + ターンを追加
+      </button>
+    </div>
+  );
+}
+
+// テストケースフォームの状態型
+type TestCaseFormData = {
+  title: string;
+  turns: Turn[];
+  expected_description: string;
+};
+
+function getInitialFormData(testCase?: TestCase): TestCaseFormData {
+  if (testCase) {
+    return {
+      title: testCase.title,
+      turns: testCase.turns,
+      expected_description: testCase.expected_description ?? "",
+    };
+  }
+  return {
+    title: "",
+    turns: [createEmptyTurn()],
+    expected_description: "",
+  };
+}
+
+// 作成・編集モーダルコンポーネント
+type TestCaseModalProps = {
+  testCase?: TestCase;
+  onClose: () => void;
+  onSubmit: (data: TestCaseFormData) => void;
+  isLoading: boolean;
+};
+
+function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModalProps) {
+  const [formData, setFormData] = useState<TestCaseFormData>(() =>
+    getInitialFormData(testCase),
+  );
+  const isEdit = !!testCase;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmedTitle = formData.title.trim();
+    if (!trimmedTitle) return;
+    const validTurns = formData.turns.filter((t) => t.content.trim());
+    if (validTurns.length === 0) return;
+    onSubmit({ ...formData, title: trimmedTitle, turns: validTurns });
+  }
+
+  const isSubmittable =
+    formData.title.trim() !== "" && formData.turns.some((t) => t.content.trim() !== "");
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        zIndex: 100,
+        overflowY: "auto",
+        padding: "40px 0",
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div
+        style={{
+          background: colors.overlay,
+          border: `1px solid ${colors.border}`,
+          borderRadius: "12px",
+          padding: "28px",
+          width: "600px",
+          maxWidth: "90vw",
+        }}
+      >
+        <h3
+          style={{
+            margin: "0 0 20px",
+            fontSize: "18px",
+            color: colors.text,
+          }}
+        >
+          {isEdit ? "テストケースを編集" : "テストケースを作成"}
+        </h3>
+        <form onSubmit={handleSubmit}>
+          {/* タイトル */}
+          <div style={{ marginBottom: "16px" }}>
+            <label
+              htmlFor="test-case-title"
+              style={{
+                display: "block",
+                marginBottom: "6px",
+                fontSize: "14px",
+                color: colors.subtext,
+              }}
+            >
+              タイトル
+              <span style={{ color: colors.danger, marginLeft: "4px" }}>*</span>
+            </label>
+            <input
+              id="test-case-title"
+              type="text"
+              value={formData.title}
+              onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+              placeholder="例: 基本的な挨拶テスト"
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                background: colors.card,
+                border: `1px solid ${colors.border}`,
+                borderRadius: "8px",
+                color: colors.text,
+                fontSize: "14px",
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+
+          {/* ターン */}
+          <div style={{ marginBottom: "16px" }}>
+            <p
+              style={{
+                display: "block",
+                marginBottom: "8px",
+                fontSize: "14px",
+                color: colors.subtext,
+                margin: "0 0 8px",
+              }}
+            >
+              会話ターン
+              <span style={{ color: colors.danger, marginLeft: "4px" }}>*</span>
+            </p>
+            <TurnEditor
+              turns={formData.turns}
+              onChange={(turns) => setFormData((prev) => ({ ...prev, turns }))}
+            />
+          </div>
+
+          {/* 期待記述 */}
+          <div style={{ marginBottom: "24px" }}>
+            <label
+              htmlFor="test-case-expected"
+              style={{
+                display: "block",
+                marginBottom: "6px",
+                fontSize: "14px",
+                color: colors.subtext,
+              }}
+            >
+              期待記述（任意）
+            </label>
+            <textarea
+              id="test-case-expected"
+              value={formData.expected_description}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, expected_description: e.target.value }))
+              }
+              placeholder="期待するアシスタントの振る舞いを記述..."
+              rows={3}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                background: colors.card,
+                border: `1px solid ${colors.border}`,
+                borderRadius: "8px",
+                color: colors.text,
+                fontSize: "14px",
+                outline: "none",
+                resize: "vertical",
+                boxSizing: "border-box",
+                fontFamily: "inherit",
+              }}
+            />
+          </div>
+
+          <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: "8px 20px",
+                background: "transparent",
+                border: `1px solid ${colors.border}`,
+                borderRadius: "8px",
+                color: colors.subtext,
+                fontSize: "14px",
+                cursor: "pointer",
+              }}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={!isSubmittable || isLoading}
+              style={{
+                padding: "8px 20px",
+                background: colors.accent,
+                border: "none",
+                borderRadius: "8px",
+                color: colors.overlay,
+                fontSize: "14px",
+                fontWeight: 600,
+                cursor: !isSubmittable || isLoading ? "not-allowed" : "pointer",
+                opacity: !isSubmittable || isLoading ? 0.6 : 1,
+              }}
+            >
+              {isLoading ? (isEdit ? "保存中..." : "作成中...") : isEdit ? "保存" : "作成"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// 削除確認ダイアログ
+type DeleteDialogProps = {
+  testCase: TestCase;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+};
+
+function DeleteDialog({ testCase, onClose, onConfirm, isLoading }: DeleteDialogProps) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 100,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div
+        style={{
+          background: colors.overlay,
+          border: `1px solid ${colors.border}`,
+          borderRadius: "12px",
+          padding: "28px",
+          width: "420px",
+          maxWidth: "90vw",
+        }}
+      >
+        <h3
+          style={{
+            margin: "0 0 12px",
+            fontSize: "18px",
+            color: colors.text,
+          }}
+        >
+          テストケースを削除
+        </h3>
+        <p style={{ margin: "0 0 8px", color: colors.subtext, fontSize: "14px" }}>
+          以下のテストケースを削除してもよいですか？
+        </p>
+        <p
+          style={{
+            margin: "0 0 20px",
+            color: colors.text,
+            fontWeight: 600,
+            fontSize: "15px",
+            padding: "8px 12px",
+            background: colors.card,
+            borderRadius: "6px",
+          }}
+        >
+          {testCase.title}
+        </p>
+        <p style={{ margin: "0 0 24px", color: colors.danger, fontSize: "13px" }}>
+          この操作は取り消せません。
+        </p>
+        <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: "8px 20px",
+              background: "transparent",
+              border: `1px solid ${colors.border}`,
+              borderRadius: "8px",
+              color: colors.subtext,
+              fontSize: "14px",
+              cursor: "pointer",
+            }}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            style={{
+              padding: "8px 20px",
+              background: colors.danger,
+              border: "none",
+              borderRadius: "8px",
+              color: colors.overlay,
+              fontSize: "14px",
+              fontWeight: 600,
+              cursor: isLoading ? "not-allowed" : "pointer",
+              opacity: isLoading ? 0.6 : 1,
+            }}
+          >
+            {isLoading ? "削除中..." : "削除する"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// テストケースカードコンポーネント
+type TestCaseCardProps = {
+  testCase: TestCase;
+  onEdit: (testCase: TestCase) => void;
+  onDelete: (testCase: TestCase) => void;
+};
+
+function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
+  const userTurns = testCase.turns.filter((t) => t.role === "user").length;
+  const assistantTurns = testCase.turns.filter((t) => t.role === "assistant").length;
+
+  return (
+    <div
+      style={{
+        background: colors.card,
+        border: `1px solid ${colors.border}`,
+        borderRadius: "12px",
+        padding: "16px 20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "10px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          gap: "12px",
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontSize: "15px",
+            fontWeight: 600,
+            color: colors.text,
+            wordBreak: "break-word",
+            lineHeight: 1.4,
+          }}
+        >
+          {testCase.title}
+        </h3>
+        <div style={{ display: "flex", gap: "6px", flexShrink: 0 }}>
+          <button
+            type="button"
+            onClick={() => onEdit(testCase)}
+            style={{
+              padding: "4px 10px",
+              background: "transparent",
+              border: `1px solid ${colors.border}`,
+              borderRadius: "6px",
+              color: colors.accent,
+              fontSize: "12px",
+              cursor: "pointer",
+            }}
+          >
+            編集
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(testCase)}
+            style={{
+              padding: "4px 10px",
+              background: "transparent",
+              border: `1px solid ${colors.border}`,
+              borderRadius: "6px",
+              color: colors.danger,
+              fontSize: "12px",
+              cursor: "pointer",
+            }}
+          >
+            削除
+          </button>
+        </div>
+      </div>
+
+      {/* ターン情報バッジ */}
+      <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+        <span
+          style={{
+            padding: "2px 8px",
+            background: colors.overlay,
+            borderRadius: "4px",
+            fontSize: "12px",
+            color: colors.subtext,
+            border: `1px solid ${colors.border}`,
+          }}
+        >
+          計 {testCase.turns.length} ターン
+        </span>
+        {userTurns > 0 && (
+          <span
+            style={{
+              padding: "2px 8px",
+              background: colors.overlay,
+              borderRadius: "4px",
+              fontSize: "12px",
+              color: colors.accent,
+              border: `1px solid ${colors.border}`,
+            }}
+          >
+            user × {userTurns}
+          </span>
+        )}
+        {assistantTurns > 0 && (
+          <span
+            style={{
+              padding: "2px 8px",
+              background: colors.overlay,
+              borderRadius: "4px",
+              fontSize: "12px",
+              color: colors.green,
+              border: `1px solid ${colors.border}`,
+            }}
+          >
+            assistant × {assistantTurns}
+          </span>
+        )}
+        {testCase.expected_description && (
+          <span
+            style={{
+              padding: "2px 8px",
+              background: colors.overlay,
+              borderRadius: "4px",
+              fontSize: "12px",
+              color: colors.yellow,
+              border: `1px solid ${colors.border}`,
+            }}
+          >
+            期待記述あり
+          </span>
+        )}
+      </div>
+
+      {/* 最初のターンのプレビュー */}
+      {testCase.turns[0] && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: "13px",
+            color: colors.muted,
+            lineHeight: 1.5,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {testCase.turns[0].content}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// メインページコンポーネント
+export function TestCasesPage() {
+  const { id } = useParams<{ id: string }>();
+  const projectId = Number(id);
+  const queryClient = useQueryClient();
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<TestCase | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TestCase | null>(null);
+
+  const {
+    data: testCases,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["test-cases", projectId],
+    queryFn: () => getTestCases(projectId),
+    enabled: !Number.isNaN(projectId),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: TestCaseFormData) =>
+      createTestCase(projectId, {
+        title: data.title,
+        turns: data.turns,
+        expected_description: data.expected_description || undefined,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+      setIsCreateOpen(false);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id: tcId, data }: { id: number; data: TestCaseFormData }) =>
+      updateTestCase(projectId, tcId, {
+        title: data.title,
+        turns: data.turns,
+        expected_description: data.expected_description || null,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+      setEditTarget(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (tcId: number) => deleteTestCase(projectId, tcId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+      setDeleteTarget(null);
+    },
+  });
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "8px",
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: "20px", color: colors.text }}>テストケース管理</h2>
+        <button
+          type="button"
+          onClick={() => setIsCreateOpen(true)}
+          style={{
+            padding: "8px 18px",
+            background: colors.accent,
+            border: "none",
+            borderRadius: "8px",
+            color: colors.overlay,
+            fontSize: "14px",
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          + 新規作成
+        </button>
+      </div>
+
+      <p style={{ color: colors.subtext, marginBottom: "24px", margin: "0 0 24px" }}>
+        プロジェクトのテストケース一覧です。マルチターンの会話と期待記述を管理します。
       </p>
-      <p style={{ color: "#6c7086", marginTop: "24px" }}>（実装予定）</p>
+
+      {isLoading && (
+        <p style={{ color: colors.muted, textAlign: "center", padding: "40px 0" }}>読み込み中...</p>
+      )}
+
+      {isError && (
+        <p style={{ color: colors.danger, textAlign: "center", padding: "40px 0" }}>
+          エラーが発生しました: {error instanceof Error ? error.message : "不明なエラー"}
+        </p>
+      )}
+
+      {!isLoading && !isError && testCases && testCases.length === 0 && (
+        <div
+          style={{
+            textAlign: "center",
+            padding: "60px 0",
+            color: colors.muted,
+          }}
+        >
+          <p style={{ margin: "0 0 8px", fontSize: "16px" }}>テストケースがまだありません</p>
+          <p style={{ margin: 0, fontSize: "14px" }}>
+            「新規作成」ボタンから最初のテストケースを作成してください。
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && testCases && testCases.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+          }}
+        >
+          {testCases.map((tc) => (
+            <TestCaseCard
+              key={tc.id}
+              testCase={tc}
+              onEdit={setEditTarget}
+              onDelete={setDeleteTarget}
+            />
+          ))}
+        </div>
+      )}
+
+      {isCreateOpen && (
+        <TestCaseModal
+          onClose={() => setIsCreateOpen(false)}
+          onSubmit={(data) => createMutation.mutate(data)}
+          isLoading={createMutation.isPending}
+        />
+      )}
+
+      {editTarget && (
+        <TestCaseModal
+          testCase={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSubmit={(data) => updateMutation.mutate({ id: editTarget.id, data })}
+          isLoading={updateMutation.isPending}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteDialog
+          testCase={deleteTarget}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={() => deleteMutation.mutate(deleteTarget.id)}
+          isLoading={deleteMutation.isPending}
+        />
+      )}
     </div>
   );
 }

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -9,21 +9,7 @@ import {
   getTestCases,
   updateTestCase,
 } from "../lib/api";
-
-const colors = {
-  bg: "#1e1e2e",
-  card: "#313244",
-  border: "#45475a",
-  text: "#cdd6f4",
-  subtext: "#a6adc8",
-  accent: "#cba6f7",
-  danger: "#f38ba8",
-  overlay: "#181825",
-  surface: "#45475a",
-  muted: "#6c7086",
-  green: "#a6e3a1",
-  yellow: "#f9e2af",
-};
+import styles from "./TestCasesPage.module.css";
 
 // ターン操作ユーティリティ
 function createEmptyTurn(): Turn {
@@ -83,55 +69,24 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
             // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
             index
           }`}
-          style={{
-            marginBottom: "12px",
-            padding: "12px",
-            background: colors.bg,
-            borderRadius: "8px",
-            border: `1px solid ${colors.border}`,
-          }}
+          className={styles.turnItem}
         >
-          <div
-            style={{
-              display: "flex",
-              gap: "8px",
-              alignItems: "center",
-              marginBottom: "8px",
-            }}
-          >
-            <span style={{ fontSize: "13px", color: colors.muted, minWidth: "40px" }}>
-              #{index + 1}
-            </span>
+          <div className={styles.turnHeader}>
+            <span className={styles.turnNumber}>#{index + 1}</span>
             <select
               value={turn.role}
               onChange={(e) => handleRoleChange(index, e.target.value as "user" | "assistant")}
-              style={{
-                padding: "4px 8px",
-                background: colors.card,
-                border: `1px solid ${colors.border}`,
-                borderRadius: "6px",
-                color: turn.role === "user" ? colors.accent : colors.green,
-                fontSize: "13px",
-                cursor: "pointer",
-              }}
+              className={`${styles.turnSelect} ${turn.role === "user" ? styles.turnSelectUser : styles.turnSelectAssistant}`}
             >
               <option value="user">user</option>
               <option value="assistant">assistant</option>
             </select>
-            <div style={{ marginLeft: "auto", display: "flex", gap: "4px" }}>
+            <div className={styles.turnControls}>
               <button
                 type="button"
                 onClick={() => handleMoveUp(index)}
                 disabled={index === 0}
-                style={{
-                  padding: "2px 8px",
-                  background: "transparent",
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: "4px",
-                  color: index === 0 ? colors.muted : colors.subtext,
-                  fontSize: "12px",
-                  cursor: index === 0 ? "not-allowed" : "pointer",
-                }}
+                className={`${styles.btnTurnBase} ${index === 0 ? styles.btnTurnMoveDisabled : styles.btnTurnMove}`}
               >
                 ↑
               </button>
@@ -139,30 +94,14 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
                 type="button"
                 onClick={() => handleMoveDown(index)}
                 disabled={index === turns.length - 1}
-                style={{
-                  padding: "2px 8px",
-                  background: "transparent",
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: "4px",
-                  color: index === turns.length - 1 ? colors.muted : colors.subtext,
-                  fontSize: "12px",
-                  cursor: index === turns.length - 1 ? "not-allowed" : "pointer",
-                }}
+                className={`${styles.btnTurnBase} ${index === turns.length - 1 ? styles.btnTurnMoveDisabled : styles.btnTurnMove}`}
               >
                 ↓
               </button>
               <button
                 type="button"
                 onClick={() => handleRemoveTurn(index)}
-                style={{
-                  padding: "2px 8px",
-                  background: "transparent",
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: "4px",
-                  color: colors.danger,
-                  fontSize: "12px",
-                  cursor: "pointer",
-                }}
+                className={`${styles.btnTurnBase} ${styles.btnTurnDelete}`}
               >
                 削除
               </button>
@@ -175,37 +114,11 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
               turn.role === "user" ? "ユーザーの入力を記述..." : "アシスタントの期待応答を記述..."
             }
             rows={3}
-            style={{
-              width: "100%",
-              padding: "8px 10px",
-              background: colors.card,
-              border: `1px solid ${colors.border}`,
-              borderRadius: "6px",
-              color: colors.text,
-              fontSize: "13px",
-              outline: "none",
-              resize: "vertical",
-              boxSizing: "border-box",
-              fontFamily: "inherit",
-            }}
+            className={styles.turnTextarea}
           />
         </div>
       ))}
-      <button
-        type="button"
-        onClick={handleAddTurn}
-        style={{
-          padding: "6px 14px",
-          background: "transparent",
-          border: `1px dashed ${colors.border}`,
-          borderRadius: "6px",
-          color: colors.subtext,
-          fontSize: "13px",
-          cursor: "pointer",
-          width: "100%",
-          marginTop: "4px",
-        }}
-      >
+      <button type="button" onClick={handleAddTurn} className={styles.btnAddTurn}>
         + ターンを追加
       </button>
     </div>
@@ -273,17 +186,7 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
 
   return (
     <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.6)",
-        display: "flex",
-        alignItems: "flex-start",
-        justifyContent: "center",
-        zIndex: 100,
-        overflowY: "auto",
-        padding: "40px 0",
-      }}
+      className={styles.modalOverlay}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -291,39 +194,16 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
         if (e.key === "Escape") onClose();
       }}
     >
-      <div
-        style={{
-          background: colors.overlay,
-          border: `1px solid ${colors.border}`,
-          borderRadius: "12px",
-          padding: "28px",
-          width: "600px",
-          maxWidth: "90vw",
-        }}
-      >
-        <h3
-          style={{
-            margin: "0 0 20px",
-            fontSize: "18px",
-            color: colors.text,
-          }}
-        >
+      <div className={styles.modalContent}>
+        <h3 className={styles.modalTitle}>
           {isEdit ? "テストケースを編集" : "テストケースを作成"}
         </h3>
         <form onSubmit={handleSubmit}>
           {/* タイトル */}
-          <div style={{ marginBottom: "16px" }}>
-            <label
-              htmlFor="test-case-title"
-              style={{
-                display: "block",
-                marginBottom: "6px",
-                fontSize: "14px",
-                color: colors.subtext,
-              }}
-            >
+          <div className={styles.fieldGroup}>
+            <label htmlFor="test-case-title" className={styles.fieldLabel}>
               タイトル
-              <span style={{ color: colors.danger, marginLeft: "4px" }}>*</span>
+              <span className={styles.requiredMark}>*</span>
             </label>
             <input
               id="test-case-title"
@@ -331,67 +211,30 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
               value={formData.title}
               onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
               placeholder="例: 基本的な挨拶テスト"
-              style={{
-                width: "100%",
-                padding: "10px 12px",
-                background: colors.card,
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.text,
-                fontSize: "14px",
-                outline: "none",
-                boxSizing: "border-box",
-              }}
+              className={styles.fieldInput}
             />
           </div>
 
           {/* 入力モード切替 */}
-          <div style={{ marginBottom: "16px" }}>
-            <p
-              style={{
-                fontSize: "14px",
-                color: colors.subtext,
-                margin: "0 0 8px",
-              }}
-            >
-              入力モード
-            </p>
-            <div style={{ display: "flex", borderRadius: "8px", overflow: "hidden", border: `1px solid ${colors.border}` }}>
+          <div className={styles.fieldGroup}>
+            <p className={styles.modeLabel}>入力モード</p>
+            <div className={styles.modeToggle}>
               <button
                 type="button"
                 onClick={() => setFormData((prev) => ({ ...prev, inputMode: "turns" }))}
-                style={{
-                  flex: 1,
-                  padding: "7px 0",
-                  background: formData.inputMode === "turns" ? colors.accent : "transparent",
-                  border: "none",
-                  color: formData.inputMode === "turns" ? colors.overlay : colors.subtext,
-                  fontSize: "13px",
-                  fontWeight: formData.inputMode === "turns" ? 600 : 400,
-                  cursor: "pointer",
-                }}
+                className={`${styles.btnModeBase} ${formData.inputMode === "turns" ? styles.btnModeActive : styles.btnModeInactive}`}
               >
                 ターン形式
               </button>
               <button
                 type="button"
                 onClick={() => setFormData((prev) => ({ ...prev, inputMode: "context" }))}
-                style={{
-                  flex: 1,
-                  padding: "7px 0",
-                  background: formData.inputMode === "context" ? colors.accent : "transparent",
-                  border: "none",
-                  borderLeft: `1px solid ${colors.border}`,
-                  color: formData.inputMode === "context" ? colors.overlay : colors.subtext,
-                  fontSize: "13px",
-                  fontWeight: formData.inputMode === "context" ? 600 : 400,
-                  cursor: "pointer",
-                }}
+                className={`${styles.btnModeBase} ${styles.btnModeRight} ${formData.inputMode === "context" ? styles.btnModeActive : styles.btnModeInactive}`}
               >
                 テキスト形式
               </button>
             </div>
-            <p style={{ margin: "6px 0 0", fontSize: "12px", color: colors.muted }}>
+            <p className={styles.modeHint}>
               {formData.inputMode === "turns"
                 ? "会話をターンごとに分けて入力します（ターンは任意）。"
                 : "会話履歴をまとめてテキストとして入力します（context_content）。"}
@@ -400,32 +243,16 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
 
           {/* 入力内容 */}
           {formData.inputMode === "turns" ? (
-            <div style={{ marginBottom: "16px" }}>
-              <p
-                style={{
-                  fontSize: "14px",
-                  color: colors.subtext,
-                  margin: "0 0 8px",
-                }}
-              >
-                会話ターン（任意）
-              </p>
+            <div className={styles.fieldGroup}>
+              <p className={styles.fieldLabel}>会話ターン（任意）</p>
               <TurnEditor
                 turns={formData.turns}
                 onChange={(turns) => setFormData((prev) => ({ ...prev, turns }))}
               />
             </div>
           ) : (
-            <div style={{ marginBottom: "16px" }}>
-              <label
-                htmlFor="test-case-context"
-                style={{
-                  display: "block",
-                  marginBottom: "6px",
-                  fontSize: "14px",
-                  color: colors.subtext,
-                }}
-              >
+            <div className={styles.fieldGroup}>
+              <label htmlFor="test-case-context" className={styles.fieldLabel}>
                 コンテキスト（任意）
               </label>
               <textarea
@@ -436,34 +263,14 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
                 }
                 placeholder="会話履歴や参照テキストをまとめて入力..."
                 rows={6}
-                style={{
-                  width: "100%",
-                  padding: "10px 12px",
-                  background: colors.card,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: "8px",
-                  color: colors.text,
-                  fontSize: "13px",
-                  outline: "none",
-                  resize: "vertical",
-                  boxSizing: "border-box",
-                  fontFamily: "monospace",
-                }}
+                className={styles.fieldTextareaContext}
               />
             </div>
           )}
 
           {/* 期待記述 */}
-          <div style={{ marginBottom: "24px" }}>
-            <label
-              htmlFor="test-case-expected"
-              style={{
-                display: "block",
-                marginBottom: "6px",
-                fontSize: "14px",
-                color: colors.subtext,
-              }}
-            >
+          <div className={styles.fieldGroupLg}>
+            <label htmlFor="test-case-expected" className={styles.fieldLabel}>
               期待記述（任意）
             </label>
             <textarea
@@ -474,52 +281,18 @@ function TestCaseModal({ testCase, onClose, onSubmit, isLoading }: TestCaseModal
               }
               placeholder="期待するアシスタントの振る舞いを記述..."
               rows={3}
-              style={{
-                width: "100%",
-                padding: "10px 12px",
-                background: colors.card,
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.text,
-                fontSize: "14px",
-                outline: "none",
-                resize: "vertical",
-                boxSizing: "border-box",
-                fontFamily: "inherit",
-              }}
+              className={styles.fieldTextarea}
             />
           </div>
 
-          <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
-            <button
-              type="button"
-              onClick={onClose}
-              style={{
-                padding: "8px 20px",
-                background: "transparent",
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.subtext,
-                fontSize: "14px",
-                cursor: "pointer",
-              }}
-            >
+          <div className={styles.formActions}>
+            <button type="button" onClick={onClose} className={styles.btnSecondary}>
               キャンセル
             </button>
             <button
               type="submit"
               disabled={!isSubmittable || isLoading}
-              style={{
-                padding: "8px 20px",
-                background: colors.accent,
-                border: "none",
-                borderRadius: "8px",
-                color: colors.overlay,
-                fontSize: "14px",
-                fontWeight: 600,
-                cursor: !isSubmittable || isLoading ? "not-allowed" : "pointer",
-                opacity: !isSubmittable || isLoading ? 0.6 : 1,
-              }}
+              className={`${styles.btnPrimary} ${!isSubmittable || isLoading ? styles.btnDisabled : ""}`}
             >
               {isLoading ? (isEdit ? "保存中..." : "作成中...") : isEdit ? "保存" : "作成"}
             </button>
@@ -541,15 +314,7 @@ type DeleteDialogProps = {
 function DeleteDialog({ testCase, onClose, onConfirm, isLoading }: DeleteDialogProps) {
   return (
     <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.6)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 100,
-      }}
+      className={styles.modalOverlayCentered}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -557,75 +322,20 @@ function DeleteDialog({ testCase, onClose, onConfirm, isLoading }: DeleteDialogP
         if (e.key === "Escape") onClose();
       }}
     >
-      <div
-        style={{
-          background: colors.overlay,
-          border: `1px solid ${colors.border}`,
-          borderRadius: "12px",
-          padding: "28px",
-          width: "420px",
-          maxWidth: "90vw",
-        }}
-      >
-        <h3
-          style={{
-            margin: "0 0 12px",
-            fontSize: "18px",
-            color: colors.text,
-          }}
-        >
-          テストケースを削除
-        </h3>
-        <p style={{ margin: "0 0 8px", color: colors.subtext, fontSize: "14px" }}>
-          以下のテストケースを削除してもよいですか？
-        </p>
-        <p
-          style={{
-            margin: "0 0 20px",
-            color: colors.text,
-            fontWeight: 600,
-            fontSize: "15px",
-            padding: "8px 12px",
-            background: colors.card,
-            borderRadius: "6px",
-          }}
-        >
-          {testCase.title}
-        </p>
-        <p style={{ margin: "0 0 24px", color: colors.danger, fontSize: "13px" }}>
-          この操作は取り消せません。
-        </p>
-        <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
-          <button
-            type="button"
-            onClick={onClose}
-            style={{
-              padding: "8px 20px",
-              background: "transparent",
-              border: `1px solid ${colors.border}`,
-              borderRadius: "8px",
-              color: colors.subtext,
-              fontSize: "14px",
-              cursor: "pointer",
-            }}
-          >
+      <div className={styles.modalContentSm}>
+        <h3 className={styles.modalTitle}>テストケースを削除</h3>
+        <p className={styles.deleteDescription}>以下のテストケースを削除してもよいですか？</p>
+        <p className={styles.deleteName}>{testCase.title}</p>
+        <p className={styles.deleteWarning}>この操作は取り消せません。</p>
+        <div className={styles.formActions}>
+          <button type="button" onClick={onClose} className={styles.btnSecondary}>
             キャンセル
           </button>
           <button
             type="button"
             onClick={onConfirm}
             disabled={isLoading}
-            style={{
-              padding: "8px 20px",
-              background: colors.danger,
-              border: "none",
-              borderRadius: "8px",
-              color: colors.overlay,
-              fontSize: "14px",
-              fontWeight: 600,
-              cursor: isLoading ? "not-allowed" : "pointer",
-              opacity: isLoading ? 0.6 : 1,
-            }}
+            className={`${styles.btnDanger} ${isLoading ? styles.btnDisabled : ""}`}
           >
             {isLoading ? "削除中..." : "削除する"}
           </button>
@@ -648,65 +358,21 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
   const assistantTurns = testCase.turns.filter((t) => t.role === "assistant").length;
 
   return (
-    <div
-      style={{
-        background: colors.card,
-        border: `1px solid ${colors.border}`,
-        borderRadius: "12px",
-        padding: "16px 20px",
-        display: "flex",
-        flexDirection: "column",
-        gap: "10px",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "flex-start",
-          gap: "12px",
-        }}
-      >
-        <h3
-          style={{
-            margin: 0,
-            fontSize: "15px",
-            fontWeight: 600,
-            color: colors.text,
-            wordBreak: "break-word",
-            lineHeight: 1.4,
-          }}
-        >
-          {testCase.title}
-        </h3>
-        <div style={{ display: "flex", gap: "6px", flexShrink: 0 }}>
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <h3 className={styles.cardTitle}>{testCase.title}</h3>
+        <div className={styles.cardActions}>
           <button
             type="button"
             onClick={() => onEdit(testCase)}
-            style={{
-              padding: "4px 10px",
-              background: "transparent",
-              border: `1px solid ${colors.border}`,
-              borderRadius: "6px",
-              color: colors.accent,
-              fontSize: "12px",
-              cursor: "pointer",
-            }}
+            className={styles.btnCardEdit}
           >
             編集
           </button>
           <button
             type="button"
             onClick={() => onDelete(testCase)}
-            style={{
-              padding: "4px 10px",
-              background: "transparent",
-              border: `1px solid ${colors.border}`,
-              borderRadius: "6px",
-              color: colors.danger,
-              fontSize: "12px",
-              cursor: "pointer",
-            }}
+            className={styles.btnCardDelete}
           >
             削除
           </button>
@@ -714,114 +380,38 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
       </div>
 
       {/* ターン情報バッジ */}
-      <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+      <div className={styles.badgeRow}>
         {isContextMode ? (
-          <span
-            style={{
-              padding: "2px 8px",
-              background: colors.overlay,
-              borderRadius: "4px",
-              fontSize: "12px",
-              color: colors.accent,
-              border: `1px solid ${colors.border}`,
-            }}
-          >
-            テキスト形式
-          </span>
+          <span className={`${styles.badge} ${styles.badgeTextMode}`}>テキスト形式</span>
         ) : (
           <>
-            <span
-              style={{
-                padding: "2px 8px",
-                background: colors.overlay,
-                borderRadius: "4px",
-                fontSize: "12px",
-                color: colors.subtext,
-                border: `1px solid ${colors.border}`,
-              }}
-            >
+            <span className={`${styles.badge} ${styles.badgeTurnCount}`}>
               計 {testCase.turns.length} ターン
             </span>
             {userTurns > 0 && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  background: colors.overlay,
-                  borderRadius: "4px",
-                  fontSize: "12px",
-                  color: colors.accent,
-                  border: `1px solid ${colors.border}`,
-                }}
-              >
-                user × {userTurns}
-              </span>
+              <span className={`${styles.badge} ${styles.badgeUser}`}>user × {userTurns}</span>
             )}
             {assistantTurns > 0 && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  background: colors.overlay,
-                  borderRadius: "4px",
-                  fontSize: "12px",
-                  color: colors.green,
-                  border: `1px solid ${colors.border}`,
-                }}
-              >
+              <span className={`${styles.badge} ${styles.badgeAssistant}`}>
                 assistant × {assistantTurns}
               </span>
             )}
           </>
         )}
         {testCase.expected_description && (
-          <span
-            style={{
-              padding: "2px 8px",
-              background: colors.overlay,
-              borderRadius: "4px",
-              fontSize: "12px",
-              color: colors.yellow,
-              border: `1px solid ${colors.border}`,
-            }}
-          >
-            期待記述あり
-          </span>
+          <span className={`${styles.badge} ${styles.badgeExpected}`}>期待記述あり</span>
         )}
       </div>
 
       {/* プレビュー */}
       {isContextMode
         ? testCase.context_content && (
-            <p
-              style={{
-                margin: 0,
-                fontSize: "13px",
-                color: colors.muted,
-                lineHeight: 1.5,
-                overflow: "hidden",
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-                fontFamily: "monospace",
-              }}
-            >
+            <p className={`${styles.preview} ${styles.previewMono}`}>
               {testCase.context_content}
             </p>
           )
         : testCase.turns[0] && (
-            <p
-              style={{
-                margin: 0,
-                fontSize: "13px",
-                color: colors.muted,
-                lineHeight: 1.5,
-                overflow: "hidden",
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-              }}
-            >
-              {testCase.turns[0].content}
-            </p>
+            <p className={styles.preview}>{testCase.turns[0].content}</p>
           )}
     </div>
   );
@@ -885,71 +475,43 @@ export function TestCasesPage() {
   });
 
   return (
-    <div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: "8px",
-        }}
-      >
-        <h2 style={{ margin: 0, fontSize: "20px", color: colors.text }}>テストケース管理</h2>
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <h2 className={styles.pageTitle}>テストケース管理</h2>
         <button
           type="button"
           onClick={() => setIsCreateOpen(true)}
-          style={{
-            padding: "8px 18px",
-            background: colors.accent,
-            border: "none",
-            borderRadius: "8px",
-            color: colors.overlay,
-            fontSize: "14px",
-            fontWeight: 600,
-            cursor: "pointer",
-          }}
+          className={styles.btnPrimary}
         >
           + 新規作成
         </button>
       </div>
 
-      <p style={{ color: colors.subtext, marginBottom: "24px", margin: "0 0 24px" }}>
+      <p className={styles.pageDescription}>
         プロジェクトのテストケース一覧です。参照情報と期待記述を管理します。
       </p>
 
       {isLoading && (
-        <p style={{ color: colors.muted, textAlign: "center", padding: "40px 0" }}>読み込み中...</p>
+        <p className={`${styles.statusText} ${styles.loading}`}>読み込み中...</p>
       )}
 
       {isError && (
-        <p style={{ color: colors.danger, textAlign: "center", padding: "40px 0" }}>
+        <p className={`${styles.statusText} ${styles.error}`}>
           エラーが発生しました: {error instanceof Error ? error.message : "不明なエラー"}
         </p>
       )}
 
       {!isLoading && !isError && testCases && testCases.length === 0 && (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "60px 0",
-            color: colors.muted,
-          }}
-        >
-          <p style={{ margin: "0 0 8px", fontSize: "16px" }}>テストケースがまだありません</p>
-          <p style={{ margin: 0, fontSize: "14px" }}>
+        <div className={styles.emptyState}>
+          <p className={styles.emptyStateTitle}>テストケースがまだありません</p>
+          <p className={styles.emptyStateSubtext}>
             「新規作成」ボタンから最初のテストケースを作成してください。
           </p>
         </div>
       )}
 
       {!isLoading && !isError && testCases && testCases.length > 0 && (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "12px",
-          }}
-        >
+        <div className={styles.listContainer}>
           {testCases.map((tc) => (
             <TestCaseCard
               key={tc.id}

--- a/packages/ui/src/vite-env.d.ts
+++ b/packages/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## 概要

Issue #17 に対応するテストケース管理UIを実装しました。

## 変更内容

### `packages/ui/src/lib/api.ts`
- `Turn`・`TestCase` 型を追加
- `api.patch()` メソッドを追加
- テストケース用API関数を追加:
  - `getTestCases(projectId)` - 一覧取得
  - `getTestCase(projectId, id)` - 単件取得
  - `createTestCase(projectId, data)` - 作成
  - `updateTestCase(projectId, id, data)` - 更新
  - `deleteTestCase(projectId, id)` - 削除

### `packages/ui/src/pages/TestCasesPage.tsx`
- **一覧表示**: タイトル・ターン数バッジ（user/assistantの内訳）・期待記述の有無・最初のターンのプレビューを表示
- **作成・編集モーダル**: タイトル入力 + マルチターンエディタ + 期待記述（任意）
- **TurnEditor コンポーネント**: ターンの追加・削除・上下並び替え・role切り替え（user/assistant）・content入力
- **削除確認ダイアログ**: 確認後に削除実行

## 完了条件の確認

- [x] マルチターンのターンを追加・削除・編集できる
- [x] 作成・編集した内容が保存・反映される

## テスト計画

- [ ] テストケース一覧が `display_order` 順に表示される
- [ ] 「新規作成」ボタンからモーダルが開き、タイトル・ターン・期待記述を入力して保存できる
- [ ] ターンの追加（ユーザー・アシスタント）ができる
- [ ] ターンの削除ができる（最後の1件は削除不可）
- [ ] ターンの上下並び替えができる
- [ ] 「編集」ボタンから既存内容を編集して保存できる
- [ ] 「削除」ボタンから確認ダイアログを経て削除できる
- [ ] 空のプロジェクトで空状態メッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)