### PR TITLE
Issue 25 LLM Run execution

### DIFF
--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -13,7 +13,7 @@ vi.mock("better-sqlite3", () => {
   };
 });
 
-import type { DB } from "@prompt-reviewer/core";
+import type { DB, LLMRequest } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import { createRunsRouter } from "./runs.js";
@@ -283,6 +283,215 @@ describe("POST /api/projects/:projectId/runs", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/projects/:projectId/runs/execute", () => {
+  it("LLM応答をSSEで返し、完了時にRunとして保存する", async () => {
+    const version = {
+      id: 1,
+      project_id: 1,
+      content: "あなたは親切なアシスタントです。\n\n{{context}}",
+    };
+    const testCase = {
+      id: 1,
+      project_id: 1,
+      turns: JSON.stringify([{ role: "user", content: "要約してください" }]),
+      context_content: "入力文: 今日は晴れです。",
+    };
+    const settings = {
+      model: "claude-sonnet-4-6",
+      temperature: 0.4,
+      api_provider: "anthropic",
+    };
+    const created = {
+      ...sampleRun,
+      conversation: JSON.stringify([
+        { role: "user", content: "要約してください" },
+        { role: "assistant", content: "今日は晴れです。" },
+      ]),
+      model: settings.model,
+      temperature: settings.temperature,
+      api_provider: settings.api_provider,
+    };
+
+    const capturedRequests: LLMRequest[] = [];
+    const capturedInsertValues: Array<{
+      conversation: string;
+      model: string;
+      temperature: number;
+      api_provider: string;
+    }> = [];
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const result =
+          selectCallCount === 1 ? [version] : selectCallCount === 2 ? [testCase] : [settings];
+        return {
+          from: () => ({
+            where: () => Promise.resolve(result),
+          }),
+        };
+      },
+      insert: () => ({
+        values: (values: {
+          conversation: string;
+          model: string;
+          temperature: number;
+          api_provider: string;
+        }) => {
+          capturedInsertValues.push(values);
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const app = new Hono();
+    app.route(
+      "/api/projects/:projectId/runs",
+      createRunsRouter(db as unknown as DB, {
+        llmClientFactory: () => ({
+          async sendMessage() {
+            throw new Error("sendMessage should not be used for streaming execute");
+          },
+          async *stream(request: LLMRequest) {
+            capturedRequests.push(request);
+            yield { type: "text-delta" as const, text: "今日は" };
+            yield { type: "text-delta" as const, text: "晴れです。" };
+            yield {
+              type: "response" as const,
+              response: {
+                content: "今日は晴れです。",
+                stopReason: "end_turn",
+                raw: {},
+              },
+            };
+          },
+        }),
+      }),
+    );
+
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const streamText = await res.text();
+    expect(streamText).toContain('event: delta\ndata: {"text":"今日は"}');
+    expect(streamText).toContain('event: delta\ndata: {"text":"晴れです。"}');
+    expect(streamText).toContain("event: run");
+
+    expect(capturedRequests).toEqual([
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "要約してください" }],
+        systemPrompt: "あなたは親切なアシスタントです。\n\n入力文: 今日は晴れです。",
+        temperature: 0.4,
+      },
+    ]);
+    expect(JSON.parse(capturedInsertValues[0]?.conversation ?? "[]")).toEqual([
+      { role: "user", content: "要約してください" },
+      { role: "assistant", content: "今日は晴れです。" },
+    ]);
+    expect(capturedInsertValues[0]?.model).toBe("claude-sonnet-4-6");
+    expect(capturedInsertValues[0]?.temperature).toBe(0.4);
+    expect(capturedInsertValues[0]?.api_provider).toBe("anthropic");
+  });
+
+  it("プロジェクト設定が未作成のとき404を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const result =
+          selectCallCount === 1
+            ? [{ id: 1, project_id: 1, content: "system" }]
+            : selectCallCount === 2
+              ? [
+                  {
+                    id: 1,
+                    project_id: 1,
+                    turns: JSON.stringify(sampleConversation),
+                    context_content: "",
+                  },
+                ]
+              : [];
+        return {
+          from: () => ({
+            where: () => Promise.resolve(result),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project settings not found");
+  });
+
+  it("未対応プロバイダーのとき501を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const result =
+          selectCallCount === 1
+            ? [{ id: 1, project_id: 1, content: "system" }]
+            : selectCallCount === 2
+              ? [
+                  {
+                    id: 1,
+                    project_id: 1,
+                    turns: JSON.stringify(sampleConversation),
+                    context_content: "",
+                  },
+                ]
+              : [{ model: "gpt-4o", temperature: 0.7, api_provider: "openai" }];
+        return {
+          from: () => ({
+            where: () => Promise.resolve(result),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-test",
+      }),
+    });
+
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Provider execution is not implemented");
   });
 });
 

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -410,6 +410,143 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
     expect(capturedInsertValues[0]?.api_provider).toBe("anthropic");
   });
 
+  it("turnsが空のときプロンプトをuser messageとして送信してRunを保存する", async () => {
+    const version = {
+      id: 1,
+      project_id: 1,
+      content: "次のルールで回答してください。\n\n{{context}}",
+    };
+    const testCase = {
+      id: 1,
+      project_id: 1,
+      turns: JSON.stringify([]),
+      context_content: "入力文: 今日は晴れです。",
+    };
+    const settings = {
+      model: "claude-sonnet-4-6",
+      temperature: 0.4,
+      api_provider: "anthropic",
+    };
+    const promptMessage = "次のルールで回答してください。\n\n入力文: 今日は晴れです。";
+    const created = {
+      ...sampleRun,
+      conversation: JSON.stringify([
+        { role: "user", content: promptMessage },
+        { role: "assistant", content: "今日は晴れです。" },
+      ]),
+      model: settings.model,
+      temperature: settings.temperature,
+      api_provider: settings.api_provider,
+    };
+
+    const capturedRequests: LLMRequest[] = [];
+    const capturedInsertValues: Array<{ conversation: string }> = [];
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const result =
+          selectCallCount === 1 ? [version] : selectCallCount === 2 ? [testCase] : [settings];
+        return {
+          from: () => ({
+            where: () => Promise.resolve(result),
+          }),
+        };
+      },
+      insert: () => ({
+        values: (values: { conversation: string }) => {
+          capturedInsertValues.push(values);
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const app = new Hono();
+    app.route(
+      "/api/projects/:projectId/runs",
+      createRunsRouter(db as unknown as DB, {
+        llmClientFactory: () => ({
+          async sendMessage() {
+            throw new Error("sendMessage should not be used for streaming execute");
+          },
+          async *stream(request: LLMRequest) {
+            capturedRequests.push(request);
+            yield { type: "text-delta" as const, text: "今日は晴れです。" };
+            yield {
+              type: "response" as const,
+              response: {
+                content: "今日は晴れです。",
+                stopReason: "end_turn",
+                raw: {},
+              },
+            };
+          },
+        }),
+      }),
+    );
+
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedRequests).toEqual([
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: promptMessage }],
+        temperature: 0.4,
+      },
+    ]);
+    expect(JSON.parse(capturedInsertValues[0]?.conversation ?? "[]")).toEqual([
+      { role: "user", content: promptMessage },
+      { role: "assistant", content: "今日は晴れです。" },
+    ]);
+  });
+
+  it("turnsもプロンプトも空のとき400を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const result =
+          selectCallCount === 1
+            ? [{ id: 1, project_id: 1, content: "   " }]
+            : selectCallCount === 2
+              ? [{ id: 1, project_id: 1, turns: JSON.stringify([]), context_content: "" }]
+              : [{ model: "claude-sonnet-4-6", temperature: 0.7, api_provider: "anthropic" }];
+        return {
+          from: () => ({
+            where: () => Promise.resolve(result),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Prompt or test case turns are required");
+  });
+
   it("プロジェクト設定が未作成のとき404を返す", async () => {
     let selectCallCount = 0;
     const db = {

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -1,7 +1,15 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { runs } from "@prompt-reviewer/core";
-import type { ConversationMessage } from "@prompt-reviewer/core";
+import {
+  AnthropicLLMClient,
+  LLMAuthenticationError,
+  LLMConfigurationError,
+  project_settings,
+  prompt_versions,
+  runs,
+  test_cases,
+} from "@prompt-reviewer/core";
+import type { ConversationMessage, LLMClient, LLMRequest } from "@prompt-reviewer/core";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -20,6 +28,52 @@ const createRunSchema = z.object({
   api_provider: z.string().min(1, "api_providerは1文字以上必要です"),
 });
 
+const executeRunSchema = z.object({
+  prompt_version_id: z.number().int().positive("prompt_version_idは正の整数が必要です"),
+  test_case_id: z.number().int().positive("test_case_idは正の整数が必要です"),
+  api_key: z.string().min(1, "api_keyは1文字以上必要です"),
+});
+
+type ExecuteRunBody = z.infer<typeof executeRunSchema>;
+
+type RunExecutionClientFactoryInput = {
+  apiProvider: string;
+  apiKey: string;
+};
+
+type RunsRouterOptions = {
+  llmClientFactory?: (input: RunExecutionClientFactoryInput) => LLMClient | null;
+};
+
+type StoredPromptVersion = {
+  id: number;
+  project_id: number;
+  content: string;
+};
+
+type StoredTestCase = {
+  id: number;
+  project_id: number;
+  turns: string;
+  context_content: string;
+};
+
+type StoredProjectSettings = {
+  model: string;
+  temperature: number;
+  api_provider: string;
+};
+
+const encoder = new TextEncoder();
+
+function defaultLLMClientFactory(input: RunExecutionClientFactoryInput): LLMClient | null {
+  if (input.apiProvider === "anthropic") {
+    return new AnthropicLLMClient({ apiKey: input.apiKey });
+  }
+
+  return null;
+}
+
 /** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
 function parseIntParam(value: string | undefined): number | null {
   if (value === undefined) return null;
@@ -32,8 +86,41 @@ function parseConversation(json: string): ConversationMessage[] {
   return JSON.parse(json) as ConversationMessage[];
 }
 
-export function createRunsRouter(db: DB) {
+function buildSystemPrompt(version: StoredPromptVersion, testCase: StoredTestCase): string {
+  if (!testCase.context_content) {
+    return version.content;
+  }
+
+  if (version.content.includes("{{context}}")) {
+    return version.content.replace("{{context}}", testCase.context_content);
+  }
+
+  return `${version.content}\n\n${testCase.context_content}`;
+}
+
+function encodeSse(event: string, data: unknown): Uint8Array {
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function normalizeExecuteError(error: unknown): { status: number; message: string } {
+  if (error instanceof LLMConfigurationError) {
+    return { status: 400, message: error.message };
+  }
+
+  if (error instanceof LLMAuthenticationError) {
+    return { status: 401, message: error.message };
+  }
+
+  if (error instanceof Error) {
+    return { status: 502, message: error.message };
+  }
+
+  return { status: 502, message: "Failed to execute Run" };
+}
+
+export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   const router = new Hono();
+  const llmClientFactory = options.llmClientFactory ?? defaultLLMClientFactory;
 
   // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
   router.get("/", async (c) => {
@@ -116,6 +203,125 @@ export function createRunsRouter(db: DB) {
     );
   });
 
+  // POST /api/projects/:projectId/runs/execute - LLMに接続してRunを実行・保存
+  router.post("/execute", zValidator("json", executeRunSchema), async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const body: ExecuteRunBody = c.req.valid("json");
+
+    const [[version], [testCase], [settings]] = await Promise.all([
+      db
+        .select()
+        .from(prompt_versions)
+        .where(
+          and(
+            eq(prompt_versions.id, body.prompt_version_id),
+            eq(prompt_versions.project_id, projectId),
+          ),
+        ),
+      db
+        .select()
+        .from(test_cases)
+        .where(and(eq(test_cases.id, body.test_case_id), eq(test_cases.project_id, projectId))),
+      db.select().from(project_settings).where(eq(project_settings.project_id, projectId)),
+    ]);
+
+    if (!version) {
+      return c.json({ error: "Prompt version not found" }, 404);
+    }
+
+    if (!testCase) {
+      return c.json({ error: "Test case not found" }, 404);
+    }
+
+    if (!settings) {
+      return c.json({ error: "Project settings not found" }, 404);
+    }
+
+    const client = llmClientFactory({
+      apiProvider: settings.api_provider,
+      apiKey: body.api_key,
+    });
+
+    if (!client) {
+      return c.json({ error: "Provider execution is not implemented" }, 501);
+    }
+
+    const messages = parseConversation(testCase.turns);
+    const request: LLMRequest = {
+      model: settings.model,
+      messages,
+      systemPrompt: buildSystemPrompt(version, testCase),
+      temperature: settings.temperature,
+    };
+
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          let assistantContent = "";
+
+          try {
+            for await (const event of client.stream(request)) {
+              if (event.type === "text-delta") {
+                assistantContent += event.text;
+                controller.enqueue(encodeSse("delta", { text: event.text }));
+              }
+            }
+
+            const conversation: ConversationMessage[] = [
+              ...messages,
+              { role: "assistant", content: assistantContent },
+            ];
+
+            const [created] = await db
+              .insert(runs)
+              .values({
+                project_id: projectId,
+                prompt_version_id: body.prompt_version_id,
+                test_case_id: body.test_case_id,
+                conversation: JSON.stringify(conversation),
+                is_best: false,
+                model: settings.model,
+                temperature: settings.temperature,
+                api_provider: settings.api_provider,
+                created_at: Date.now(),
+              })
+              .returning();
+
+            if (!created) {
+              controller.enqueue(
+                encodeSse("error", { status: 500, message: "Failed to create Run" }),
+              );
+              return;
+            }
+
+            controller.enqueue(
+              encodeSse("run", {
+                ...created,
+                conversation: parseConversation(created.conversation),
+              }),
+            );
+          } catch (error) {
+            controller.enqueue(encodeSse("error", normalizeExecuteError(error)));
+          } finally {
+            controller.close();
+          }
+        },
+      }),
+      {
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      },
+    );
+  });
+
   // GET /api/projects/:projectId/runs/:id - 特定Run取得
   router.get("/:id", async (c) => {
     const projectId = parseIntParam(c.req.param("projectId"));
@@ -160,7 +366,7 @@ export function createRunsRouter(db: DB) {
       return c.json({ error: "Run not found" }, 404);
     }
 
-    const body = await c.req.json().catch(() => ({})) as { unset?: boolean };
+    const body = (await c.req.json().catch(() => ({}))) as { unset?: boolean };
 
     if (body.unset) {
       // ベスト解除

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -98,6 +98,40 @@ function buildSystemPrompt(version: StoredPromptVersion, testCase: StoredTestCas
   return `${version.content}\n\n${testCase.context_content}`;
 }
 
+function buildExecutionRequest(params: {
+  model: string;
+  messages: ConversationMessage[];
+  systemPrompt: string;
+  temperature: number;
+}): { request: LLMRequest; conversationBase: ConversationMessage[] } | null {
+  if (params.messages.length > 0) {
+    return {
+      request: {
+        model: params.model,
+        messages: params.messages,
+        systemPrompt: params.systemPrompt,
+        temperature: params.temperature,
+      },
+      conversationBase: params.messages,
+    };
+  }
+
+  const promptMessage = params.systemPrompt.trim();
+  if (promptMessage.length === 0) {
+    return null;
+  }
+
+  const fallbackMessages: ConversationMessage[] = [{ role: "user", content: promptMessage }];
+  return {
+    request: {
+      model: params.model,
+      messages: fallbackMessages,
+      temperature: params.temperature,
+    },
+    conversationBase: fallbackMessages,
+  };
+}
+
 function encodeSse(event: string, data: unknown): Uint8Array {
   return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
@@ -251,13 +285,16 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Provider execution is not implemented" }, 501);
     }
 
-    const messages = parseConversation(testCase.turns);
-    const request: LLMRequest = {
+    const execution = buildExecutionRequest({
       model: settings.model,
-      messages,
+      messages: parseConversation(testCase.turns),
       systemPrompt: buildSystemPrompt(version, testCase),
       temperature: settings.temperature,
-    };
+    });
+
+    if (!execution) {
+      return c.json({ error: "Prompt or test case turns are required" }, 400);
+    }
 
     return new Response(
       new ReadableStream({
@@ -265,7 +302,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
           let assistantContent = "";
 
           try {
-            for await (const event of client.stream(request)) {
+            for await (const event of client.stream(execution.request)) {
               if (event.type === "text-delta") {
                 assistantContent += event.text;
                 controller.enqueue(encodeSse("delta", { text: event.text }));
@@ -273,7 +310,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
             }
 
             const conversation: ConversationMessage[] = [
-              ...messages,
+              ...execution.conversationBase,
               { role: "assistant", content: assistantContent },
             ];
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -252,6 +252,116 @@ export function createRun(
   return api.post<Run>(`/projects/${projectId}/runs`, data);
 }
 
+type ExecuteRunStreamOptions = {
+  prompt_version_id: number;
+  test_case_id: number;
+  api_key: string;
+  onDelta: (text: string) => void;
+};
+
+type RunExecuteEvent =
+  | {
+      event: "delta";
+      data: { text: string };
+    }
+  | {
+      event: "run";
+      data: Run;
+    }
+  | {
+      event: "error";
+      data: { status?: number; message?: string };
+    };
+
+function parseSseEvent(chunk: string): RunExecuteEvent | null {
+  const lines = chunk.split("\n");
+  const eventLine = lines.find((line) => line.startsWith("event: "));
+  const dataLine = lines.find((line) => line.startsWith("data: "));
+
+  if (!eventLine || !dataLine) {
+    return null;
+  }
+
+  const event = eventLine.slice("event: ".length) as RunExecuteEvent["event"];
+  const data = JSON.parse(dataLine.slice("data: ".length)) as RunExecuteEvent["data"];
+
+  if (event === "delta" || event === "run" || event === "error") {
+    return { event, data } as RunExecuteEvent;
+  }
+
+  return null;
+}
+
+export async function executeRunStream(
+  projectId: number,
+  options: ExecuteRunStreamOptions,
+): Promise<Run> {
+  const response = await fetch(`${API_BASE_URL}/projects/${projectId}/runs/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      prompt_version_id: options.prompt_version_id,
+      test_case_id: options.test_case_id,
+      api_key: options.api_key,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new ApiError(response.status, `API error: ${response.status} ${response.statusText}`);
+  }
+
+  if (!response.body) {
+    throw new ApiError(502, "API error: empty streaming response");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let savedRun: Run | null = null;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (value) {
+      buffer += decoder.decode(value, { stream: !done });
+    }
+
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+
+    for (const chunk of chunks) {
+      const parsed = parseSseEvent(chunk.trim());
+      if (!parsed) continue;
+
+      if (parsed.event === "delta") {
+        options.onDelta(parsed.data.text);
+      }
+
+      if (parsed.event === "run") {
+        savedRun = parsed.data;
+      }
+
+      if (parsed.event === "error") {
+        throw new ApiError(
+          parsed.data.status ?? 502,
+          parsed.data.message ?? "Run execution failed",
+        );
+      }
+    }
+
+    if (done) {
+      break;
+    }
+  }
+
+  if (!savedRun) {
+    throw new ApiError(502, "API error: run was not returned");
+  }
+
+  return savedRun;
+}
+
 export function setBestRun(projectId: number, id: number, unset = false): Promise<Run> {
   return api.patch<Run>(`/projects/${projectId}/runs/${id}/best`, { unset });
 }

--- a/packages/ui/src/pages/ProjectSettingsPage.tsx
+++ b/packages/ui/src/pages/ProjectSettingsPage.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { useApiKey } from "../hooks/useApiKey";
 import {
-  type ApiProvider,
   ApiError,
+  type ApiProvider,
   getProjectSettings,
   listProjectSettingsModels,
   upsertProjectSettings,
@@ -170,7 +170,9 @@ export function ProjectSettingsPage() {
               <p className={styles.fieldHint}>取得した候補からモデルを選択してください</p>
             )}
             {!hasApiKey && (
-              <p className={styles.fieldHint}>先に API キーを保存すると、利用可能なモデル候補を取得します</p>
+              <p className={styles.fieldHint}>
+                先に API キーを保存すると、利用可能なモデル候補を取得します
+              </p>
             )}
             {modelsError instanceof ApiError && (
               <p className={styles.fieldError}>
@@ -232,8 +234,8 @@ export function ProjectSettingsPage() {
         <div className={styles.section}>
           <h3 className={styles.sectionTitle}>API キー</h3>
           <p className={styles.apiKeyNote}>
-            APIキーはブラウザの localStorage に保存され、モデル候補取得時にサーバーへ一時送信されます。
-            サーバー側では保存しません。
+            APIキーはブラウザの localStorage に保存され、モデル候補取得時と Run
+            実行時にサーバーへ一時送信されます。 サーバー側では保存しません。
           </p>
 
           <div className={styles.fieldGroup}>

--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -275,14 +275,19 @@
 
 .btnLlmRun {
   padding: 10px 20px;
-  background: var(--c-muted);
+  background: var(--c-blue);
   color: var(--c-overlay);
   border: none;
   border-radius: 6px;
   font-size: 14px;
   font-weight: 600;
+  cursor: pointer;
+}
+
+.btnLlmRunDisabled {
+  background: var(--c-muted);
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 .errorMsg {

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -9,6 +9,7 @@ import {
   type Run,
   type TestCase,
   createRun,
+  executeRunStream,
   getProject,
   getPromptVersions,
   getRuns,
@@ -16,76 +17,6 @@ import {
   setBestRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
-
-function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; text: string }[] {
-  const aLines = a.split("\n");
-  const bLines = b.split("\n");
-  const result: { type: "same" | "removed" | "added"; text: string }[] = [];
-
-  const maxLen = Math.max(aLines.length, bLines.length);
-  let ai = 0;
-  let bi = 0;
-
-  while (ai < aLines.length || bi < bLines.length) {
-    if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-      result.push({ type: "same", text: aLines[ai]! });
-      ai++;
-      bi++;
-    } else {
-      const aRemainder = aLines.slice(ai);
-      const bRemainder = bLines.slice(bi);
-
-      let foundInA = -1;
-      let foundInB = -1;
-      const lookAhead = Math.min(5, maxLen);
-
-      for (let d = 0; d < lookAhead; d++) {
-        // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d]!)) {
-          foundInB = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-          foundInA = aRemainder.indexOf(bRemainder[d]!);
-          break;
-        }
-        // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d]!)) {
-          foundInA = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-          foundInB = bRemainder.indexOf(aRemainder[d]!);
-          break;
-        }
-      }
-
-      if (foundInA > 0) {
-        for (let i = 0; i < foundInA; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInA <= aRemainder.length
-          result.push({ type: "removed", text: aRemainder[i]! });
-        }
-        ai += foundInA;
-      } else if (foundInB > 0) {
-        for (let i = 0; i < foundInB; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInB <= bRemainder.length
-          result.push({ type: "added", text: bRemainder[i]! });
-        }
-        bi += foundInB;
-      } else {
-        if (ai < aLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "removed", text: aLines[ai]! });
-          ai++;
-        }
-        if (bi < bLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "added", text: bLines[bi]! });
-          bi++;
-        }
-      }
-    }
-  }
-
-  return result;
-}
 
 function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
   const systemPrompt = testCase.context_content
@@ -238,10 +169,7 @@ function RunCard({
               {isCompareSelected ? "比較解除" : "比較"}
             </button>
           )}
-          <Link
-            to={`/projects/${projectId}/score?runId=${run.id}`}
-            className={styles.btnScore}
-          >
+          <Link to={`/projects/${projectId}/score?runId=${run.id}`} className={styles.btnScore}>
             採点
           </Link>
           <button
@@ -273,7 +201,7 @@ export function RunsPage() {
   const projectId = Number(id);
   const queryClient = useQueryClient();
 
-  const { hasApiKey } = useApiKey(projectId);
+  const { apiKey, hasApiKey } = useApiKey(projectId);
 
   const [activeTab, setActiveTab] = useState<PageTab>("create");
 
@@ -283,6 +211,7 @@ export function RunsPage() {
   const [selectedTestCaseId, setSelectedTestCaseId] = useState<number | "">("");
   const [llmResponse, setLlmResponse] = useState("");
   const [savedRun, setSavedRun] = useState<Run | null>(null);
+  const [executeError, setExecuteError] = useState<string | null>(null);
 
   // 「Run 一覧」タブのフィルター状態
   const [filterVersionId, setFilterVersionId] = useState<number | "">("");
@@ -360,6 +289,29 @@ export function RunsPage() {
     },
   });
 
+  const executeRunMutation = useMutation({
+    mutationFn: (data: { prompt_version_id: number; test_case_id: number }) =>
+      executeRunStream(projectId, {
+        ...data,
+        api_key: apiKey,
+        onDelta: (text) => {
+          setLlmResponse((prev) => `${prev}${text}`);
+        },
+      }),
+    onMutate: () => {
+      setExecuteError(null);
+      setLlmResponse("");
+    },
+    onSuccess: (run) => {
+      setSavedRun(run);
+      setStep("saved");
+      void queryClient.invalidateQueries({ queryKey: ["runs", projectId] });
+    },
+    onError: (error) => {
+      setExecuteError(error instanceof Error ? error.message : "LLM 実行に失敗しました。");
+    },
+  });
+
   const setBestMutation = useMutation({
     mutationFn: ({ id, unset }: { id: number; unset: boolean }) => setBestRun(projectId, id, unset),
     onSuccess: () => {
@@ -390,6 +342,7 @@ export function RunsPage() {
   function handleStartRun() {
     if (selectedVersionId === "" || selectedTestCaseId === "") return;
     setLlmResponse("");
+    setExecuteError(null);
     setStep("input");
   }
 
@@ -411,7 +364,18 @@ export function RunsPage() {
 
   function handleNewRun() {
     setSavedRun(null);
+    setLlmResponse("");
+    setExecuteError(null);
     setStep("select");
+  }
+
+  function handleExecuteRun() {
+    if (selectedVersionId === "" || selectedTestCaseId === "" || !hasApiKey) return;
+
+    executeRunMutation.mutate({
+      prompt_version_id: selectedVersionId,
+      test_case_id: selectedTestCaseId,
+    });
   }
 
   function handleCompareRun(run: Run) {
@@ -436,7 +400,14 @@ export function RunsPage() {
   }
 
   const isStartDisabled = selectedVersionId === "" || selectedTestCaseId === "" || !hasApiKey;
-  const isSaveDisabled = !llmResponse.trim() || createRunMutation.isPending;
+  const isSaveDisabled =
+    !llmResponse.trim() || createRunMutation.isPending || executeRunMutation.isPending;
+  const isExecuteDisabled =
+    selectedVersionId === "" ||
+    selectedTestCaseId === "" ||
+    !hasApiKey ||
+    executeRunMutation.isPending ||
+    createRunMutation.isPending;
 
   return (
     <div className={`${styles.root} ${styles.page}`}>
@@ -539,10 +510,7 @@ export function RunsPage() {
               {!hasApiKey && (
                 <p className={styles.fieldHint}>
                   APIキーが未設定です。
-                  <Link
-                    to={`/projects/${projectId}/settings`}
-                    className={styles.settingsLink}
-                  >
+                  <Link to={`/projects/${projectId}/settings`} className={styles.settingsLink}>
                     設定画面
                   </Link>
                   で入力してください。
@@ -607,19 +575,31 @@ export function RunsPage() {
                   )}
                 </div>
 
-                {/* 右カラム: 手動入力エリア */}
+                {/* 右カラム: LLM実行・手動入力エリア */}
                 <div className={`${styles.panel} ${styles.panelFlex}`}>
-                  <h3 className={styles.panelSubtitle}>LLM 応答の入力</h3>
-                  <p className={styles.inputDescription}>LLM 応答を手動で入力してください</p>
+                  <h3 className={styles.panelSubtitle}>LLM 応答</h3>
+                  <p className={styles.inputDescription}>
+                    実行すると応答をストリーミング表示し、完了後に Run として保存します。
+                  </p>
 
                   <textarea
                     value={llmResponse}
                     onChange={(e) => setLlmResponse(e.target.value)}
-                    placeholder="LLM の応答をここにペーストまたは入力してください..."
+                    placeholder="実行結果がここに表示されます。手動入力して保存することもできます。"
                     className={styles.responseTextarea}
+                    readOnly={executeRunMutation.isPending}
                   />
 
                   <div className={styles.inputActions}>
+                    <button
+                      type="button"
+                      onClick={handleExecuteRun}
+                      disabled={isExecuteDisabled}
+                      className={`${styles.btnLlmRun} ${isExecuteDisabled ? styles.btnLlmRunDisabled : ""}`}
+                    >
+                      {executeRunMutation.isPending ? "実行中..." : "実行"}
+                    </button>
+
                     <button
                       type="button"
                       onClick={handleSaveRun}
@@ -628,18 +608,9 @@ export function RunsPage() {
                     >
                       {createRunMutation.isPending ? "保存中..." : "Run を保存"}
                     </button>
-
-                    {/* TODO: Phase 2 - LLM実行ボタン */}
-                    <button
-                      type="button"
-                      disabled
-                      title="Phase 2 で実装予定"
-                      className={styles.btnLlmRun}
-                    >
-                      LLM 実行（Phase 2）
-                    </button>
                   </div>
 
+                  {executeError && <p className={styles.errorMsg}>{executeError}</p>}
                   {createRunMutation.isError && (
                     <p className={styles.errorMsg}>保存に失敗しました。もう一度お試しください。</p>
                   )}


### PR DESCRIPTION
## 概要
- POST /api/projects/:projectId/runs/execute を追加し、Anthropic LLM のストリーミング応答を SSE で返しながら Run に保存
- Run 作成画面に実行ボタンを追加し、応答をリアルタイム表示して完了後に保存済み Run へ遷移
- API キー説明文と実行ルートのテストを更新

## 検証
- pnpm exec vitest run packages/server/src/routes/runs.test.ts
- pnpm --filter @prompt-reviewer/server exec tsc --noEmit
- pnpm exec biome check packages/server/src/routes/runs.ts packages/server/src/routes/runs.test.ts packages/ui/src/lib/api.ts packages/ui/src/pages/RunsPage.tsx packages/ui/src/pages/RunsPage.module.css packages/ui/src/pages/ProjectSettingsPage.tsx

## 補足
- pnpm --filter @prompt-reviewer/ui typecheck は既存の RunCompareView.tsx と ScorePage.tsx の型エラーで失敗しています。