### PR TITLE
fix(ui): プロジェクト一覧の作成日が58251年と表示されるバグを修正

### DIFF
--- a/packages/ui/src/pages/ProjectsPage.tsx
+++ b/packages/ui/src/pages/ProjectsPage.tsx
@@ -17,7 +17,7 @@ const colors = {
 };
 
 function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("ja-JP", {
+  return new Date(timestamp).toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
## 概要

プロジェクト一覧で作成日が「58251年5月28日」のように表示されるバグを修正しました。

## 原因

- バックエンド（`packages/server/src/routes/projects.ts`）は `Date.now()` でミリ秒のタイムスタンプを保存
- フロントエンド（`packages/ui/src/pages/ProjectsPage.tsx`）の `formatDate` 関数が `timestamp * 1000` でさらに1000倍していた

```ts
// 修正前（誤り）: ミリ秒値をさらに1000倍してしまう
new Date(timestamp * 1000)

// 修正後（正しい）: ミリ秒値をそのまま渡す
new Date(timestamp)
```

## 修正箇所

- `packages/ui/src/pages/ProjectsPage.tsx`: `formatDate` 関数の `timestamp * 1000` を `timestamp` に変更

## テスト計画

- [x] `pnpm run typecheck` - 型エラーなし
- [x] `pnpm run test` - 163件すべてのテストがパス
- [ ] 動作確認: プロジェクトを新規作成して作成日が正しく表示されること（2026年の日付が表示される）

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)