### PR TITLE
feat: スコア推移ページを実装する (#22)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
 import { createRunsRouter } from "./routes/runs.js";
+import { createScoreProgressionRouter } from "./routes/score-progression.js";
 import { createScoresRouter, createVersionSummaryRouter } from "./routes/scores.js";
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
@@ -30,6 +31,7 @@ app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
+app.route("/api/projects/:projectId/score-progression", createScoreProgressionRouter(db));
 app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db));
 
 const port = Number(process.env.PORT ?? 3001);

--- a/packages/server/src/routes/score-progression.ts
+++ b/packages/server/src/routes/score-progression.ts
@@ -1,0 +1,197 @@
+import type { DB } from "@prompt-reviewer/core";
+import { prompt_versions, runs, scores, test_cases } from "@prompt-reviewer/core";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+/** Convert string or undefined to integer. Returns null when invalid or undefined. */
+function parseIntParam(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export type VersionSummary = {
+  versionId: number;
+  versionNumber: number;
+  versionName: string | null;
+  avgHumanScore: number | null;
+  avgJudgeScore: number | null;
+  runCount: number;
+  scoredCount: number;
+};
+
+export type TestCaseScoreBreakdown = {
+  testCaseId: number;
+  testCaseTitle: string;
+  versions: {
+    versionId: number;
+    versionNumber: number;
+    versionName: string | null;
+    humanScore: number | null;
+    judgeScore: number | null;
+    runId: number | null;
+  }[];
+};
+
+export type ScoreProgressionResponse = {
+  versionSummaries: VersionSummary[];
+  testCaseBreakdown: TestCaseScoreBreakdown[];
+};
+
+/**
+ * Score progression router
+ * GET /api/projects/:projectId/score-progression
+ *
+ * Returns aggregated score data for all versions in a project:
+ * - versionSummaries: average scores per version (for the line chart)
+ * - testCaseBreakdown: per-test-case scores broken down by version (for the table)
+ */
+export function createScoreProgressionRouter(db: DB) {
+  const router = new Hono();
+
+  router.get("/", async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    // Fetch all prompt versions for this project
+    const versions = await db
+      .select()
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId));
+
+    if (versions.length === 0) {
+      return c.json({
+        versionSummaries: [],
+        testCaseBreakdown: [],
+      } satisfies ScoreProgressionResponse);
+    }
+
+    // Fetch all runs for this project
+    const allRuns = await db.select().from(runs).where(eq(runs.project_id, projectId));
+
+    if (allRuns.length === 0) {
+      const emptySummaries: VersionSummary[] = versions.map((v) => ({
+        versionId: v.id,
+        versionNumber: v.version,
+        versionName: v.name,
+        avgHumanScore: null,
+        avgJudgeScore: null,
+        runCount: 0,
+        scoredCount: 0,
+      }));
+      return c.json({
+        versionSummaries: emptySummaries,
+        testCaseBreakdown: [],
+      } satisfies ScoreProgressionResponse);
+    }
+
+    const runIds = allRuns.map((r) => r.id);
+
+    // Fetch all non-discarded scores for runs in this project
+    const allScores = await db.select().from(scores).where(eq(scores.is_discarded, false));
+
+    // Filter by run IDs belonging to this project (application-side IN filter)
+    const projectScores = allScores.filter((s) => runIds.includes(s.run_id));
+
+    // Build a map: runId -> score
+    const scoreByRunId = new Map(projectScores.map((s) => [s.run_id, s]));
+
+    // Build version summaries
+    const versionSummaries: VersionSummary[] = versions
+      .sort((a, b) => a.version - b.version)
+      .map((v) => {
+        const versionRuns = allRuns.filter((r) => r.prompt_version_id === v.id);
+        const versionScores = versionRuns
+          .map((r) => scoreByRunId.get(r.id))
+          .filter((s): s is NonNullable<typeof s> => s !== undefined);
+
+        const humanScores = versionScores
+          .map((s) => s.human_score)
+          .filter((v): v is number => v !== null);
+        const judgeScores = versionScores
+          .map((s) => s.judge_score)
+          .filter((v): v is number => v !== null);
+
+        const avgHumanScore =
+          humanScores.length > 0
+            ? humanScores.reduce((sum, v) => sum + v, 0) / humanScores.length
+            : null;
+
+        const avgJudgeScore =
+          judgeScores.length > 0
+            ? judgeScores.reduce((sum, v) => sum + v, 0) / judgeScores.length
+            : null;
+
+        return {
+          versionId: v.id,
+          versionNumber: v.version,
+          versionName: v.name,
+          avgHumanScore,
+          avgJudgeScore,
+          runCount: versionRuns.length,
+          scoredCount: versionScores.length,
+        };
+      });
+
+    // Fetch all test cases for this project
+    const testCases = await db
+      .select()
+      .from(test_cases)
+      .where(eq(test_cases.project_id, projectId));
+
+    // Build test case breakdown
+    // For each test case, for each version, find the best run's score (or any run's score)
+    const testCaseBreakdown: TestCaseScoreBreakdown[] = testCases
+      .sort((a, b) => a.display_order - b.display_order)
+      .map((tc) => {
+        const versionScores = versions
+          .sort((a, b) => a.version - b.version)
+          .map((v) => {
+            const tcRuns = allRuns.filter(
+              (r) => r.prompt_version_id === v.id && r.test_case_id === tc.id,
+            );
+
+            // Prefer best run, fall back to latest run
+            const bestRun = tcRuns.find((r) => r.is_best);
+            const targetRun = bestRun ?? tcRuns.sort((a, b) => b.created_at - a.created_at)[0];
+
+            if (!targetRun) {
+              return {
+                versionId: v.id,
+                versionNumber: v.version,
+                versionName: v.name,
+                humanScore: null,
+                judgeScore: null,
+                runId: null,
+              };
+            }
+
+            const score = scoreByRunId.get(targetRun.id);
+            return {
+              versionId: v.id,
+              versionNumber: v.version,
+              versionName: v.name,
+              humanScore: score?.human_score ?? null,
+              judgeScore: score?.judge_score ?? null,
+              runId: targetRun.id,
+            };
+          });
+
+        return {
+          testCaseId: tc.id,
+          testCaseTitle: tc.title,
+          versions: versionScores,
+        };
+      });
+
+    return c.json({
+      versionSummaries,
+      testCaseBreakdown,
+    } satisfies ScoreProgressionResponse);
+  });
+
+  return router;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,8 @@
     "@tanstack/react-query": "^5.62.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.1.1"
+    "react-router": "^7.1.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { ProjectsPage } from "./pages/ProjectsPage";
 import { PromptsPage } from "./pages/PromptsPage";
 import { RunsPage } from "./pages/RunsPage";
 import { ScorePage } from "./pages/ScorePage";
+import { ScoreProgressionPage } from "./pages/ScoreProgressionPage";
 import { TestCasesPage } from "./pages/TestCasesPage";
 
 const queryClient = new QueryClient({
@@ -34,6 +35,7 @@ export function App() {
             <Route path="projects/:id/prompts" element={<PromptsPage />} />
             <Route path="projects/:id/runs" element={<RunsPage />} />
             <Route path="projects/:id/score" element={<ScorePage />} />
+            <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
             <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -19,6 +19,7 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
     { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
     { to: `/projects/${projectId}/runs`, label: "Run 一覧" },
     { to: `/projects/${projectId}/score`, label: "採点" },
+    { to: `/projects/${projectId}/score-progression`, label: "スコア推移" },
     { to: `/projects/${projectId}/settings`, label: "設定" },
   ];
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -313,3 +313,37 @@ export function upsertScore(
     human_comment: data.human_comment ?? undefined,
   });
 }
+
+// Score Progression API
+
+export type VersionSummary = {
+  versionId: number;
+  versionNumber: number;
+  versionName: string | null;
+  avgHumanScore: number | null;
+  avgJudgeScore: number | null;
+  runCount: number;
+  scoredCount: number;
+};
+
+export type TestCaseScoreBreakdown = {
+  testCaseId: number;
+  testCaseTitle: string;
+  versions: {
+    versionId: number;
+    versionNumber: number;
+    versionName: string | null;
+    humanScore: number | null;
+    judgeScore: number | null;
+    runId: number | null;
+  }[];
+};
+
+export type ScoreProgressionResponse = {
+  versionSummaries: VersionSummary[];
+  testCaseBreakdown: TestCaseScoreBreakdown[];
+};
+
+export function getScoreProgression(projectId: number): Promise<ScoreProgressionResponse> {
+  return api.get<ScoreProgressionResponse>(`/projects/${projectId}/score-progression`);
+}

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -95,71 +95,37 @@ function flattenTree(nodes: VersionTreeNode[]): VersionTreeNode[] {
   return result;
 }
 
-// ツリー接続線を構築するためのヘルパー
-function buildConnectorFlags(flatNodes: VersionTreeNode[]): boolean[][] {
-  // 各ノードのdepthごとに「まだ下に兄弟がいるか」を追跡
-  const flags: boolean[][] = flatNodes.map(() => []);
+// Determine whether to draw a vertical line at depth d for each node
 
-  for (let i = 0; i < flatNodes.length; i++) {
-    const node = flatNodes[i];
-    const depthFlags: boolean[] = [];
-
-    for (let d = 0; d < node.depth; d++) {
-      // depth d において、このノードより後ろに同じ深さ(または浅い深さで分岐が続く)ノードがあるか
-      let hasMore = false;
-      for (let j = i + 1; j < flatNodes.length; j++) {
-        if (flatNodes[j].depth <= d) {
-          break;
-        }
-        if (
-          flatNodes[j].depth === d + 1 &&
-          flatNodes[j].version.parent_version_id === flatNodes[i].version.parent_version_id
-        ) {
-          // 同じ親を持つ兄弟が後ろにいるか確認
-        }
-        if (flatNodes[j].depth === d) {
-          hasMore = true;
-          break;
-        }
-      }
-      depthFlags.push(hasMore);
-    }
-    flags[i] = depthFlags;
-  }
-  return flags;
-}
-
-// 各ノードについて、そのdepth位置に縦線を引くかどうかを判断
 function computeVerticalLines(flatNodes: VersionTreeNode[]): boolean[][] {
   const result: boolean[][] = flatNodes.map(() => []);
   const maxDepth = Math.max(...flatNodes.map((n) => n.depth), 0);
 
   for (let d = 0; d <= maxDepth; d++) {
-    // depth d のノードがどの位置にいるかを記録
     for (let i = 0; i < flatNodes.length; i++) {
       const node = flatNodes[i];
+      if (!node) continue;
       if (node.depth >= d) {
-        // このインデックスの位置でdepth dの縦線を引くか
         if (node.depth === d) {
-          result[i][d] = false; // このノード自身
+          // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
+          result[i]![d] = false;
         } else {
-          // このノードがdepth d のノードの後裔かどうか
-          // depth d の最後の兄弟より前に現れるか確認
           let showLine = false;
-          // depth d+1...node.depth の間に親をたどる
-          // 簡易的に: depth d のノードがiの前にあって、iより後にも depth d のノードが同じ親の下に続くか
           for (let j = i + 1; j < flatNodes.length; j++) {
-            if (flatNodes[j].depth < d) break;
-            if (flatNodes[j].depth === d) {
-              // iからjまでの間に、depth d のノードがあるということは縦線が必要
+            const jNode = flatNodes[j];
+            if (!jNode) break;
+            if (jNode.depth < d) break;
+            if (jNode.depth === d) {
               showLine = true;
               break;
             }
           }
-          result[i][d] = showLine;
+          // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
+          result[i]![d] = showLine;
         }
       } else {
-        result[i][d] = false;
+        // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
+        result[i]![d] = false;
       }
     }
   }
@@ -184,16 +150,13 @@ function VersionTreeItem({
   onSelect,
   onBranch,
   onCompare,
-  verticalLines,
+  verticalLines: _verticalLines,
 }: VersionTreeItemProps) {
   const { version } = node;
   const depth = node.depth;
 
   return (
-    <div
-      className={styles.treeItem}
-      style={{ paddingLeft: `${depth * 20}px` }}
-    >
+    <div className={styles.treeItem} style={{ paddingLeft: `${depth * 20}px` }}>
       {/* 接続線（分岐ノードのみ） */}
       {depth > 0 && (
         <div className={styles.treeConnector}>
@@ -216,9 +179,7 @@ function VersionTreeItem({
         <span className={styles.treeVersionName}>
           {version.name ?? `バージョン ${version.version}`}
         </span>
-        {version.parent_version_id !== null && (
-          <span className={styles.badgeBranch}>分岐</span>
-        )}
+        {version.parent_version_id !== null && <span className={styles.badgeBranch}>分岐</span>}
         <div
           className={styles.treeCardActions}
           onClick={(e) => e.stopPropagation()}
@@ -344,11 +305,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
         />
       </div>
       <div className={styles.formActions}>
-        <button
-          type="button"
-          onClick={onCancel}
-          className={styles.btnCancel}
-        >
+        <button type="button" onClick={onCancel} className={styles.btnCancel}>
           キャンセル
         </button>
         <button
@@ -438,15 +395,9 @@ function BranchModal({ parentVersion, projectId, onClose, onCreated }: BranchMod
               className={styles.fieldInput}
             />
           </div>
-          {branchMutation.isError && (
-            <p className={styles.errorMsg}>分岐の作成に失敗しました。</p>
-          )}
+          {branchMutation.isError && <p className={styles.errorMsg}>分岐の作成に失敗しました。</p>}
           <div className={styles.modalActions}>
-            <button
-              type="button"
-              onClick={onClose}
-              className={styles.btnCancel}
-            >
+            <button type="button" onClick={onClose} className={styles.btnCancel}>
               キャンセル
             </button>
             <button
@@ -481,49 +432,56 @@ function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; 
 
   while (ai < aLines.length || bi < bLines.length) {
     if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      result.push({ type: "same", text: aLines[ai] });
+      // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+      result.push({ type: "same", text: aLines[ai]! });
       ai++;
       bi++;
     } else {
-      // 先読みして一致するものを探す
       const aRemainder = aLines.slice(ai);
       const bRemainder = bLines.slice(bi);
 
-      // bの行がaに出てくるか（削除の後に挿入）
       let foundInA = -1;
       let foundInB = -1;
       const lookAhead = Math.min(5, maxLen);
 
       for (let d = 0; d < lookAhead; d++) {
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d])) {
+        // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
+        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d]!)) {
           foundInB = d;
-          foundInA = aRemainder.indexOf(bRemainder[d]);
+          // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
+          foundInA = aRemainder.indexOf(bRemainder[d]!);
           break;
         }
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d])) {
+        // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
+        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d]!)) {
           foundInA = d;
-          foundInB = bRemainder.indexOf(aRemainder[d]);
+          // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
+          foundInB = bRemainder.indexOf(aRemainder[d]!);
           break;
         }
       }
 
       if (foundInA > 0) {
         for (let i = 0; i < foundInA; i++) {
-          result.push({ type: "removed", text: aRemainder[i] });
+          // biome-ignore lint/style/noNonNullAssertion: i < foundInA <= aRemainder.length
+          result.push({ type: "removed", text: aRemainder[i]! });
         }
         ai += foundInA;
       } else if (foundInB > 0) {
         for (let i = 0; i < foundInB; i++) {
-          result.push({ type: "added", text: bRemainder[i] });
+          // biome-ignore lint/style/noNonNullAssertion: i < foundInB <= bRemainder.length
+          result.push({ type: "added", text: bRemainder[i]! });
         }
         bi += foundInB;
       } else {
         if (ai < aLines.length) {
-          result.push({ type: "removed", text: aLines[ai] });
+          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+          result.push({ type: "removed", text: aLines[ai]! });
           ai++;
         }
         if (bi < bLines.length) {
-          result.push({ type: "added", text: bLines[bi] });
+          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+          result.push({ type: "added", text: bLines[bi]! });
           bi++;
         }
       }
@@ -564,11 +522,7 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
                 </button>
               ))}
             </div>
-            <button
-              type="button"
-              onClick={onClose}
-              className={styles.btnCloseCompare}
-            >
+            <button type="button" onClick={onClose} className={styles.btnCloseCompare}>
               閉じる
             </button>
           </div>
@@ -584,9 +538,7 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
                   <span>
                     v{versionA.version} {versionA.name && `— ${versionA.name}`}
                   </span>
-                  <span className={styles.comparePanelDate}>
-                    {formatDate(versionA.created_at)}
-                  </span>
+                  <span className={styles.comparePanelDate}>{formatDate(versionA.created_at)}</span>
                 </div>
                 <pre className={styles.comparePre}>{versionA.content}</pre>
               </div>
@@ -596,9 +548,7 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
                   <span>
                     v{versionB.version} {versionB.name && `— ${versionB.name}`}
                   </span>
-                  <span className={styles.comparePanelDate}>
-                    {formatDate(versionB.created_at)}
-                  </span>
+                  <span className={styles.comparePanelDate}>{formatDate(versionB.created_at)}</span>
                 </div>
                 <pre className={styles.comparePre}>{versionB.content}</pre>
               </div>
@@ -725,11 +675,7 @@ export function PromptsPage() {
         </div>
         <div className={styles.pageActions}>
           {selectedVersion && compareVersion && (
-            <button
-              type="button"
-              onClick={handleOpenCompare}
-              className={styles.btnBlue}
-            >
+            <button type="button" onClick={handleOpenCompare} className={styles.btnBlue}>
               比較を表示
             </button>
           )}
@@ -814,9 +760,7 @@ export function PromptsPage() {
         {/* 右パネル */}
         <div className={styles.rightPanel}>
           {panelMode === null && (
-            <div className={styles.panelEmpty}>
-              バージョンを選択するか、新規作成してください
-            </div>
+            <div className={styles.panelEmpty}>バージョンを選択するか、新規作成してください</div>
           )}
 
           {panelMode?.type === "new" && (
@@ -889,9 +833,7 @@ export function PromptsPage() {
 
           {panelMode?.type === "edit" && (
             <>
-              <div className={styles.panelHeaderTitle}>
-                v{panelMode.version.version} を編集
-              </div>
+              <div className={styles.panelHeaderTitle}>v{panelMode.version.version} を編集</div>
               <div className={styles.panelEditorBody}>
                 <PromptEditor
                   version={panelMode.version}

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -26,7 +26,8 @@ function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; 
 
   while (ai < aLines.length || bi < bLines.length) {
     if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      result.push({ type: "same", text: aLines[ai] });
+      // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+      result.push({ type: "same", text: aLines[ai]! });
       ai++;
       bi++;
     } else {
@@ -38,35 +39,43 @@ function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; 
       const lookAhead = Math.min(5, maxLen);
 
       for (let d = 0; d < lookAhead; d++) {
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d])) {
+        // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
+        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d]!)) {
           foundInB = d;
-          foundInA = aRemainder.indexOf(bRemainder[d]);
+          // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
+          foundInA = aRemainder.indexOf(bRemainder[d]!);
           break;
         }
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d])) {
+        // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
+        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d]!)) {
           foundInA = d;
-          foundInB = bRemainder.indexOf(aRemainder[d]);
+          // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
+          foundInB = bRemainder.indexOf(aRemainder[d]!);
           break;
         }
       }
 
       if (foundInA > 0) {
         for (let i = 0; i < foundInA; i++) {
-          result.push({ type: "removed", text: aRemainder[i] });
+          // biome-ignore lint/style/noNonNullAssertion: i < foundInA <= aRemainder.length
+          result.push({ type: "removed", text: aRemainder[i]! });
         }
         ai += foundInA;
       } else if (foundInB > 0) {
         for (let i = 0; i < foundInB; i++) {
-          result.push({ type: "added", text: bRemainder[i] });
+          // biome-ignore lint/style/noNonNullAssertion: i < foundInB <= bRemainder.length
+          result.push({ type: "added", text: bRemainder[i]! });
         }
         bi += foundInB;
       } else {
         if (ai < aLines.length) {
-          result.push({ type: "removed", text: aLines[ai] });
+          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+          result.push({ type: "removed", text: aLines[ai]! });
           ai++;
         }
         if (bi < bLines.length) {
-          result.push({ type: "added", text: bLines[bi] });
+          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
+          result.push({ type: "added", text: bLines[bi]! });
           bi++;
         }
       }
@@ -84,7 +93,13 @@ type RunCompareViewProps = {
   onClose: () => void;
 };
 
-function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClose }: RunCompareViewProps) {
+function RunCompareView({
+  runA,
+  runB,
+  versionLabelA,
+  versionLabelB,
+  onClose,
+}: RunCompareViewProps) {
   const [mode, setMode] = useState<"side-by-side" | "unified">("side-by-side");
 
   const lastAssistantA =
@@ -142,8 +157,12 @@ function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClose }: R
                       }`}
                       className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
                     >
-                      <span className={styles.bubbleRole}>{msg.role === "user" ? "User" : "Assistant"}</span>
-                      <div className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}>
+                      <span className={styles.bubbleRole}>
+                        {msg.role === "user" ? "User" : "Assistant"}
+                      </span>
+                      <div
+                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                      >
                         {msg.content}
                       </div>
                     </div>
@@ -164,8 +183,12 @@ function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClose }: R
                       }`}
                       className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
                     >
-                      <span className={styles.bubbleRole}>{msg.role === "user" ? "User" : "Assistant"}</span>
-                      <div className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}>
+                      <span className={styles.bubbleRole}>
+                        {msg.role === "user" ? "User" : "Assistant"}
+                      </span>
+                      <div
+                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                      >
                         {msg.content}
                       </div>
                     </div>
@@ -322,7 +345,9 @@ function RunCard({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className={`${styles.runCard} ${run.is_best ? styles.runCardBest : ""} ${isCompareSelected ? styles.runCardCompareSelected : ""}`}>
+    <div
+      className={`${styles.runCard} ${run.is_best ? styles.runCardBest : ""} ${isCompareSelected ? styles.runCardCompareSelected : ""}`}
+    >
       <div className={styles.runCardTop}>
         <div className={styles.runCardHeader}>
           <span className={styles.runId}>Run #{run.id}</span>
@@ -355,10 +380,7 @@ function RunCard({
               {isCompareSelected ? "比較解除" : "比較"}
             </button>
           )}
-          <Link
-            to={`/projects/${projectId}/score`}
-            className={styles.btnScore}
-          >
+          <Link to={`/projects/${projectId}/score`} className={styles.btnScore}>
             採点
           </Link>
           <button
@@ -476,8 +498,7 @@ export function RunsPage() {
   });
 
   const setBestMutation = useMutation({
-    mutationFn: ({ id, unset }: { id: number; unset: boolean }) =>
-      setBestRun(projectId, id, unset),
+    mutationFn: ({ id, unset }: { id: number; unset: boolean }) => setBestRun(projectId, id, unset),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["runs", projectId] });
     },
@@ -846,7 +867,10 @@ export function RunsPage() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => { setCompareRunA(null); setCompareRunB(null); }}
+                    onClick={() => {
+                      setCompareRunA(null);
+                      setCompareRunB(null);
+                    }}
                     className={styles.btnClearCompare}
                   >
                     クリア

--- a/packages/ui/src/pages/ScoreProgressionPage.module.css
+++ b/packages/ui/src/pages/ScoreProgressionPage.module.css
@@ -1,0 +1,263 @@
+/* ==================== Root ==================== */
+.root {
+  --c-bg: #1e1e2e;
+  --c-text: #cdd6f4;
+  --c-subtext: #a6adc8;
+  --c-accent: #cba6f7;
+  --c-border: #313244;
+  --c-card: #181825;
+  --c-overlay: #313244;
+  --c-surface: #45475a;
+  --c-green: #a6e3a1;
+  --c-yellow: #f9e2af;
+  --c-danger: #f38ba8;
+
+  color: var(--c-text);
+}
+
+/* ==================== Page header ==================== */
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 32px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.pageTitle {
+  margin: 0 0 4px;
+  font-size: 20px;
+  color: var(--c-text);
+}
+
+.projectName {
+  margin: 0;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+/* ==================== Score type switcher ==================== */
+.scoreTypeSwitcher {
+  display: flex;
+  gap: 4px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.switcherBtn {
+  padding: 6px 16px;
+  font-size: 13px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--c-subtext);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.switcherBtn:hover:not(.switcherBtnDisabled) {
+  background: var(--c-overlay);
+  color: var(--c-text);
+}
+
+.switcherBtnActive {
+  background: var(--c-accent);
+  color: #1e1e2e;
+  font-weight: 600;
+}
+
+.switcherBtnActive:hover {
+  background: var(--c-accent);
+  color: #1e1e2e;
+}
+
+.switcherBtnDisabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ==================== Section ==================== */
+.section {
+  margin-bottom: 40px;
+}
+
+.sectionTitle {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--c-text);
+}
+
+.sectionDesc {
+  margin: 0 0 16px;
+  font-size: 13px;
+  color: var(--c-subtext);
+}
+
+/* ==================== Chart ==================== */
+.chartWrapper {
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 24px 16px 16px;
+}
+
+.chartEmpty {
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+/* ==================== Table ==================== */
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid var(--c-border);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  background: var(--c-card);
+}
+
+.th {
+  padding: 10px 16px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--c-subtext);
+  background: var(--c-overlay);
+  border-bottom: 1px solid var(--c-border);
+  white-space: nowrap;
+}
+
+.thNumber {
+  text-align: center;
+}
+
+.thVersionName {
+  display: block;
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--c-subtext);
+  margin-top: 2px;
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tr {
+  border-bottom: 1px solid var(--c-border);
+}
+
+.tr:last-child {
+  border-bottom: none;
+}
+
+.tr:hover {
+  background: color-mix(in srgb, var(--c-accent) 5%, transparent);
+}
+
+.td {
+  padding: 10px 16px;
+  color: var(--c-text);
+  vertical-align: middle;
+}
+
+.tdNumber {
+  text-align: center;
+}
+
+/* ==================== Version / TestCase labels ==================== */
+.versionNum {
+  font-weight: 600;
+  color: var(--c-accent);
+  font-size: 13px;
+}
+
+.versionName {
+  font-size: 13px;
+  color: var(--c-subtext);
+}
+
+.testCaseTitle {
+  font-size: 13px;
+  color: var(--c-text);
+}
+
+/* ==================== Score badge ==================== */
+.scoreBadge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  min-width: 40px;
+  text-align: center;
+}
+
+.scoreBadgeEmpty {
+  display: inline-block;
+  padding: 2px 10px;
+  font-size: 12px;
+  color: var(--c-surface);
+  min-width: 40px;
+  text-align: center;
+}
+
+.scoreBadgeHigh {
+  background: color-mix(in srgb, var(--c-green) 20%, transparent);
+  color: var(--c-green);
+  border: 1px solid color-mix(in srgb, var(--c-green) 40%, transparent);
+}
+
+.scoreBadgeMid {
+  background: color-mix(in srgb, var(--c-yellow) 20%, transparent);
+  color: var(--c-yellow);
+  border: 1px solid color-mix(in srgb, var(--c-yellow) 40%, transparent);
+}
+
+.scoreBadgeLow {
+  background: color-mix(in srgb, var(--c-danger) 20%, transparent);
+  color: var(--c-danger);
+  border: 1px solid color-mix(in srgb, var(--c-danger) 40%, transparent);
+}
+
+/* ==================== Status messages ==================== */
+.loadingMsg {
+  color: var(--c-subtext);
+  font-size: 14px;
+  padding: 32px;
+  text-align: center;
+}
+
+.errorMsg {
+  color: var(--c-danger);
+  font-size: 14px;
+  padding: 32px;
+  text-align: center;
+}
+
+.emptyMsg {
+  color: var(--c-subtext);
+  font-size: 14px;
+  padding: 48px;
+  text-align: center;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+}

--- a/packages/ui/src/pages/ScoreProgressionPage.tsx
+++ b/packages/ui/src/pages/ScoreProgressionPage.tsx
@@ -1,0 +1,352 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useParams } from "react-router";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { type VersionSummary, getProject, getScoreProgression } from "../lib/api";
+import styles from "./ScoreProgressionPage.module.css";
+
+type ScoreType = "human" | "judge";
+
+/** Get version label for display */
+function versionLabel(versionNumber: number, versionName: string | null): string {
+  return versionName ? `v${versionNumber} - ${versionName}` : `v${versionNumber}`;
+}
+
+/** Short version label for chart axis */
+function shortVersionLabel(versionNumber: number): string {
+  return `v${versionNumber}`;
+}
+
+// --------------- ScoreBadge ---------------
+function ScoreBadge({ score, max = 5 }: { score: number | null; max?: number }) {
+  if (score === null) {
+    return <span className={styles.scoreBadgeEmpty}>—</span>;
+  }
+
+  // Normalize to 0-100 range for color calculation
+  const normalized = (score / max) * 100;
+  const level = normalized >= 80 ? "high" : normalized >= 50 ? "mid" : "low";
+
+  return (
+    <span
+      className={`${styles.scoreBadge} ${styles[`scoreBadge${level.charAt(0).toUpperCase()}${level.slice(1)}`]}`}
+    >
+      {score.toFixed(1)}
+    </span>
+  );
+}
+
+// --------------- VersionSummaryTable ---------------
+function VersionSummaryTable({
+  summaries,
+  scoreType,
+}: {
+  summaries: VersionSummary[];
+  scoreType: ScoreType;
+}) {
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}>Version</th>
+            <th className={styles.th}>Name</th>
+            <th className={`${styles.th} ${styles.thNumber}`}>Avg Score</th>
+            <th className={`${styles.th} ${styles.thNumber}`}>Runs</th>
+            <th className={`${styles.th} ${styles.thNumber}`}>Scored</th>
+          </tr>
+        </thead>
+        <tbody>
+          {summaries.map((v) => {
+            const avg = scoreType === "human" ? v.avgHumanScore : v.avgJudgeScore;
+            return (
+              <tr key={v.versionId} className={styles.tr}>
+                <td className={styles.td}>
+                  <span className={styles.versionNum}>v{v.versionNumber}</span>
+                </td>
+                <td className={styles.td}>
+                  <span className={styles.versionName}>{v.versionName ?? "—"}</span>
+                </td>
+                <td className={`${styles.td} ${styles.tdNumber}`}>
+                  <ScoreBadge score={avg} />
+                </td>
+                <td className={`${styles.td} ${styles.tdNumber}`}>{v.runCount}</td>
+                <td className={`${styles.td} ${styles.tdNumber}`}>{v.scoredCount}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// --------------- ScoreProgressionChart ---------------
+function ScoreProgressionChart({
+  summaries,
+  scoreType,
+}: {
+  summaries: VersionSummary[];
+  scoreType: ScoreType;
+}) {
+  const chartData = summaries.map((v) => ({
+    name: shortVersionLabel(v.versionNumber),
+    label: versionLabel(v.versionNumber, v.versionName),
+    score: scoreType === "human" ? v.avgHumanScore : v.avgJudgeScore,
+    runCount: v.runCount,
+    scoredCount: v.scoredCount,
+  }));
+
+  const hasData = chartData.some((d) => d.score !== null);
+
+  if (!hasData) {
+    return (
+      <div className={styles.chartEmpty}>
+        No scored runs yet. Score some runs to see the progression chart.
+      </div>
+    );
+  }
+
+  const scoreLabel = scoreType === "human" ? "Human Score" : "Judge Score";
+
+  return (
+    <div className={styles.chartWrapper}>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData} margin={{ top: 8, right: 24, left: 0, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--c-border)" />
+          <XAxis
+            dataKey="name"
+            tick={{ fill: "var(--c-subtext)", fontSize: 12 }}
+            axisLine={{ stroke: "var(--c-border)" }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 5]}
+            tick={{ fill: "var(--c-subtext)", fontSize: 12 }}
+            axisLine={{ stroke: "var(--c-border)" }}
+            tickLine={false}
+            width={32}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "var(--c-overlay)",
+              border: "1px solid var(--c-border)",
+              borderRadius: "8px",
+              fontSize: "13px",
+              color: "var(--c-text)",
+            }}
+            formatter={(value, _name, item) => {
+              const entryPayload = item?.payload as { scoredCount?: number } | undefined;
+              const displayValue = typeof value === "number" ? value.toFixed(1) : "—";
+              const detail =
+                entryPayload?.scoredCount !== undefined
+                  ? ` (${entryPayload.scoredCount} scored)`
+                  : "";
+              return [`${displayValue}${detail}`, scoreLabel] as [string, string];
+            }}
+            labelFormatter={(_label, payload) => {
+              type ChartPayload = { payload?: { label?: string } };
+              const item = (payload as unknown as ChartPayload[])[0];
+              return item?.payload?.label ?? String(_label);
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: "13px", color: "var(--c-subtext)" }} />
+          <Line
+            type="monotone"
+            dataKey="score"
+            name={scoreLabel}
+            stroke="var(--c-accent)"
+            strokeWidth={2}
+            dot={{ r: 5, fill: "var(--c-accent)", strokeWidth: 0 }}
+            activeDot={{ r: 7 }}
+            connectNulls={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// --------------- TestCaseBreakdownTable ---------------
+type TestCaseBreakdown = {
+  testCaseId: number;
+  testCaseTitle: string;
+  versions: {
+    versionId: number;
+    versionNumber: number;
+    versionName: string | null;
+    humanScore: number | null;
+    judgeScore: number | null;
+    runId: number | null;
+  }[];
+};
+
+function TestCaseBreakdownTable({
+  breakdowns,
+  summaries,
+  scoreType,
+}: {
+  breakdowns: TestCaseBreakdown[];
+  summaries: VersionSummary[];
+  scoreType: ScoreType;
+}) {
+  if (breakdowns.length === 0) {
+    return <div className={styles.emptyMsg}>No test cases found for this project.</div>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}>Test Case</th>
+            {summaries.map((v) => (
+              <th key={v.versionId} className={`${styles.th} ${styles.thNumber}`}>
+                <span className={styles.versionNum}>v{v.versionNumber}</span>
+                {v.versionName && <span className={styles.thVersionName}>{v.versionName}</span>}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {breakdowns.map((tc) => (
+            <tr key={tc.testCaseId} className={styles.tr}>
+              <td className={styles.td}>
+                <span className={styles.testCaseTitle}>{tc.testCaseTitle}</span>
+              </td>
+              {summaries.map((v) => {
+                const cell = tc.versions.find((tv) => tv.versionId === v.versionId);
+                const score = cell
+                  ? scoreType === "human"
+                    ? cell.humanScore
+                    : cell.judgeScore
+                  : null;
+                return (
+                  <td key={v.versionId} className={`${styles.td} ${styles.tdNumber}`}>
+                    <ScoreBadge score={score} />
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// --------------- ScoreProgressionPage ---------------
+export function ScoreProgressionPage() {
+  const { id } = useParams<{ id: string }>();
+  const projectId = Number(id);
+  const [scoreType, setScoreType] = useState<ScoreType>("human");
+
+  const { data: project } = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => getProject(projectId),
+    enabled: !Number.isNaN(projectId),
+  });
+
+  const {
+    data: progression,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["score-progression", projectId],
+    queryFn: () => getScoreProgression(projectId),
+    enabled: !Number.isNaN(projectId),
+    staleTime: 1000 * 30,
+  });
+
+  const summaries = progression?.versionSummaries ?? [];
+  const breakdowns = progression?.testCaseBreakdown ?? [];
+
+  const hasJudgeScores = summaries.some((v) => v.avgJudgeScore !== null);
+
+  return (
+    <div className={styles.root}>
+      {/* Page header */}
+      <div className={styles.pageHeader}>
+        <div>
+          <h2 className={styles.pageTitle}>Score Progression</h2>
+          {project && <p className={styles.projectName}>{project.name}</p>}
+        </div>
+
+        {/* Score type switcher */}
+        <div className={styles.scoreTypeSwitcher}>
+          <button
+            type="button"
+            className={`${styles.switcherBtn} ${scoreType === "human" ? styles.switcherBtnActive : ""}`}
+            onClick={() => setScoreType("human")}
+          >
+            Human Score
+          </button>
+          <button
+            type="button"
+            className={`${styles.switcherBtn} ${scoreType === "judge" ? styles.switcherBtnActive : ""} ${!hasJudgeScores ? styles.switcherBtnDisabled : ""}`}
+            onClick={() => {
+              if (hasJudgeScores) setScoreType("judge");
+            }}
+            title={!hasJudgeScores ? "No Judge scores available yet" : undefined}
+          >
+            Judge Score
+          </button>
+        </div>
+      </div>
+
+      {isLoading && <p className={styles.loadingMsg}>Loading...</p>}
+      {isError && <p className={styles.errorMsg}>Failed to load score data. Please try again.</p>}
+
+      {!isLoading && !isError && summaries.length === 0 && (
+        <div className={styles.emptyMsg}>
+          No prompt versions found. Create some prompt versions and runs to see score progression.
+        </div>
+      )}
+
+      {!isLoading && !isError && summaries.length > 0 && (
+        <>
+          {/* Section: Score progression chart */}
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Score Trend</h3>
+            <p className={styles.sectionDesc}>
+              Average {scoreType === "human" ? "human" : "judge"} score per version
+            </p>
+            <ScoreProgressionChart summaries={summaries} scoreType={scoreType} />
+          </section>
+
+          {/* Section: Version summary table */}
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Version Summary</h3>
+            <p className={styles.sectionDesc}>
+              Aggregated scores across all test cases per version
+            </p>
+            <VersionSummaryTable summaries={summaries} scoreType={scoreType} />
+          </section>
+
+          {/* Section: Per-test-case breakdown table */}
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Test Case Breakdown</h3>
+            <p className={styles.sectionDesc}>
+              {scoreType === "human" ? "Human" : "Judge"} score per test case and version (best run
+              preferred)
+            </p>
+            <TestCaseBreakdownTable
+              breakdowns={breakdowns}
+              summaries={summaries}
+              scoreType={scoreType}
+            />
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       react-router:
         specifier: ^7.1.1
         version: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.5)(react@18.3.1)(redux@5.0.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.12
@@ -1084,6 +1087,17 @@ packages:
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1225,6 +1239,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@tanstack/query-core@5.97.0':
     resolution: {integrity: sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==}
 
@@ -1248,6 +1268,33 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1264,6 +1311,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1370,6 +1420,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1395,6 +1449,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1407,6 +1505,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1540,6 +1641,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -1576,6 +1680,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1643,11 +1750,21 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1779,6 +1896,21 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@19.2.5:
+    resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1801,9 +1933,28 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1894,6 +2045,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1948,8 +2102,16 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2729,6 +2891,18 @@ snapshots:
 
   '@petamoriken/float16@3.9.3': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -2806,6 +2980,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
   '@tanstack/query-core@5.97.0': {}
 
   '@tanstack/react-query@5.97.0(react@18.3.1)':
@@ -2838,6 +3016,30 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@25.5.2':
@@ -2854,6 +3056,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2981,6 +3185,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3009,12 +3215,52 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1:
     optional: true
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -3057,6 +3303,8 @@ snapshots:
   env-paths@3.0.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.45.1: {}
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -3206,6 +3454,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventemitter3@5.0.4: {}
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
@@ -3259,9 +3509,15 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  internmap@2.0.3: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -3393,6 +3649,17 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@19.2.5: {}
+
+  react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -3413,7 +3680,35 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  recharts@3.8.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.5)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 19.2.5
+      react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-directory@2.1.1: {}
+
+  reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3528,6 +3823,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3571,7 +3868,28 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@2.1.9(@types/node@25.5.2):
     dependencies:


### PR DESCRIPTION
## Summary

- `GET /api/projects/:projectId/score-progression` エンドポイントを新規追加
  - 全バージョンの平均スコアサマリー（グラフ用）
  - テストケース別スコア内訳（表示用、ベストRunを優先）
- 新規ページ `ScoreProgressionPage` を `/projects/:id/score-progression` に追加
  - 折れ線グラフ（Recharts）でバージョンごとのスコア推移を可視化
  - バージョンサマリーテーブル（平均スコア・Run数・採点数）
  - テストケース別スコア内訳テーブル（バージョン×テストケースのマトリックス）
  - Human Score / Judge Score の切り替えスイッチャー
- サイドナビに「スコア推移」リンクを追加
- `PromptsPage.tsx` と `RunsPage.tsx` の既存TypeScriptエラーを合わせて修正

## Test plan

- [ ] スコア推移ページ（`/projects/:id/score-progression`）が表示されること
- [ ] スコアなしの場合はグラフが「No scored runs yet」メッセージを表示すること
- [ ] スコアありの場合は折れ線グラフにデータが表示されること
- [ ] バージョンサマリーテーブルに全バージョンの平均スコアが表示されること
- [ ] テストケース別内訳テーブルがバージョン×テストケースのマトリックスで表示されること
- [ ] Human Score / Judge Score の切り替えが正常に動作すること
- [ ] Judge Scoreがない場合は切り替えボタンが非活性になること
- [ ] `pnpm run check` が通ること
- [ ] `pnpm --filter @prompt-reviewer/ui run typecheck` が通ること

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)