### PR TITLE
feat(ui): Run一覧・フィルタリング・会話展開・ベスト回答管理UIを実装

### DIFF
--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -1,3 +1,8 @@
+/* ==================== Color tokens ==================== */
+.root {
+  --c-bg: var(--c-bg, #1e1e2e);
+}
+
 /* ==================== Page layout ==================== */
 .page {
   color: var(--c-text);
@@ -319,8 +324,8 @@
   border-radius: 6px;
   border: 1px solid var(--c-border);
   display: flex;
-  gap: 12px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 0;
 }
 
 .runCardBest {
@@ -337,6 +342,7 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 6px;
+  flex-wrap: wrap;
 }
 
 .runId {
@@ -395,6 +401,118 @@
 }
 
 .emptyRuns {
+  color: var(--c-muted);
+  font-size: 14px;
+}
+
+/* ==================== Tab navigation ==================== */
+.tabBar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--c-border);
+  padding-bottom: 0;
+}
+
+.tabBtn {
+  padding: 8px 20px;
+  background: transparent;
+  color: var(--c-subtext);
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tabBtnActive {
+  color: var(--c-accent);
+  border-bottom-color: var(--c-accent);
+}
+
+/* ==================== Run list: filter bar ==================== */
+.filterBar {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 180px;
+}
+
+.filterLabel {
+  font-size: 12px;
+  color: var(--c-subtext);
+  font-weight: 600;
+}
+
+.filterSelect {
+  padding: 7px 10px;
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-text);
+  font-size: 13px;
+}
+
+.btnClearFilter {
+  padding: 7px 14px;
+  background: transparent;
+  color: var(--c-muted);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  align-self: flex-end;
+}
+
+/* ==================== Run card (accordion) ==================== */
+.runCardTop {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.runCardActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.runMeta {
+  font-size: 12px;
+  color: var(--c-subtext);
+  flex: 1;
+}
+
+.btnToggle {
+  padding: 4px 10px;
+  background: transparent;
+  color: var(--c-blue);
+  border: 1px solid var(--c-blue);
+  border-radius: 5px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.runConversation {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--c-border);
+}
+
+/* ==================== Loading ==================== */
+.loadingMsg {
   color: var(--c-muted);
   font-size: 14px;
 }

--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -511,6 +511,61 @@
   border-top: 1px solid var(--c-border);
 }
 
+/* ==================== Copy prompt panel ==================== */
+.copyPromptPanel {
+  margin-bottom: 16px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.copyPromptHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+}
+
+.btnCopyPromptToggle {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--c-blue);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.btnCopy {
+  padding: 5px 14px;
+  background: var(--c-accent);
+  color: var(--c-overlay);
+  border: none;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.copyPromptTextarea {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  background: var(--c-overlay);
+  border: none;
+  border-top: 1px solid var(--c-border);
+  color: var(--c-text);
+  font-size: 13px;
+  font-family: monospace;
+  line-height: 1.5;
+  resize: vertical;
+}
+
 /* ==================== Loading ==================== */
 .loadingMsg {
   color: var(--c-muted);

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -3,7 +3,9 @@ import { useState } from "react";
 import { useParams } from "react-router";
 import {
   type ConversationMessage,
+  type PromptVersion,
   type Run,
+  type TestCase,
   createRun,
   getProject,
   getPromptVersions,
@@ -12,6 +14,67 @@ import {
   setBestRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
+
+function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
+  const systemPrompt = testCase.context_content
+    ? version.content.includes("{{context}}")
+      ? version.content.replace("{{context}}", testCase.context_content)
+      : `${version.content}\n\n${testCase.context_content}`
+    : version.content;
+
+  const turnsText = testCase.turns
+    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
+    .join("\n\n");
+
+  return turnsText
+    ? `[System Prompt]\n${systemPrompt}\n\n[Conversation]\n${turnsText}`
+    : `[System Prompt]\n${systemPrompt}`;
+}
+
+function CopyPromptPanel({
+  version,
+  testCase,
+}: {
+  version: PromptVersion;
+  testCase: TestCase;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const fullPrompt = buildFullPrompt(version, testCase);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(fullPrompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className={styles.copyPromptPanel}>
+      <div className={styles.copyPromptHeader}>
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className={styles.btnCopyPromptToggle}
+          aria-expanded={open}
+        >
+          {open ? "▲ プロンプト全文を閉じる" : "▼ プロンプト全文を表示"}
+        </button>
+        <button type="button" onClick={handleCopy} className={styles.btnCopy}>
+          {copied ? "✓ コピー済み" : "コピー"}
+        </button>
+      </div>
+      {open && (
+        <textarea
+          readOnly
+          value={fullPrompt}
+          className={styles.copyPromptTextarea}
+          rows={12}
+        />
+      )}
+    </div>
+  );
+}
 
 function formatDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString("ja-JP", {
@@ -362,6 +425,8 @@ export function RunsPage() {
                   {selectedTestCase.title}
                 </span>
               </div>
+
+              <CopyPromptPanel version={selectedVersion} testCase={selectedTestCase} />
 
               <div className={styles.twoColumns}>
                 {/* 左カラム: テストケース表示 */}

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -27,8 +27,8 @@ function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
     .join("\n\n");
 
   return turnsText
-    ? `[System Prompt]\n${systemPrompt}\n\n[Conversation]\n${turnsText}`
-    : `[System Prompt]\n${systemPrompt}`;
+    ? `${systemPrompt}\n\n[Conversation]\n${turnsText}`
+    : systemPrompt;
 }
 
 function CopyPromptPanel({

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -24,17 +24,106 @@ function formatDate(timestamp: number): string {
 }
 
 type Step = "select" | "input" | "saved";
+type PageTab = "create" | "list";
+
+// アコーディオン形式の会話表示コンポーネント
+function RunConversation({ conversation }: { conversation: ConversationMessage[] }) {
+  return (
+    <div className={styles.chatList}>
+      {conversation.map((msg, index) => (
+        <div
+          key={`msg-${
+            // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理するため index をキーとして使用
+            index
+          }`}
+          className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
+        >
+          <span className={styles.bubbleRole}>{msg.role === "user" ? "User" : "Assistant"}</span>
+          <div
+            className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+          >
+            {msg.content}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Run一覧カードコンポーネント
+function RunCard({
+  run,
+  versionLabel,
+  testCaseLabel,
+  onSetBest,
+  isBestPending,
+}: {
+  run: Run;
+  versionLabel: string;
+  testCaseLabel: string;
+  onSetBest: () => void;
+  isBestPending: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className={`${styles.runCard} ${run.is_best ? styles.runCardBest : ""}`}>
+      <div className={styles.runCardTop}>
+        <div className={styles.runCardHeader}>
+          <span className={styles.runId}>Run #{run.id}</span>
+          {run.is_best && <span className={styles.badgeBest}>ベスト回答</span>}
+          <span className={styles.runMeta}>
+            {versionLabel} &times; {testCaseLabel}
+          </span>
+          <span className={styles.runDate}>{formatDate(run.created_at)}</span>
+        </div>
+
+        <div className={styles.runCardActions}>
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className={styles.btnToggle}
+            aria-expanded={expanded}
+          >
+            {expanded ? "▲ 折りたたむ" : "▼ 会話を表示"}
+          </button>
+          <button
+            type="button"
+            onClick={onSetBest}
+            disabled={isBestPending || run.is_best}
+            className={`${styles.btnBest} ${run.is_best ? styles.btnBestActive : styles.btnBestInactive}`}
+          >
+            {run.is_best ? "ベスト済み" : "ベストに設定"}
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className={styles.runConversation}>
+          <RunConversation conversation={run.conversation} />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function RunsPage() {
   const { id } = useParams<{ id: string }>();
   const projectId = Number(id);
   const queryClient = useQueryClient();
 
+  const [activeTab, setActiveTab] = useState<PageTab>("create");
+
+  // 「Run 作成」タブの状態
   const [step, setStep] = useState<Step>("select");
   const [selectedVersionId, setSelectedVersionId] = useState<number | "">("");
   const [selectedTestCaseId, setSelectedTestCaseId] = useState<number | "">("");
   const [llmResponse, setLlmResponse] = useState("");
   const [savedRun, setSavedRun] = useState<Run | null>(null);
+
+  // 「Run 一覧」タブのフィルター状態
+  const [filterVersionId, setFilterVersionId] = useState<number | "">("");
+  const [filterTestCaseId, setFilterTestCaseId] = useState<number | "">("");
 
   const { data: project } = useQuery({
     queryKey: ["projects", projectId],
@@ -54,7 +143,8 @@ export function RunsPage() {
     enabled: !Number.isNaN(projectId),
   });
 
-  const { data: existingRuns = [] } = useQuery({
+  // Run 作成タブ: savedステップ時に同一バージョン×ケースのRunを取得
+  const { data: relatedRuns = [] } = useQuery({
     queryKey: [
       "runs",
       projectId,
@@ -66,6 +156,21 @@ export function RunsPage() {
         test_case_id: selectedTestCaseId !== "" ? selectedTestCaseId : undefined,
       }),
     enabled: step === "saved" && selectedVersionId !== "" && selectedTestCaseId !== "",
+  });
+
+  // Run 一覧タブ: フィルター付きで全Runを取得
+  const { data: allRuns = [], isLoading: isRunsLoading } = useQuery({
+    queryKey: [
+      "runs",
+      projectId,
+      { prompt_version_id: filterVersionId, test_case_id: filterTestCaseId },
+    ],
+    queryFn: () =>
+      getRuns(projectId, {
+        prompt_version_id: filterVersionId !== "" ? filterVersionId : undefined,
+        test_case_id: filterTestCaseId !== "" ? filterTestCaseId : undefined,
+      }),
+    enabled: activeTab === "list" && !Number.isNaN(projectId),
   });
 
   const createRunMutation = useMutation({
@@ -99,6 +204,17 @@ export function RunsPage() {
   const selectedTestCase =
     selectedTestCaseId !== "" ? testCases.find((tc) => tc.id === selectedTestCaseId) : undefined;
 
+  function getVersionLabel(versionId: number): string {
+    const v = promptVersions.find((pv) => pv.id === versionId);
+    if (!v) return "v?";
+    return `v${v.version}${v.name ? ` - ${v.name}` : ""}`;
+  }
+
+  function getTestCaseLabel(testCaseId: number): string {
+    const tc = testCases.find((t) => t.id === testCaseId);
+    return tc?.title ?? "不明";
+  }
+
   function handleStartRun() {
     if (selectedVersionId === "" || selectedTestCaseId === "") return;
     setLlmResponse("");
@@ -126,11 +242,6 @@ export function RunsPage() {
     setStep("select");
   }
 
-  function getLastAssistantMessage(conversation: ConversationMessage[]): string {
-    const assistantMessages = conversation.filter((m) => m.role === "assistant");
-    return assistantMessages[assistantMessages.length - 1]?.content ?? "";
-  }
-
   const isStartDisabled = selectedVersionId === "" || selectedTestCaseId === "";
   const isSaveDisabled = !llmResponse.trim() || createRunMutation.isPending;
 
@@ -144,256 +255,340 @@ export function RunsPage() {
         </div>
       </div>
 
-      {/* Step 1: 選択フォーム */}
-      {step === "select" && (
-        <div className={styles.selectCard}>
-          <h3 className={styles.selectCardTitle}>Run を開始する</h3>
+      {/* タブ */}
+      <div className={styles.tabBar}>
+        <button
+          type="button"
+          onClick={() => setActiveTab("create")}
+          className={`${styles.tabBtn} ${activeTab === "create" ? styles.tabBtnActive : ""}`}
+        >
+          Run を作成
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("list")}
+          className={`${styles.tabBtn} ${activeTab === "list" ? styles.tabBtnActive : ""}`}
+        >
+          Run 一覧
+        </button>
+      </div>
 
-          <div className={styles.fieldGroup}>
-            <label htmlFor="select-version" className={styles.fieldLabel}>
-              プロンプトバージョン
-            </label>
-            <select
-              id="select-version"
-              value={selectedVersionId}
-              onChange={(e) =>
-                setSelectedVersionId(e.target.value === "" ? "" : Number(e.target.value))
-              }
-              className={styles.fieldSelect}
-            >
-              <option value="">-- 選択してください --</option>
-              {promptVersions.map((v) => (
-                <option key={v.id} value={v.id}>
-                  v{v.version}
-                  {v.name ? ` - ${v.name}` : ""}
-                </option>
-              ))}
-            </select>
-            {promptVersions.length === 0 && (
-              <p className={styles.fieldHint}>
-                プロンプトバージョンがありません。先にバージョンを作成してください。
-              </p>
-            )}
-          </div>
+      {/* ============ タブ: Run を作成 ============ */}
+      {activeTab === "create" && (
+        <div>
+          {/* Step 1: 選択フォーム */}
+          {step === "select" && (
+            <div className={styles.selectCard}>
+              <h3 className={styles.selectCardTitle}>Run を開始する</h3>
 
-          <div className={styles.fieldGroupLg}>
-            <label htmlFor="select-test-case" className={styles.fieldLabel}>
-              テストケース
-            </label>
-            <select
-              id="select-test-case"
-              value={selectedTestCaseId}
-              onChange={(e) =>
-                setSelectedTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
-              }
-              className={styles.fieldSelect}
-            >
-              <option value="">-- 選択してください --</option>
-              {testCases.map((tc) => (
-                <option key={tc.id} value={tc.id}>
-                  {tc.title}
-                </option>
-              ))}
-            </select>
-            {testCases.length === 0 && (
-              <p className={styles.fieldHint}>
-                テストケースがありません。先にテストケースを作成してください。
-              </p>
-            )}
-          </div>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="select-version" className={styles.fieldLabel}>
+                  プロンプトバージョン
+                </label>
+                <select
+                  id="select-version"
+                  value={selectedVersionId}
+                  onChange={(e) =>
+                    setSelectedVersionId(e.target.value === "" ? "" : Number(e.target.value))
+                  }
+                  className={styles.fieldSelect}
+                >
+                  <option value="">-- 選択してください --</option>
+                  {promptVersions.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      v{v.version}
+                      {v.name ? ` - ${v.name}` : ""}
+                    </option>
+                  ))}
+                </select>
+                {promptVersions.length === 0 && (
+                  <p className={styles.fieldHint}>
+                    プロンプトバージョンがありません。先にバージョンを作成してください。
+                  </p>
+                )}
+              </div>
 
-          <button
-            type="button"
-            onClick={handleStartRun}
-            disabled={isStartDisabled}
-            className={`${styles.btnStart} ${isStartDisabled ? styles.btnStartDisabled : ""}`}
-          >
-            Run を開始
-          </button>
+              <div className={styles.fieldGroupLg}>
+                <label htmlFor="select-test-case" className={styles.fieldLabel}>
+                  テストケース
+                </label>
+                <select
+                  id="select-test-case"
+                  value={selectedTestCaseId}
+                  onChange={(e) =>
+                    setSelectedTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
+                  }
+                  className={styles.fieldSelect}
+                >
+                  <option value="">-- 選択してください --</option>
+                  {testCases.map((tc) => (
+                    <option key={tc.id} value={tc.id}>
+                      {tc.title}
+                    </option>
+                  ))}
+                </select>
+                {testCases.length === 0 && (
+                  <p className={styles.fieldHint}>
+                    テストケースがありません。先にテストケースを作成してください。
+                  </p>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={handleStartRun}
+                disabled={isStartDisabled}
+                className={`${styles.btnStart} ${isStartDisabled ? styles.btnStartDisabled : ""}`}
+              >
+                Run を開始
+              </button>
+            </div>
+          )}
+
+          {/* Step 2: Run 実行UI */}
+          {step === "input" && selectedVersion && selectedTestCase && (
+            <div>
+              <div className={styles.stepHeader}>
+                <button
+                  type="button"
+                  onClick={() => setStep("select")}
+                  className={styles.btnSecondary}
+                >
+                  ← 戻る
+                </button>
+                <span className={styles.stepLabel}>
+                  v{selectedVersion.version}
+                  {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
+                  {selectedTestCase.title}
+                </span>
+              </div>
+
+              <div className={styles.twoColumns}>
+                {/* 左カラム: テストケース表示 */}
+                <div className={styles.panel}>
+                  <h3 className={styles.panelTitle}>テストケース: {selectedTestCase.title}</h3>
+
+                  {/* 会話ターン表示 */}
+                  <div className={styles.chatList}>
+                    {selectedTestCase.turns.map((turn, index) => (
+                      <div
+                        key={`turn-${
+                          // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
+                          index
+                        }`}
+                        className={`${styles.bubbleWrapper} ${turn.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
+                      >
+                        <span className={styles.bubbleRole}>
+                          {turn.role === "user" ? "User" : "Assistant"}
+                        </span>
+                        <div
+                          className={`${styles.bubble} ${turn.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                        >
+                          {turn.content}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* 期待される説明 */}
+                  {selectedTestCase.expected_description && (
+                    <div className={styles.expectedBox}>
+                      <p className={styles.expectedLabel}>期待される応答の説明</p>
+                      <p className={styles.expectedText}>{selectedTestCase.expected_description}</p>
+                    </div>
+                  )}
+                </div>
+
+                {/* 右カラム: 手動入力エリア */}
+                <div className={`${styles.panel} ${styles.panelFlex}`}>
+                  <h3 className={styles.panelSubtitle}>LLM 応答の入力</h3>
+                  <p className={styles.inputDescription}>LLM 応答を手動で入力してください</p>
+
+                  <textarea
+                    value={llmResponse}
+                    onChange={(e) => setLlmResponse(e.target.value)}
+                    placeholder="LLM の応答をここにペーストまたは入力してください..."
+                    className={styles.responseTextarea}
+                  />
+
+                  <div className={styles.inputActions}>
+                    <button
+                      type="button"
+                      onClick={handleSaveRun}
+                      disabled={isSaveDisabled}
+                      className={`${styles.btnSave} ${isSaveDisabled ? styles.btnSaveDisabled : ""}`}
+                    >
+                      {createRunMutation.isPending ? "保存中..." : "Run を保存"}
+                    </button>
+
+                    {/* TODO: Phase 2 - LLM実行ボタン */}
+                    <button
+                      type="button"
+                      disabled
+                      title="Phase 2 で実装予定"
+                      className={styles.btnLlmRun}
+                    >
+                      LLM 実行（Phase 2）
+                    </button>
+                  </div>
+
+                  {createRunMutation.isError && (
+                    <p className={styles.errorMsg}>保存に失敗しました。もう一度お試しください。</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: 保存後の表示 */}
+          {step === "saved" && savedRun && selectedVersion && selectedTestCase && (
+            <div>
+              <div className={styles.successBanner}>Run を保存しました（ID: {savedRun.id}）</div>
+
+              <div className={styles.savedActions}>
+                <button type="button" onClick={handleNewRun} className={styles.btnPrimary}>
+                  新しい Run を作成
+                </button>
+              </div>
+
+              {/* 保存したRunの内容 */}
+              <div className={styles.savedPanel}>
+                <h3 className={styles.panelTitle}>保存した Run の内容</h3>
+                <p className={styles.savedMeta}>
+                  v{selectedVersion.version}
+                  {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
+                  {selectedTestCase.title} · {formatDate(savedRun.created_at)}
+                </p>
+                <div className={styles.chatList}>
+                  {savedRun.conversation.map((msg, index) => (
+                    <div
+                      key={`msg-${
+                        // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理するため index をキーとして使用
+                        index
+                      }`}
+                      className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
+                    >
+                      <span className={styles.bubbleRole}>
+                        {msg.role === "user" ? "User" : "Assistant"}
+                      </span>
+                      <div
+                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                      >
+                        {msg.content}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* 同一バージョン×ケースの過去Run一覧 */}
+              <div className={styles.savedPanel}>
+                <h3 className={styles.panelTitle}>過去の Run 一覧</h3>
+                {relatedRuns.length === 0 ? (
+                  <p className={styles.emptyRuns}>まだ Run がありません。</p>
+                ) : (
+                  <div className={styles.runList}>
+                    {relatedRuns.map((run) => (
+                      <RunCard
+                        key={run.id}
+                        run={run}
+                        versionLabel={getVersionLabel(run.prompt_version_id)}
+                        testCaseLabel={getTestCaseLabel(run.test_case_id)}
+                        onSetBest={() => setBestMutation.mutate(run.id)}
+                        isBestPending={setBestMutation.isPending}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       )}
 
-      {/* Step 2: Run 実行UI */}
-      {step === "input" && selectedVersion && selectedTestCase && (
+      {/* ============ タブ: Run 一覧 ============ */}
+      {activeTab === "list" && (
         <div>
-          <div className={styles.stepHeader}>
+          {/* フィルターバー */}
+          <div className={styles.filterBar}>
+            <div className={styles.filterField}>
+              <label htmlFor="filter-version" className={styles.filterLabel}>
+                バージョン
+              </label>
+              <select
+                id="filter-version"
+                value={filterVersionId}
+                onChange={(e) =>
+                  setFilterVersionId(e.target.value === "" ? "" : Number(e.target.value))
+                }
+                className={styles.filterSelect}
+              >
+                <option value="">すべて</option>
+                {promptVersions.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    v{v.version}
+                    {v.name ? ` - ${v.name}` : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.filterField}>
+              <label htmlFor="filter-test-case" className={styles.filterLabel}>
+                テストケース
+              </label>
+              <select
+                id="filter-test-case"
+                value={filterTestCaseId}
+                onChange={(e) =>
+                  setFilterTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
+                }
+                className={styles.filterSelect}
+              >
+                <option value="">すべて</option>
+                {testCases.map((tc) => (
+                  <option key={tc.id} value={tc.id}>
+                    {tc.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <button
               type="button"
-              onClick={() => setStep("select")}
-              className={styles.btnSecondary}
+              onClick={() => {
+                setFilterVersionId("");
+                setFilterTestCaseId("");
+              }}
+              className={styles.btnClearFilter}
             >
-              ← 戻る
-            </button>
-            <span className={styles.stepLabel}>
-              v{selectedVersion.version}
-              {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} × {selectedTestCase.title}
-            </span>
-          </div>
-
-          <div className={styles.twoColumns}>
-            {/* 左カラム: テストケース表示 */}
-            <div className={styles.panel}>
-              <h3 className={styles.panelTitle}>
-                テストケース: {selectedTestCase.title}
-              </h3>
-
-              {/* 会話ターン表示 */}
-              <div className={styles.chatList}>
-                {selectedTestCase.turns.map((turn, index) => (
-                  <div
-                    key={`turn-${
-                      // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
-                      index
-                    }`}
-                    className={`${styles.bubbleWrapper} ${turn.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                  >
-                    <span className={styles.bubbleRole}>
-                      {turn.role === "user" ? "User" : "Assistant"}
-                    </span>
-                    <div
-                      className={`${styles.bubble} ${turn.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                    >
-                      {turn.content}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* 期待される説明 */}
-              {selectedTestCase.expected_description && (
-                <div className={styles.expectedBox}>
-                  <p className={styles.expectedLabel}>期待される応答の説明</p>
-                  <p className={styles.expectedText}>
-                    {selectedTestCase.expected_description}
-                  </p>
-                </div>
-              )}
-            </div>
-
-            {/* 右カラム: 手動入力エリア */}
-            <div className={`${styles.panel} ${styles.panelFlex}`}>
-              <h3 className={styles.panelSubtitle}>LLM 応答の入力</h3>
-              <p className={styles.inputDescription}>LLM 応答を手動で入力してください</p>
-
-              <textarea
-                value={llmResponse}
-                onChange={(e) => setLlmResponse(e.target.value)}
-                placeholder="LLM の応答をここにペーストまたは入力してください..."
-                className={styles.responseTextarea}
-              />
-
-              <div className={styles.inputActions}>
-                <button
-                  type="button"
-                  onClick={handleSaveRun}
-                  disabled={isSaveDisabled}
-                  className={`${styles.btnSave} ${isSaveDisabled ? styles.btnSaveDisabled : ""}`}
-                >
-                  {createRunMutation.isPending ? "保存中..." : "Run を保存"}
-                </button>
-
-                {/* TODO: Phase 2 - LLM実行ボタン */}
-                <button
-                  type="button"
-                  disabled
-                  title="Phase 2 で実装予定"
-                  className={styles.btnLlmRun}
-                >
-                  LLM 実行（Phase 2）
-                </button>
-              </div>
-
-              {createRunMutation.isError && (
-                <p className={styles.errorMsg}>保存に失敗しました。もう一度お試しください。</p>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Step 3: 保存後の表示 */}
-      {step === "saved" && savedRun && selectedVersion && selectedTestCase && (
-        <div>
-          <div className={styles.successBanner}>
-            Run を保存しました（ID: {savedRun.id}）
-          </div>
-
-          <div className={styles.savedActions}>
-            <button type="button" onClick={handleNewRun} className={styles.btnPrimary}>
-              新しい Run を作成
+              クリア
             </button>
           </div>
 
-          {/* 保存したRunの内容 */}
-          <div className={styles.savedPanel}>
-            <h3 className={styles.panelTitle}>保存した Run の内容</h3>
-            <p className={styles.savedMeta}>
-              v{selectedVersion.version}
-              {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} × {selectedTestCase.title}{" "}
-              · {formatDate(savedRun.created_at)}
+          {/* Run 一覧 */}
+          {isRunsLoading ? (
+            <p className={styles.loadingMsg}>読み込み中...</p>
+          ) : allRuns.length === 0 ? (
+            <p className={styles.emptyRuns}>
+              {filterVersionId !== "" || filterTestCaseId !== ""
+                ? "条件に一致する Run がありません。"
+                : "まだ Run がありません。「Run を作成」タブから実行してください。"}
             </p>
-            <div className={styles.chatList}>
-              {savedRun.conversation.map((msg, index) => (
-                <div
-                  key={`msg-${
-                    // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理するため index をキーとして使用
-                    index
-                  }`}
-                  className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                >
-                  <span className={styles.bubbleRole}>
-                    {msg.role === "user" ? "User" : "Assistant"}
-                  </span>
-                  <div
-                    className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                  >
-                    {msg.content}
-                  </div>
-                </div>
+          ) : (
+            <div className={styles.runList}>
+              {allRuns.map((run) => (
+                <RunCard
+                  key={run.id}
+                  run={run}
+                  versionLabel={getVersionLabel(run.prompt_version_id)}
+                  testCaseLabel={getTestCaseLabel(run.test_case_id)}
+                  onSetBest={() => setBestMutation.mutate(run.id)}
+                  isBestPending={setBestMutation.isPending}
+                />
               ))}
             </div>
-          </div>
-
-          {/* 既存のRun一覧 */}
-          <div className={styles.savedPanel}>
-            <h3 className={styles.panelTitle}>過去の Run 一覧</h3>
-            {existingRuns.length === 0 ? (
-              <p className={styles.emptyRuns}>まだ Run がありません。</p>
-            ) : (
-              <div className={styles.runList}>
-                {existingRuns.map((run) => {
-                  const lastResponse = getLastAssistantMessage(run.conversation);
-                  return (
-                    <div
-                      key={run.id}
-                      className={`${styles.runCard} ${run.is_best ? styles.runCardBest : ""}`}
-                    >
-                      <div className={styles.runCardBody}>
-                        <div className={styles.runCardHeader}>
-                          <span className={styles.runId}>Run #{run.id}</span>
-                          {run.is_best && (
-                            <span className={styles.badgeBest}>ベスト回答</span>
-                          )}
-                          <span className={styles.runDate}>{formatDate(run.created_at)}</span>
-                        </div>
-                        {lastResponse && (
-                          <p className={styles.runPreview}>{lastResponse}</p>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setBestMutation.mutate(run.id)}
-                        disabled={setBestMutation.isPending || run.is_best}
-                        className={`${styles.btnBest} ${run.is_best ? styles.btnBestActive : styles.btnBestInactive}`}
-                      >
-                        {run.is_best ? "ベスト済み" : "ベストに設定"}
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Add tab-based navigation to separate "Create Run" and "Run List" views
- Implement version × test case filter selects for the Run list
- Add accordion-style conversation expand/collapse for each Run card
- Enable best-answer flag toggle (only one per test case, existing flag auto-cleared by server)

## Completion conditions

- [x] Run一覧をフィルタリングできる (version / test case filter selects)
- [x] 会話内容が展開・折りたたみできる (accordion per RunCard)
- [x] ベスト回答が1件のみ設定できる (server-side constraint already in place; UI reflects it)

## Test plan

- [ ] Open a project that has multiple prompt versions and test cases
- [ ] Navigate to "Run 一覧" tab — confirm all runs are listed
- [ ] Filter by version — confirm only matching runs appear
- [ ] Filter by test case — confirm only matching runs appear
- [ ] Clear filters — confirm all runs reappear
- [ ] Click "▼ 会話を表示" — confirm conversation bubbles expand
- [ ] Click "▲ 折りたたむ" — confirm conversation collapses
- [ ] Click "ベストに設定" on a run — confirm badge appears and button becomes disabled
- [ ] Click "ベストに設定" on a different run in the same test case — confirm previous best is cleared

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)