### PR TITLE
Issue 77 Fix UI typecheck errors

### DIFF
--- a/packages/ui/src/components/RunCompareView.tsx
+++ b/packages/ui/src/components/RunCompareView.tsx
@@ -15,8 +15,11 @@ export function diffLines(
   let bi = 0;
 
   while (ai < aLines.length || bi < bLines.length) {
-    if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      result.push({ type: "same", text: aLines[ai] });
+    const currentA = aLines[ai];
+    const currentB = bLines[bi];
+
+    if (currentA !== undefined && currentB !== undefined && currentA === currentB) {
+      result.push({ type: "same", text: currentA });
       ai++;
       bi++;
     } else {
@@ -28,35 +31,44 @@ export function diffLines(
       const lookAhead = Math.min(5, maxLen);
 
       for (let d = 0; d < lookAhead; d++) {
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d])) {
+        const candidateB = bRemainder[d];
+        if (candidateB !== undefined && aRemainder.slice(0, lookAhead).includes(candidateB)) {
           foundInB = d;
-          foundInA = aRemainder.indexOf(bRemainder[d]);
+          foundInA = aRemainder.indexOf(candidateB);
           break;
         }
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d])) {
+
+        const candidateA = aRemainder[d];
+        if (candidateA !== undefined && bRemainder.slice(0, lookAhead).includes(candidateA)) {
           foundInA = d;
-          foundInB = bRemainder.indexOf(aRemainder[d]);
+          foundInB = bRemainder.indexOf(candidateA);
           break;
         }
       }
 
       if (foundInA > 0) {
         for (let i = 0; i < foundInA; i++) {
-          result.push({ type: "removed", text: aRemainder[i] });
+          const line = aRemainder[i];
+          if (line !== undefined) {
+            result.push({ type: "removed", text: line });
+          }
         }
         ai += foundInA;
       } else if (foundInB > 0) {
         for (let i = 0; i < foundInB; i++) {
-          result.push({ type: "added", text: bRemainder[i] });
+          const line = bRemainder[i];
+          if (line !== undefined) {
+            result.push({ type: "added", text: line });
+          }
         }
         bi += foundInB;
       } else {
-        if (ai < aLines.length) {
-          result.push({ type: "removed", text: aLines[ai] });
+        if (currentA !== undefined) {
+          result.push({ type: "removed", text: currentA });
           ai++;
         }
-        if (bi < bLines.length) {
-          result.push({ type: "added", text: bLines[bi] });
+        if (currentB !== undefined) {
+          result.push({ type: "added", text: currentB });
           bi++;
         }
       }
@@ -140,11 +152,7 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                   <span>Run #{runA.id}</span>
                   <span className={styles.panelMeta}>{versionLabelA}</span>
                 </div>
-                <div
-                  ref={scrollRefA}
-                  className={styles.chatList}
-                  onScroll={handleScrollA}
-                >
+                <div ref={scrollRefA} className={styles.chatList} onScroll={handleScrollA}>
                   {runA.conversation.map((msg, i) => (
                     <div
                       key={`a-msg-${
@@ -170,11 +178,7 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                   <span>Run #{runB.id}</span>
                   <span className={styles.panelMeta}>{versionLabelB}</span>
                 </div>
-                <div
-                  ref={scrollRefB}
-                  className={styles.chatList}
-                  onScroll={handleScrollB}
-                >
+                <div ref={scrollRefB} className={styles.chatList} onScroll={handleScrollB}>
                   {runB.conversation.map((msg, i) => (
                     <div
                       key={`b-msg-${

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -17,76 +17,6 @@ import {
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
 
-function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; text: string }[] {
-  const aLines = a.split("\n");
-  const bLines = b.split("\n");
-  const result: { type: "same" | "removed" | "added"; text: string }[] = [];
-
-  const maxLen = Math.max(aLines.length, bLines.length);
-  let ai = 0;
-  let bi = 0;
-
-  while (ai < aLines.length || bi < bLines.length) {
-    if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-      result.push({ type: "same", text: aLines[ai]! });
-      ai++;
-      bi++;
-    } else {
-      const aRemainder = aLines.slice(ai);
-      const bRemainder = bLines.slice(bi);
-
-      let foundInA = -1;
-      let foundInB = -1;
-      const lookAhead = Math.min(5, maxLen);
-
-      for (let d = 0; d < lookAhead; d++) {
-        // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d]!)) {
-          foundInB = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-          foundInA = aRemainder.indexOf(bRemainder[d]!);
-          break;
-        }
-        // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d]!)) {
-          foundInA = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-          foundInB = bRemainder.indexOf(aRemainder[d]!);
-          break;
-        }
-      }
-
-      if (foundInA > 0) {
-        for (let i = 0; i < foundInA; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInA <= aRemainder.length
-          result.push({ type: "removed", text: aRemainder[i]! });
-        }
-        ai += foundInA;
-      } else if (foundInB > 0) {
-        for (let i = 0; i < foundInB; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInB <= bRemainder.length
-          result.push({ type: "added", text: bRemainder[i]! });
-        }
-        bi += foundInB;
-      } else {
-        if (ai < aLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "removed", text: aLines[ai]! });
-          ai++;
-        }
-        if (bi < bLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "added", text: bLines[bi]! });
-          bi++;
-        }
-      }
-    }
-  }
-
-  return result;
-}
-
 function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
   const systemPrompt = testCase.context_content
     ? version.content.includes("{{context}}")
@@ -238,10 +168,7 @@ function RunCard({
               {isCompareSelected ? "比較解除" : "比較"}
             </button>
           )}
-          <Link
-            to={`/projects/${projectId}/score?runId=${run.id}`}
-            className={styles.btnScore}
-          >
+          <Link to={`/projects/${projectId}/score?runId=${run.id}`} className={styles.btnScore}>
             採点
           </Link>
           <button
@@ -539,10 +466,7 @@ export function RunsPage() {
               {!hasApiKey && (
                 <p className={styles.fieldHint}>
                   APIキーが未設定です。
-                  <Link
-                    to={`/projects/${projectId}/settings`}
-                    className={styles.settingsLink}
-                  >
+                  <Link to={`/projects/${projectId}/settings`} className={styles.settingsLink}>
                     設定画面
                   </Link>
                   で入力してください。

--- a/packages/ui/src/pages/ScorePage.tsx
+++ b/packages/ui/src/pages/ScorePage.tsx
@@ -124,13 +124,7 @@ function ScoreInput({
   if (mode === "numeric") {
     return <NumericScore value={value} onChange={onChange} disabled={disabled} />;
   }
-  return (
-    <StarRating
-      value={value}
-      onChange={(v) => onChange(v)}
-      disabled={disabled}
-    />
-  );
+  return <StarRating value={value} onChange={(v) => onChange(v)} disabled={disabled} />;
 }
 
 // --------------- StatusBadge ---------------
@@ -234,10 +228,7 @@ function IndividualRunRow({
   const isDiscarded = score?.is_discarded ?? false;
 
   return (
-    <div
-      ref={cardRef}
-      className={`${styles.runCard} ${autoFocus ? styles.runCardFocused : ""}`}
-    >
+    <div ref={cardRef} className={`${styles.runCard} ${autoFocus ? styles.runCardFocused : ""}`}>
       <button
         type="button"
         className={styles.runCardHeader}
@@ -439,7 +430,10 @@ export function ScorePage() {
   function toggleCompare(runId: number) {
     setCompareIds((prev) => {
       if (prev.includes(runId)) return prev.filter((id) => id !== runId);
-      if (prev.length >= 2) return [prev[1], runId];
+      if (prev.length >= 2) {
+        const previousSecond = prev[1];
+        return previousSecond === undefined ? [runId] : [previousSecond, runId];
+      }
       return [...prev, runId];
     });
   }


### PR DESCRIPTION
## 概要
- RunCompareView の diffLines で string | undefined が混入しないよう配列アクセスを明示的にガード
- RunsPage の未使用 diffLines を削除
- ScorePage の比較 ID 更新で number | undefined が state に混入しないよう修正

## 検証
- pnpm --filter @prompt-reviewer/ui typecheck
- pnpm exec biome check packages/ui/src/components/RunCompareView.tsx packages/ui/src/pages/RunsPage.tsx packages/ui/src/pages/ScorePage.tsx
- git diff --check

## 補足
- pnpm run test は packages/server/src/routes/test-cases.test.ts の既存 2 件（turns 空配列/未指定が 500 になる）で失敗しました。今回変更した UI ファイルとは別領域です。