### PR TITLE
feat: PromptVersionにselectedフラグを追加し選定版を管理できるようにする

### DIFF
--- a/packages/core/drizzle/0005_prompt_version_selected.sql
+++ b/packages/core/drizzle/0005_prompt_version_selected.sql
@@ -1,0 +1,3 @@
+-- prompt_versions テーブルに is_selected カラムを追加
+-- プロジェクト内で「Selected（選定版）」として1バージョンをマークできる
+ALTER TABLE `prompt_versions` ADD `is_selected` integer NOT NULL DEFAULT 0;

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1744509600000,
       "tag": "0004_project_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1744596000000,
+      "tag": "0005_prompt_version_selected",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/schema/prompt-versions.ts
+++ b/packages/core/src/schema/prompt-versions.ts
@@ -18,6 +18,7 @@ export const prompt_versions = sqliteTable("prompt_versions", {
     (): AnySQLiteColumn => prompt_versions.id,
   ),
   created_at: integer("created_at").notNull(),
+  is_selected: integer("is_selected", { mode: "boolean" }).notNull().default(false),
 });
 
 // Drizzle推論型のエクスポート

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -193,5 +193,45 @@ export function createPromptVersionsRouter(db: DB) {
     return c.json(created, 201);
   });
 
+  // PATCH /api/projects/:projectId/prompt-versions/:id/selected - Selected フラグ設定
+  // プロジェクト内の既存フラグを解除してから対象バージョンに設定（1プロジェクト1件制約）
+  router.patch("/:id/selected", async (c) => {
+    const projectId = Number(c.req.param("projectId"));
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(prompt_versions)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+
+    if (!existing) {
+      return c.json({ error: "PromptVersion not found" }, 404);
+    }
+
+    // プロジェクト内の既存 selected フラグを解除
+    await db
+      .update(prompt_versions)
+      .set({ is_selected: false })
+      .where(eq(prompt_versions.project_id, projectId));
+
+    // 対象バージョンに selected フラグを設定
+    const updateResult = await db
+      .update(prompt_versions)
+      .set({ is_selected: true })
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update PromptVersion" }, 500);
+    }
+
+    return c.json(updated);
+  });
+
   return router;
 }

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -106,6 +106,7 @@ export type PromptVersion = {
   content: string;
   parent_version_id: number | null;
   created_at: number;
+  is_selected: boolean;
 };
 
 export function getPromptVersions(projectId: number): Promise<PromptVersion[]> {
@@ -253,4 +254,8 @@ export function createRun(
 
 export function setBestRun(projectId: number, id: number): Promise<Run> {
   return api.patch<Run>(`/projects/${projectId}/runs/${id}/best`, {});
+}
+
+export function setSelectedVersion(projectId: number, id: number): Promise<PromptVersion> {
+  return api.patch<PromptVersion>(`/projects/${projectId}/prompt-versions/${id}/selected`, {});
 }

--- a/packages/ui/src/pages/PromptsPage.module.css
+++ b/packages/ui/src/pages/PromptsPage.module.css
@@ -323,6 +323,12 @@
   flex-direction: column;
 }
 
+.panelHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .btnEdit {
   padding: 5px 14px;
   background: transparent;
@@ -331,6 +337,38 @@
   color: var(--c-subtext);
   font-size: 13px;
   cursor: pointer;
+}
+
+/* ==================== Selected badge & button ==================== */
+.badgeSelected {
+  padding: 2px 8px;
+  background: rgba(137, 220, 235, 0.2);
+  border: 1px solid rgba(137, 220, 235, 0.4);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--c-blue);
+  font-weight: 600;
+}
+
+.btnSelected {
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btnSelectedInactive {
+  background: transparent;
+  color: var(--c-muted);
+  border: 1px solid var(--c-border);
+}
+
+.btnSelectedActive {
+  background: rgba(137, 220, 235, 0.13);
+  color: var(--c-blue);
+  border: 1px solid rgba(137, 220, 235, 0.4);
+  cursor: not-allowed;
 }
 
 .memoBox {

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -672,8 +672,9 @@ export function PromptsPage() {
 
   const setSelectedMutation = useMutation({
     mutationFn: (versionId: number) => setSelectedVersion(projectId, versionId),
-    onSuccess: () => {
+    onSuccess: (updatedVersion) => {
       void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
+      setPanelMode({ type: "view", version: updatedVersion });
     },
   });
 

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -7,6 +7,7 @@ import {
   createPromptVersion,
   getProject,
   getPromptVersions,
+  setSelectedVersion,
   updatePromptVersion,
 } from "../lib/api";
 import styles from "./PromptsPage.module.css";
@@ -645,8 +646,9 @@ type PanelMode =
 export function PromptsPage() {
   const { id } = useParams<{ id: string }>();
   const projectId = Number(id);
+  const queryClient = useQueryClient();
 
-  const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
+  const [selectedVersion, setSelectedVersionState] = useState<PromptVersion | null>(null);
   const [compareVersion, setCompareVersion] = useState<PromptVersion | null>(null);
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
   const [branchTarget, setBranchTarget] = useState<PromptVersion | null>(null);
@@ -668,12 +670,19 @@ export function PromptsPage() {
     enabled: !Number.isNaN(projectId),
   });
 
+  const setSelectedMutation = useMutation({
+    mutationFn: (versionId: number) => setSelectedVersion(projectId, versionId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
+    },
+  });
+
   const tree = versions ? buildVersionTree(versions) : [];
   const flatNodes = flattenTree(tree);
   const verticalLinesPerNode = computeVerticalLines(flatNodes);
 
   function handleSelectVersion(v: PromptVersion) {
-    setSelectedVersion(v);
+    setSelectedVersionState(v);
     setPanelMode({ type: "view", version: v });
   }
 
@@ -701,7 +710,7 @@ export function PromptsPage() {
 
   function handleBranchCreated(newVersion: PromptVersion) {
     setBranchTarget(null);
-    setSelectedVersion(newVersion);
+    setSelectedVersionState(newVersion);
     setPanelMode({ type: "edit", version: newVersion });
   }
 
@@ -726,7 +735,7 @@ export function PromptsPage() {
           <button
             type="button"
             onClick={() => {
-              setSelectedVersion(null);
+              setSelectedVersionState(null);
               setPanelMode({ type: "new" });
             }}
             className={styles.btnPrimary}
@@ -833,13 +842,26 @@ export function PromptsPage() {
                     {panelMode.version.name ?? `バージョン ${panelMode.version.version}`}
                   </span>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setPanelMode({ type: "edit", version: panelMode.version })}
-                  className={styles.btnEdit}
-                >
-                  編集
-                </button>
+                <div className={styles.panelHeaderRight}>
+                  {panelMode.version.is_selected && (
+                    <span className={styles.badgeSelected}>Selected</span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setSelectedMutation.mutate(panelMode.version.id)}
+                    disabled={setSelectedMutation.isPending || panelMode.version.is_selected}
+                    className={`${styles.btnSelected} ${panelMode.version.is_selected ? styles.btnSelectedActive : styles.btnSelectedInactive}`}
+                  >
+                    {panelMode.version.is_selected ? "Selected 済み" : "Selected に設定"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPanelMode({ type: "edit", version: panelMode.version })}
+                    className={styles.btnEdit}
+                  >
+                    編集
+                  </button>
+                </div>
               </div>
               <div className={styles.panelBody}>
                 {panelMode.version.memo && (
@@ -877,7 +899,7 @@ export function PromptsPage() {
                   onSave={() => {
                     // 編集完了後に最新データで表示モードに戻す
                     setPanelMode(null);
-                    setSelectedVersion(null);
+                    setSelectedVersionState(null);
                   }}
                   onCancel={() => setPanelMode({ type: "view", version: panelMode.version })}
                 />


### PR DESCRIPTION
## Summary

- `prompt_versions` テーブルに `is_selected` カラム（boolean）を追加
- マイグレーション `0005_prompt_version_selected.sql` を作成・適用
- `PATCH /api/projects/:projectId/prompt-versions/:id/selected` APIエンドポイントを追加（1プロジェクト1件制約：既存フラグを解除してから設定）
- UIクライアント `api.ts` の `PromptVersion` 型に `is_selected` を追加し、`setSelectedVersion` 関数を追加
- `PromptsPage.tsx` に Selected バッジと「Selected に設定」ボタンを追加（右パネルの view モード）
- `PromptsPage.module.css` に対応スタイルを追加（CSS Module、カラー変数使用）

## Test plan

- [ ] プロンプト管理ページを開き、バージョンを選択する
- [ ] 右パネルに「Selected に設定」ボタンが表示されることを確認
- [ ] ボタンをクリックすると「Selected」バッジが表示され、ボタンが「Selected 済み」に変わることを確認
- [ ] 別のバージョンを選択して「Selected に設定」をクリックすると、前のバージョンのフラグが解除され、新しいバージョンにフラグが設定されることを確認（1プロジェクト1件制約）
- [ ] ページをリロードしても Selected 状態が保持されることを確認

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)