### PR TITLE
feat(core): Anthropic API クライアントを実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Server
 PORT=3001
 DB_PATH=./data/prompt-reviewer.db
+ANTHROPIC_API_KEY=
 
 # UI (Vite)
 VITE_API_BASE_URL=http://localhost:3001

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "seed": "tsx src/seed.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.61.0",
     "better-sqlite3": "^12.0.0",
     "drizzle-orm": "^0.44.0"
   },

--- a/packages/core/src/__test-stubs__/index.ts
+++ b/packages/core/src/__test-stubs__/index.ts
@@ -5,6 +5,7 @@
  * ネイティブバイナリのビルドエラーを回避する。
  */
 export * from "../schema/index.js";
+export * from "../llm/index.js";
 
 // DB型のみエクスポート（実際のDBインスタンスは含まない）
 export type { DB } from "../db/client.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,6 @@
  * スキーマ型定義とDBクライアントをエクスポートする
  */
 export * from "./schema/index";
+export * from "./llm/index.js";
 export { db } from "./db/client";
 export type { DB } from "./db/client";

--- a/packages/core/src/llm/anthropic.test.ts
+++ b/packages/core/src/llm/anthropic.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicLLMClient } from "./anthropic.js";
+import { LLMAuthenticationError, LLMConfigurationError } from "./errors.js";
+
+describe("AnthropicLLMClient", () => {
+  it("sendMessage で Messages API を呼び出して応答を正規化する", async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "こんにちは" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 12,
+        output_tokens: 34,
+      },
+    });
+
+    const client = new AnthropicLLMClient({
+      apiKey: "test-key",
+      clientFactory: async () => ({
+        messages: {
+          create,
+        },
+      }),
+    });
+
+    const response = await client.sendMessage({
+      model: "claude-sonnet-4-5",
+      systemPrompt: "You are helpful",
+      temperature: 0.4,
+      maxTokens: 256,
+      messages: [{ role: "user", content: "こんにちは" }],
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      model: "claude-sonnet-4-5",
+      system: "You are helpful",
+      temperature: 0.4,
+      max_tokens: 256,
+      messages: [{ role: "user", content: "こんにちは" }],
+    });
+    expect(response).toEqual({
+      content: "こんにちは",
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 34,
+      },
+      raw: {
+        content: [{ type: "text", text: "こんにちは" }],
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 12,
+          output_tokens: 34,
+        },
+      },
+    });
+  });
+
+  it("stream で text delta と最終 response を返す", async () => {
+    async function* createStream() {
+      yield {
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 9,
+            output_tokens: 0,
+          },
+        },
+      };
+      yield {
+        type: "content_block_delta",
+        delta: {
+          type: "text_delta",
+          text: "こん",
+        },
+      };
+      yield {
+        type: "content_block_delta",
+        delta: {
+          type: "text_delta",
+          text: "にちは",
+        },
+      };
+      yield {
+        type: "message_delta",
+        delta: {
+          stop_reason: "end_turn",
+        },
+        usage: {
+          input_tokens: 9,
+          output_tokens: 5,
+        },
+      };
+    }
+
+    const create = vi.fn().mockResolvedValue(createStream());
+    const client = new AnthropicLLMClient({
+      apiKey: "test-key",
+      clientFactory: async () => ({
+        messages: {
+          create,
+        },
+      }),
+    });
+
+    const events = [];
+    for await (const event of client.stream({
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "こんにちは" }],
+    })) {
+      events.push(event);
+    }
+
+    expect(create).toHaveBeenCalledWith({
+      model: "claude-sonnet-4-5",
+      system: undefined,
+      temperature: undefined,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "こんにちは" }],
+      stream: true,
+    });
+    expect(events).toEqual([
+      {
+        type: "text-delta",
+        text: "こん",
+      },
+      {
+        type: "text-delta",
+        text: "にちは",
+      },
+      {
+        type: "response",
+        response: {
+          content: "こんにちは",
+          stopReason: "end_turn",
+          usage: {
+            inputTokens: 9,
+            outputTokens: 5,
+          },
+          raw: {
+            content: "こんにちは",
+            stopReason: "end_turn",
+            usage: {
+              inputTokens: 9,
+              outputTokens: 5,
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("API キー未設定時は設定エラーを返す", async () => {
+    const client = new AnthropicLLMClient({
+      apiKeyEnvVar: "TEST_ANTHROPIC_API_KEY",
+    });
+
+    await expect(
+      client.sendMessage({
+        model: "claude-sonnet-4-5",
+        messages: [{ role: "user", content: "こんにちは" }],
+      }),
+    ).rejects.toBeInstanceOf(LLMConfigurationError);
+  });
+
+  it("401/403 を認証エラーに正規化する", async () => {
+    const client = new AnthropicLLMClient({
+      apiKey: "invalid-key",
+      clientFactory: async () => ({
+        messages: {
+          create: vi.fn().mockRejectedValue({
+            status: 401,
+          }),
+        },
+      }),
+    });
+
+    await expect(
+      client.sendMessage({
+        model: "claude-sonnet-4-5",
+        messages: [{ role: "user", content: "こんにちは" }],
+      }),
+    ).rejects.toBeInstanceOf(LLMAuthenticationError);
+  });
+});

--- a/packages/core/src/llm/anthropic.test.ts
+++ b/packages/core/src/llm/anthropic.test.ts
@@ -19,6 +19,9 @@ describe("AnthropicLLMClient", () => {
         messages: {
           create,
         },
+        models: {
+          list: vi.fn(),
+        },
       }),
     });
 
@@ -99,6 +102,9 @@ describe("AnthropicLLMClient", () => {
         messages: {
           create,
         },
+        models: {
+          list: vi.fn(),
+        },
       }),
     });
 
@@ -162,6 +168,49 @@ describe("AnthropicLLMClient", () => {
     ).rejects.toBeInstanceOf(LLMConfigurationError);
   });
 
+  it("listModels で Models API の候補を正規化する", async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "claude-sonnet-4-5-20250929",
+          display_name: "Claude Sonnet 4.5",
+          created_at: "2025-09-29T00:00:00Z",
+          type: "model",
+        },
+        {
+          display_name: "IDなしは無視",
+        },
+      ],
+    });
+
+    const client = new AnthropicLLMClient({
+      apiKey: "test-key",
+      clientFactory: async () => ({
+        messages: {
+          create: vi.fn(),
+        },
+        models: {
+          list,
+        },
+      }),
+    });
+
+    await expect(client.listModels()).resolves.toEqual([
+      {
+        id: "claude-sonnet-4-5-20250929",
+        displayName: "Claude Sonnet 4.5",
+        createdAt: "2025-09-29T00:00:00Z",
+        raw: {
+          id: "claude-sonnet-4-5-20250929",
+          display_name: "Claude Sonnet 4.5",
+          created_at: "2025-09-29T00:00:00Z",
+          type: "model",
+        },
+      },
+    ]);
+    expect(list).toHaveBeenCalledWith();
+  });
+
   it("401/403 を認証エラーに正規化する", async () => {
     const client = new AnthropicLLMClient({
       apiKey: "invalid-key",
@@ -170,6 +219,9 @@ describe("AnthropicLLMClient", () => {
           create: vi.fn().mockRejectedValue({
             status: 401,
           }),
+        },
+        models: {
+          list: vi.fn(),
         },
       }),
     });

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -1,0 +1,244 @@
+import { LLMAuthenticationError, LLMConfigurationError } from "./errors.js";
+import type { LLMClient, LLMRequest, LLMResponse, LLMStreamEvent, LLMUsage } from "./types.js";
+
+type AnthropicTextBlock = {
+  type: "text";
+  text: string;
+};
+
+type AnthropicUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+};
+
+type AnthropicMessageResponse = {
+  content?: Array<AnthropicTextBlock | { type: string }>;
+  stop_reason?: string | null;
+  usage?: AnthropicUsage;
+};
+
+type AnthropicStreamEventShape = {
+  type: string;
+  delta?: {
+    type?: string;
+    text?: string;
+    stop_reason?: string | null;
+  };
+  usage?: AnthropicUsage;
+  message?: {
+    usage?: AnthropicUsage;
+  };
+};
+
+type AnthropicMessagesAPI = {
+  create(params: Record<string, unknown>): Promise<unknown>;
+};
+
+type AnthropicSDKClient = {
+  messages: AnthropicMessagesAPI;
+};
+
+type AnthropicClientFactory = (apiKey: string) => Promise<AnthropicSDKClient> | AnthropicSDKClient;
+
+export type AnthropicLLMClientOptions = {
+  apiKey?: string;
+  apiKeyEnvVar?: string;
+  defaultMaxTokens?: number;
+  clientFactory?: AnthropicClientFactory;
+};
+
+const DEFAULT_ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
+const DEFAULT_MAX_TOKENS = 1024;
+
+export class AnthropicLLMClient implements LLMClient {
+  private readonly apiKey: string | undefined;
+  private readonly apiKeyEnvVar: string;
+  private readonly defaultMaxTokens: number;
+  private readonly clientFactory: AnthropicClientFactory;
+  private clientPromise?: Promise<AnthropicSDKClient>;
+
+  constructor(options: AnthropicLLMClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.apiKeyEnvVar = options.apiKeyEnvVar ?? DEFAULT_ANTHROPIC_API_KEY_ENV;
+    this.defaultMaxTokens = options.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    this.clientFactory = options.clientFactory ?? createAnthropicSdkClient;
+  }
+
+  async sendMessage(request: LLMRequest): Promise<LLMResponse> {
+    try {
+      const client = await this.getClient();
+      const response = (await client.messages.create(
+        this.buildMessageParams(request),
+      )) as AnthropicMessageResponse;
+
+      return buildLLMResponse({
+        content: extractTextContent(response.content),
+        stopReason: response.stop_reason ?? null,
+        usage: mapUsage(response.usage),
+        raw: response,
+      });
+    } catch (error) {
+      throw normalizeAnthropicError(error, this.apiKeyEnvVar);
+    }
+  }
+
+  async *stream(request: LLMRequest): AsyncIterable<LLMStreamEvent> {
+    try {
+      const client = await this.getClient();
+      const stream = (await client.messages.create({
+        ...this.buildMessageParams(request),
+        stream: true,
+      })) as AsyncIterable<AnthropicStreamEventShape>;
+
+      let content = "";
+      let stopReason: string | null = null;
+      let usage: LLMUsage | undefined;
+
+      for await (const event of stream) {
+        if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+          const text = event.delta.text ?? "";
+          if (text.length > 0) {
+            content += text;
+            yield {
+              type: "text-delta",
+              text,
+            };
+          }
+        }
+
+        if (event.type === "message_delta") {
+          stopReason = event.delta?.stop_reason ?? stopReason;
+          usage = mapUsage(event.usage) ?? usage;
+        }
+
+        if (event.type === "message_start") {
+          usage = mapUsage(event.message?.usage) ?? usage;
+        }
+      }
+
+      yield {
+        type: "response",
+        response: buildLLMResponse({
+          content,
+          stopReason,
+          usage,
+          raw: {
+            content,
+            stopReason,
+            usage,
+          },
+        }),
+      };
+    } catch (error) {
+      throw normalizeAnthropicError(error, this.apiKeyEnvVar);
+    }
+  }
+
+  private async getClient(): Promise<AnthropicSDKClient> {
+    if (!this.clientPromise) {
+      const apiKey = this.resolveApiKey();
+      this.clientPromise = Promise.resolve(this.clientFactory(apiKey));
+    }
+
+    return this.clientPromise;
+  }
+
+  private resolveApiKey(): string {
+    const apiKey = this.apiKey ?? process.env[this.apiKeyEnvVar];
+
+    if (!apiKey) {
+      throw new LLMConfigurationError(
+        `${this.apiKeyEnvVar} is not set. Configure an Anthropic API key before using LLM features.`,
+      );
+    }
+
+    return apiKey;
+  }
+
+  private buildMessageParams(request: LLMRequest): Record<string, unknown> {
+    return {
+      model: request.model,
+      messages: request.messages.map((message) => ({
+        role: message.role,
+        content: message.content,
+      })),
+      system: request.systemPrompt,
+      temperature: request.temperature,
+      max_tokens: request.maxTokens ?? this.defaultMaxTokens,
+    };
+  }
+}
+
+function extractTextContent(content: AnthropicMessageResponse["content"]): string {
+  if (!content) {
+    return "";
+  }
+
+  return content.flatMap((block) => (isAnthropicTextBlock(block) ? [block.text] : [])).join("");
+}
+
+function mapUsage(usage?: AnthropicUsage): LLMUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
+
+  return {
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+  };
+}
+
+function buildLLMResponse(params: {
+  content: string;
+  stopReason: string | null;
+  usage: LLMUsage | undefined;
+  raw: unknown;
+}): LLMResponse {
+  return {
+    content: params.content,
+    stopReason: params.stopReason,
+    raw: params.raw,
+    ...(params.usage ? { usage: params.usage } : {}),
+  };
+}
+
+function normalizeAnthropicError(error: unknown, apiKeyEnvVar: string): Error {
+  if (error instanceof LLMConfigurationError || error instanceof LLMAuthenticationError) {
+    return error;
+  }
+
+  if (isAnthropicAuthError(error)) {
+    return new LLMAuthenticationError(
+      `Anthropic API authentication failed. Check ${apiKeyEnvVar} and account permissions.`,
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error("Unknown Anthropic API error");
+}
+
+function isAnthropicTextBlock(
+  block: AnthropicTextBlock | { type: string },
+): block is AnthropicTextBlock {
+  return block.type === "text";
+}
+
+function isAnthropicAuthError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const maybeStatus = "status" in error ? error.status : undefined;
+  return maybeStatus === 401 || maybeStatus === 403;
+}
+
+async function createAnthropicSdkClient(apiKey: string): Promise<AnthropicSDKClient> {
+  const loadModule = new Function("return import('@anthropic-ai/sdk')") as () => Promise<{
+    default: new (options: { apiKey: string }) => AnthropicSDKClient;
+  }>;
+  const { default: Anthropic } = await loadModule();
+  return new Anthropic({ apiKey });
+}

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -1,5 +1,13 @@
 import { LLMAuthenticationError, LLMConfigurationError } from "./errors.js";
-import type { LLMClient, LLMRequest, LLMResponse, LLMStreamEvent, LLMUsage } from "./types.js";
+import type {
+  LLMClient,
+  LLMModel,
+  LLMModelClient,
+  LLMRequest,
+  LLMResponse,
+  LLMStreamEvent,
+  LLMUsage,
+} from "./types.js";
 
 type AnthropicTextBlock = {
   type: "text";
@@ -15,6 +23,16 @@ type AnthropicMessageResponse = {
   content?: Array<AnthropicTextBlock | { type: string }>;
   stop_reason?: string | null;
   usage?: AnthropicUsage;
+};
+
+type AnthropicModelInfo = {
+  id?: string;
+  display_name?: string;
+  created_at?: string;
+};
+
+type AnthropicModelListResponse = {
+  data?: AnthropicModelInfo[];
 };
 
 type AnthropicStreamEventShape = {
@@ -34,8 +52,13 @@ type AnthropicMessagesAPI = {
   create(params: Record<string, unknown>): Promise<unknown>;
 };
 
+type AnthropicModelsAPI = {
+  list(params?: Record<string, unknown>): Promise<unknown> | unknown;
+};
+
 type AnthropicSDKClient = {
   messages: AnthropicMessagesAPI;
+  models: AnthropicModelsAPI;
 };
 
 type AnthropicClientFactory = (apiKey: string) => Promise<AnthropicSDKClient> | AnthropicSDKClient;
@@ -50,7 +73,7 @@ export type AnthropicLLMClientOptions = {
 const DEFAULT_ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
 const DEFAULT_MAX_TOKENS = 1024;
 
-export class AnthropicLLMClient implements LLMClient {
+export class AnthropicLLMClient implements LLMClient, LLMModelClient {
   private readonly apiKey: string | undefined;
   private readonly apiKeyEnvVar: string;
   private readonly defaultMaxTokens: number;
@@ -76,6 +99,30 @@ export class AnthropicLLMClient implements LLMClient {
         stopReason: response.stop_reason ?? null,
         usage: mapUsage(response.usage),
         raw: response,
+      });
+    } catch (error) {
+      throw normalizeAnthropicError(error, this.apiKeyEnvVar);
+    }
+  }
+
+  async listModels(): Promise<LLMModel[]> {
+    try {
+      const client = await this.getClient();
+      const response = (await client.models.list()) as AnthropicModelListResponse;
+
+      return (response.data ?? []).flatMap((model) => {
+        if (!model.id) {
+          return [];
+        }
+
+        return [
+          {
+            id: model.id,
+            displayName: model.display_name ?? model.id,
+            ...(model.created_at ? { createdAt: model.created_at } : {}),
+            raw: model,
+          },
+        ];
       });
     } catch (error) {
       throw normalizeAnthropicError(error, this.apiKeyEnvVar);

--- a/packages/core/src/llm/errors.ts
+++ b/packages/core/src/llm/errors.ts
@@ -1,0 +1,13 @@
+export class LLMConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LLMConfigurationError";
+  }
+}
+
+export class LLMAuthenticationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LLMAuthenticationError";
+  }
+}

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -1,0 +1,3 @@
+export * from "./anthropic.js";
+export * from "./errors.js";
+export type * from "./types.js";

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -25,6 +25,13 @@ export type LLMResponse = {
   raw: unknown;
 };
 
+export type LLMModel = {
+  id: string;
+  displayName: string;
+  createdAt?: string;
+  raw: unknown;
+};
+
 export type LLMStreamEvent =
   | {
       type: "text-delta";
@@ -38,4 +45,8 @@ export type LLMStreamEvent =
 export interface LLMClient {
   sendMessage(request: LLMRequest): Promise<LLMResponse>;
   stream(request: LLMRequest): AsyncIterable<LLMStreamEvent>;
+}
+
+export interface LLMModelClient {
+  listModels(): Promise<LLMModel[]>;
 }

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -1,0 +1,41 @@
+export type LLMMessageRole = "user" | "assistant";
+
+export type LLMMessage = {
+  role: LLMMessageRole;
+  content: string;
+};
+
+export type LLMRequest = {
+  model: string;
+  messages: LLMMessage[];
+  systemPrompt?: string;
+  temperature?: number;
+  maxTokens?: number;
+};
+
+export type LLMUsage = {
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type LLMResponse = {
+  content: string;
+  stopReason: string | null;
+  usage?: LLMUsage;
+  raw: unknown;
+};
+
+export type LLMStreamEvent =
+  | {
+      type: "text-delta";
+      text: string;
+    }
+  | {
+      type: "response";
+      response: LLMResponse;
+    };
+
+export interface LLMClient {
+  sendMessage(request: LLMRequest): Promise<LLMResponse>;
+  stream(request: LLMRequest): AsyncIterable<LLMStreamEvent>;
+}

--- a/packages/server/src/routes/project-settings.test.ts
+++ b/packages/server/src/routes/project-settings.test.ts
@@ -14,6 +14,7 @@ vi.mock("better-sqlite3", () => {
 });
 
 import type { DB } from "@prompt-reviewer/core";
+import { LLMAuthenticationError } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import { createProjectSettingsRouter } from "./project-settings.js";
@@ -30,11 +31,23 @@ type MockSettings = {
   updated_at: number;
 };
 
+type ModelListClient = {
+  listModels(): Promise<unknown[]>;
+};
+
 // ---- ヘルパー ----
 
-function buildApp(db: unknown) {
+function buildApp(
+  db: unknown,
+  options?: {
+    modelClientFactory?: (body: {
+      api_provider: "anthropic" | "openai";
+      api_key: string;
+    }) => ModelListClient | null;
+  },
+) {
   const app = new Hono();
-  app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db as DB));
+  app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db as DB, options));
   return app;
 }
 
@@ -419,5 +432,105 @@ describe("PUT /api/projects/:projectId/settings", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as MockSettings;
     expect(body.temperature).toBe(2);
+  });
+});
+
+// ---- POST /api/projects/:projectId/settings/models テスト ----
+
+describe("POST /api/projects/:projectId/settings/models", () => {
+  it("Anthropic APIキーで取得したモデル候補を返す", async () => {
+    const listModels = vi.fn().mockResolvedValue([
+      {
+        id: "claude-sonnet-4-5-20250929",
+        displayName: "Claude Sonnet 4.5",
+        createdAt: "2025-09-29T00:00:00Z",
+        raw: { id: "claude-sonnet-4-5-20250929" },
+      },
+    ]);
+    const modelClientFactory = vi.fn().mockReturnValue({ listModels });
+
+    const app = buildApp({}, { modelClientFactory });
+    const res = await app.request("/api/projects/1/settings/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_provider: "anthropic",
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(modelClientFactory).toHaveBeenCalledWith({
+      api_provider: "anthropic",
+      api_key: "sk-ant-test",
+    });
+    expect(listModels).toHaveBeenCalledWith();
+    await expect(res.json()).resolves.toEqual({
+      models: [
+        {
+          id: "claude-sonnet-4-5-20250929",
+          displayName: "Claude Sonnet 4.5",
+          createdAt: "2025-09-29T00:00:00Z",
+          raw: { id: "claude-sonnet-4-5-20250929" },
+        },
+      ],
+    });
+  });
+
+  it("APIキーが空の場合は 400 を返し、モデル取得を呼び出さない", async () => {
+    const modelClientFactory = vi.fn();
+
+    const app = buildApp({}, { modelClientFactory });
+    const res = await app.request("/api/projects/1/settings/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_provider: "anthropic",
+        api_key: "",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(modelClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("未対応プロバイダーの場合は 501 を返す", async () => {
+    const app = buildApp({}, { modelClientFactory: () => null });
+    const res = await app.request("/api/projects/1/settings/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_provider: "openai",
+        api_key: "sk-test",
+      }),
+    });
+
+    expect(res.status).toBe(501);
+    await expect(res.json()).resolves.toEqual({
+      error: "Provider model listing is not implemented",
+    });
+  });
+
+  it("認証エラーの場合は 401 を返す", async () => {
+    const app = buildApp(
+      {},
+      {
+        modelClientFactory: () => ({
+          listModels: vi.fn().mockRejectedValue(new LLMAuthenticationError("invalid api key")),
+        }),
+      },
+    );
+
+    const res = await app.request("/api/projects/1/settings/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_provider: "anthropic",
+        api_key: "invalid",
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "invalid api key" });
   });
 });

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -1,6 +1,11 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { project_settings } from "@prompt-reviewer/core";
+import {
+  AnthropicLLMClient,
+  LLMAuthenticationError,
+  LLMConfigurationError,
+  project_settings,
+} from "@prompt-reviewer/core";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -16,7 +21,31 @@ const upsertSettingsSchema = z.object({
   }),
 });
 
+const listModelsSchema = z.object({
+  api_provider: z.enum(["anthropic", "openai"], {
+    error: 'api_providerは "anthropic" または "openai" である必要があります',
+  }),
+  api_key: z.string().min(1, "api_keyは1文字以上必要です"),
+});
+
 type UpsertBody = z.infer<typeof upsertSettingsSchema>;
+type ListModelsBody = z.infer<typeof listModelsSchema>;
+
+type ModelListClient = {
+  listModels(): Promise<unknown[]>;
+};
+
+type ProjectSettingsRouterOptions = {
+  modelClientFactory?: (body: ListModelsBody) => ModelListClient | null;
+};
+
+function defaultModelClientFactory(body: ListModelsBody): ModelListClient | null {
+  if (body.api_provider === "anthropic") {
+    return new AnthropicLLMClient({ apiKey: body.api_key });
+  }
+
+  return null;
+}
 
 /** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
 function parseIntParam(value: string | undefined): number | null {
@@ -62,8 +91,9 @@ async function createSettings(db: DB, projectId: number, body: UpsertBody, now: 
  * GET /api/projects/:projectId/settings  - 設定取得（存在しなければ404）
  * PUT /api/projects/:projectId/settings  - 設定のupsert（存在しなければ作成、あれば更新）
  */
-export function createProjectSettingsRouter(db: DB) {
+export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRouterOptions = {}) {
   const router = new Hono();
+  const modelClientFactory = options.modelClientFactory ?? defaultModelClientFactory;
 
   // GET /api/projects/:projectId/settings - 設定取得
   router.get("/", async (c) => {
@@ -111,6 +141,30 @@ export function createProjectSettingsRouter(db: DB) {
     const created = await createSettings(db, projectId, body, now);
     if (!created) return c.json({ error: "Failed to create Settings" }, 500);
     return c.json(created, 201);
+  });
+
+  router.post("/models", zValidator("json", listModelsSchema), async (c) => {
+    const body = c.req.valid("json");
+    const client = modelClientFactory(body);
+
+    if (!client) {
+      return c.json({ error: "Provider model listing is not implemented" }, 501);
+    }
+
+    try {
+      const models = await client.listModels();
+      return c.json({ models });
+    } catch (error) {
+      if (error instanceof LLMConfigurationError) {
+        return c.json({ error: error.message }, 400);
+      }
+
+      if (error instanceof LLMAuthenticationError) {
+        return c.json({ error: error.message }, 401);
+      }
+
+      return c.json({ error: "Failed to fetch models" }, 502);
+    }
   });
 
   return router;

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -326,15 +326,30 @@ export type ProjectSettings = {
   updated_at: number;
 };
 
+export type ApiProvider = "anthropic" | "openai";
+
+export type LLMModelOption = {
+  id: string;
+  displayName: string;
+  createdAt?: string;
+};
+
 export function getProjectSettings(projectId: number): Promise<ProjectSettings> {
   return api.get<ProjectSettings>(`/projects/${projectId}/settings`);
 }
 
 export function upsertProjectSettings(
   projectId: number,
-  data: { model: string; temperature: number; api_provider: "anthropic" | "openai" },
+  data: { model: string; temperature: number; api_provider: ApiProvider },
 ): Promise<ProjectSettings> {
   return api.put<ProjectSettings>(`/projects/${projectId}/settings`, data);
+}
+
+export function listProjectSettingsModels(
+  projectId: number,
+  data: { api_provider: ApiProvider; api_key: string },
+): Promise<{ models: LLMModelOption[] }> {
+  return api.post<{ models: LLMModelOption[] }>(`/projects/${projectId}/settings/models`, data);
 }
 
 // Score Progression API

--- a/packages/ui/src/pages/ProjectSettingsPage.module.css
+++ b/packages/ui/src/pages/ProjectSettingsPage.module.css
@@ -131,6 +131,12 @@
   color: var(--c-muted);
 }
 
+.fieldError {
+  margin: 0;
+  font-size: 12px;
+  color: var(--c-red);
+}
+
 /* ==================== API key section ==================== */
 .apiKeyNote {
   margin: 0 0 16px;

--- a/packages/ui/src/pages/ProjectSettingsPage.tsx
+++ b/packages/ui/src/pages/ProjectSettingsPage.tsx
@@ -2,26 +2,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { useApiKey } from "../hooks/useApiKey";
-import { ApiError, getProjectSettings, upsertProjectSettings } from "../lib/api";
+import {
+  type ApiProvider,
+  ApiError,
+  getProjectSettings,
+  listProjectSettingsModels,
+  upsertProjectSettings,
+} from "../lib/api";
 import styles from "./ProjectSettingsPage.module.css";
-
-const ANTHROPIC_MODELS = [
-  { value: "claude-opus-4-6", label: "claude-opus-4-6" },
-  { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
-  { value: "claude-haiku-4-5-20251001", label: "claude-haiku-4-5-20251001" },
-] as const;
-
-const OPENAI_MODELS = [
-  { value: "gpt-4o", label: "gpt-4o" },
-  { value: "gpt-4o-mini", label: "gpt-4o-mini" },
-] as const;
-
-const ALL_MODELS = [...ANTHROPIC_MODELS.map((m) => m.value), ...OPENAI_MODELS.map((m) => m.value)];
-
-function inferProvider(model: string): "anthropic" | "openai" {
-  if (OPENAI_MODELS.some((m) => m.value === model)) return "openai";
-  return "anthropic";
-}
 
 export function ProjectSettingsPage() {
   const { id } = useParams<{ id: string }>();
@@ -31,9 +19,9 @@ export function ProjectSettingsPage() {
   const { apiKey, hasApiKey, setApiKey } = useApiKey(projectId);
   const [apiKeyInput, setApiKeyInput] = useState(apiKey);
 
-  const [model, setModel] = useState("claude-opus-4-6");
+  const [model, setModel] = useState("");
   const [temperature, setTemperature] = useState(0.7);
-  const [apiProvider, setApiProvider] = useState<"anthropic" | "openai">("anthropic");
+  const [apiProvider, setApiProvider] = useState<ApiProvider>("anthropic");
   const [initialized, setInitialized] = useState(false);
 
   const [saveFeedback, setSaveFeedback] = useState<"success" | "error" | null>(null);
@@ -54,6 +42,21 @@ export function ProjectSettingsPage() {
     },
   });
 
+  const {
+    data: modelOptionsData,
+    isFetching: isFetchingModels,
+    error: modelsError,
+  } = useQuery({
+    queryKey: ["project-settings-models", projectId, apiProvider, hasApiKey],
+    queryFn: () =>
+      listProjectSettingsModels(projectId, {
+        api_provider: apiProvider,
+        api_key: apiKey,
+      }),
+    enabled: !Number.isNaN(projectId) && hasApiKey,
+    retry: false,
+  });
+
   // DBから設定を取得したら初回のみフォームに反映する
   useEffect(() => {
     if (settingsData && !initialized) {
@@ -70,6 +73,12 @@ export function ProjectSettingsPage() {
       setInitialized(true);
     }
   }, [error, initialized]);
+
+  useEffect(() => {
+    if (initialized && model === "" && modelOptionsData?.models[0]) {
+      setModel(modelOptionsData.models[0].id);
+    }
+  }, [initialized, model, modelOptionsData]);
 
   const upsertMutation = useMutation({
     mutationFn: () =>
@@ -89,14 +98,10 @@ export function ProjectSettingsPage() {
     },
   });
 
-  function handleModelChange(newModel: string) {
-    setModel(newModel);
-    setApiProvider(inferProvider(newModel));
-  }
-
   function handleSaveApiKey() {
     setApiKey(apiKeyInput);
     setApiKeySaved(true);
+    void queryClient.invalidateQueries({ queryKey: ["project-settings-models", projectId] });
     setTimeout(() => setApiKeySaved(false), 2000);
   }
 
@@ -107,6 +112,13 @@ export function ProjectSettingsPage() {
       </div>
     );
   }
+
+  const modelOptions = modelOptionsData?.models ?? [];
+  const modelIds = modelOptions.map((option) => option.id);
+  const hasRemoteModelOptions = modelOptions.length > 0;
+  const shouldShowSavedModelOption = model !== "" && !modelIds.includes(model);
+  const isModelSelectDisabled = !hasApiKey || isFetchingModels || !hasRemoteModelOptions;
+  const canSaveSettings = model.trim().length > 0 && !upsertMutation.isPending;
 
   const isNetworkError = error instanceof ApiError ? error.status !== 404 : error != null;
   if (isNetworkError) {
@@ -136,26 +148,42 @@ export function ProjectSettingsPage() {
             <select
               id="settings-model"
               value={model}
-              onChange={(e) => handleModelChange(e.target.value)}
+              onChange={(e) => setModel(e.target.value)}
               className={styles.fieldSelect}
+              disabled={isModelSelectDisabled}
             >
-              <optgroup label="Anthropic">
-                {ANTHROPIC_MODELS.map((m) => (
-                  <option key={m.value} value={m.value}>
-                    {m.label}
-                  </option>
-                ))}
-              </optgroup>
-              <optgroup label="OpenAI">
-                {OPENAI_MODELS.map((m) => (
-                  <option key={m.value} value={m.value}>
-                    {m.label}
-                  </option>
-                ))}
-              </optgroup>
-              {/* DBに保存済みのモデルが上記リスト外の場合もオプションとして表示 */}
-              {!ALL_MODELS.includes(model) && <option value={model}>{model}</option>}
+              {!hasApiKey && <option value="">APIキーを保存すると候補を取得します</option>}
+              {hasApiKey && isFetchingModels && <option value={model}>候補を取得中...</option>}
+              {hasApiKey && !isFetchingModels && !hasRemoteModelOptions && (
+                <option value={model}>候補を取得できません</option>
+              )}
+              {modelOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.displayName === option.id
+                    ? option.id
+                    : `${option.displayName} (${option.id})`}
+                </option>
+              ))}
+              {shouldShowSavedModelOption && <option value={model}>{model}（保存済み）</option>}
             </select>
+            {hasApiKey && !isFetchingModels && hasRemoteModelOptions && model === "" && (
+              <p className={styles.fieldHint}>取得した候補からモデルを選択してください</p>
+            )}
+            {!hasApiKey && (
+              <p className={styles.fieldHint}>先に API キーを保存すると、利用可能なモデル候補を取得します</p>
+            )}
+            {modelsError instanceof ApiError && (
+              <p className={styles.fieldError}>
+                {modelsError.status === 501
+                  ? "このプロバイダーのモデル候補取得は未対応です。"
+                  : modelsError.status === 401
+                    ? "APIキーの認証に失敗しました。キーを確認してください。"
+                    : "モデル候補の取得に失敗しました。"}
+              </p>
+            )}
+            {shouldShowSavedModelOption && (
+              <p className={styles.fieldHint}>保存済みモデルは取得候補に含まれていません</p>
+            )}
           </div>
 
           {/* APIプロバイダー */}
@@ -166,13 +194,16 @@ export function ProjectSettingsPage() {
             <select
               id="settings-provider"
               value={apiProvider}
-              onChange={(e) => setApiProvider(e.target.value as "anthropic" | "openai")}
+              onChange={(e) => {
+                setApiProvider(e.target.value as ApiProvider);
+                setModel("");
+              }}
               className={styles.fieldSelect}
             >
               <option value="anthropic">Anthropic</option>
               <option value="openai">OpenAI</option>
             </select>
-            <p className={styles.fieldHint}>モデルを変更すると自動的に切り替わります</p>
+            <p className={styles.fieldHint}>プロバイダーを変更するとモデル候補を再取得します</p>
           </div>
 
           {/* Temperatureスライダー */}
@@ -201,7 +232,8 @@ export function ProjectSettingsPage() {
         <div className={styles.section}>
           <h3 className={styles.sectionTitle}>API キー</h3>
           <p className={styles.apiKeyNote}>
-            APIキーはブラウザの localStorage にのみ保存されます。サーバーには送信されません。
+            APIキーはブラウザの localStorage に保存され、モデル候補取得時にサーバーへ一時送信されます。
+            サーバー側では保存しません。
           </p>
 
           <div className={styles.fieldGroup}>
@@ -239,7 +271,7 @@ export function ProjectSettingsPage() {
           <button
             type="button"
             onClick={() => upsertMutation.mutate()}
-            disabled={upsertMutation.isPending}
+            disabled={!canSaveSettings}
             className={styles.btnSave}
           >
             {upsertMutation.isPending ? "保存中..." : "設定を保存"}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.61.0
+        version: 0.61.0
       better-sqlite3:
         specifier: ^12.0.0
         version: 12.9.0
@@ -124,6 +127,10 @@ importers:
         version: 6.4.2(@types/node@25.5.2)(tsx@4.21.0)
 
 packages:
+
+  '@anthropic-ai/sdk@0.61.0':
+    resolution: {integrity: sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==}
+    hasBin: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2272,6 +2279,8 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.61.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
## 概要
- `packages/core` に共通の `LLMClient` インターフェースと Anthropic 実装を追加
- API キー未設定と認証失敗を core 層の専用エラーに正規化
- メッセージ送信とストリーミング動作のユニットテストを追加
- `ANTHROPIC_API_KEY` と依存関係、公開エクスポートを整備

## テスト
- `pnpm exec vitest run packages/core/src/llm/anthropic.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check packages/core/src/llm packages/core/src/index.ts packages/core/src/__test-stubs__/index.ts .env.example packages/core/package.json`

Closes #74
