### PR TITLE
feat(ui): Run実行画面にプロンプト全文コピー機能を追加

### DIFF
--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -511,6 +511,61 @@
   border-top: 1px solid var(--c-border);
 }
 
+/* ==================== Copy prompt panel ==================== */
+.copyPromptPanel {
+  margin-bottom: 16px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.copyPromptHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+}
+
+.btnCopyPromptToggle {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--c-blue);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.btnCopy {
+  padding: 5px 14px;
+  background: var(--c-accent);
+  color: var(--c-overlay);
+  border: none;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.copyPromptTextarea {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  background: var(--c-overlay);
+  border: none;
+  border-top: 1px solid var(--c-border);
+  color: var(--c-text);
+  font-size: 13px;
+  font-family: monospace;
+  line-height: 1.5;
+  resize: vertical;
+}
+
 /* ==================== Loading ==================== */
 .loadingMsg {
   color: var(--c-muted);

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -3,7 +3,9 @@ import { useState } from "react";
 import { useParams } from "react-router";
 import {
   type ConversationMessage,
+  type PromptVersion,
   type Run,
+  type TestCase,
   createRun,
   getProject,
   getPromptVersions,
@@ -12,6 +14,67 @@ import {
   setBestRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
+
+function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
+  const systemPrompt = testCase.context_content
+    ? version.content.includes("{{context}}")
+      ? version.content.replace("{{context}}", testCase.context_content)
+      : `${version.content}\n\n${testCase.context_content}`
+    : version.content;
+
+  const turnsText = testCase.turns
+    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
+    .join("\n\n");
+
+  return turnsText
+    ? `[System Prompt]\n${systemPrompt}\n\n[Conversation]\n${turnsText}`
+    : `[System Prompt]\n${systemPrompt}`;
+}
+
+function CopyPromptPanel({
+  version,
+  testCase,
+}: {
+  version: PromptVersion;
+  testCase: TestCase;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const fullPrompt = buildFullPrompt(version, testCase);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(fullPrompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className={styles.copyPromptPanel}>
+      <div className={styles.copyPromptHeader}>
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className={styles.btnCopyPromptToggle}
+          aria-expanded={open}
+        >
+          {open ? "▲ プロンプト全文を閉じる" : "▼ プロンプト全文を表示"}
+        </button>
+        <button type="button" onClick={handleCopy} className={styles.btnCopy}>
+          {copied ? "✓ コピー済み" : "コピー"}
+        </button>
+      </div>
+      {open && (
+        <textarea
+          readOnly
+          value={fullPrompt}
+          className={styles.copyPromptTextarea}
+          rows={12}
+        />
+      )}
+    </div>
+  );
+}
 
 function formatDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString("ja-JP", {
@@ -362,6 +425,8 @@ export function RunsPage() {
                   {selectedTestCase.title}
                 </span>
               </div>
+
+              <CopyPromptPanel version={selectedVersion} testCase={selectedTestCase} />
 
               <div className={styles.twoColumns}>
                 {/* 左カラム: テストケース表示 */}

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -27,8 +27,8 @@ function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
     .join("\n\n");
 
   return turnsText
-    ? `[System Prompt]\n${systemPrompt}\n\n[Conversation]\n${turnsText}`
-    : `[System Prompt]\n${systemPrompt}`;
+    ? `${systemPrompt}\n\n[Conversation]\n${turnsText}`
+    : systemPrompt;
 }
 
 function CopyPromptPanel({


### PR DESCRIPTION
## Summary

- `CopyPromptPanel` コンポーネントを追加
- Step 2（Run実行UI）のtwoColumnsの上にプロンプト全文パネルを表示
- 「▼ プロンプト全文を表示」で展開し、全文を確認できる
- 「コピー」ボタンでクリップボードにコピー、成功後「✓ コピー済み」を2秒表示

## プロンプト全文の組み立てルール

1. `PromptVersion.content` の `{{context}}` を `TestCase.context_content` で置換
2. `{{context}}` がない場合は `context_content` を末尾に追記
3. 会話ターン（`TestCase.turns`）を `User: ...` / `Assistant: ...` 形式でフォーマット

## ベースブランチ

PR #62（`feature/issue-20-runs-detail-ui`）をベースにしており、PR #62の動作確認にも利用可能

## Test plan

- [ ] バージョンとテストケースを選択してRun開始
- [ ] Step 2 で「▼ プロンプト全文を表示」ボタンが表示されることを確認
- [ ] クリックするとテキストエリアが展開され、システムプロンプト + 会話ターンが表示されることを確認
- [ ] `{{context}}` を含むシステムプロンプトの場合、context_contentで置換されることを確認
- [ ] 「コピー」ボタンを押すとクリップボードにコピーされ、「✓ コピー済み」に変わることを確認
- [ ] 2秒後に「コピー」に戻ることを確認

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)