### PR TITLE
プロンプト全文でコンテキストを区切って表示

### DIFF
--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -88,17 +88,20 @@ function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; 
 }
 
 function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
+  const contextBlock = testCase.context_content
+    ? `[Context]\n${testCase.context_content}\n[/Context]`
+    : "";
   const systemPrompt = testCase.context_content
     ? version.content.includes("{{context}}")
-      ? version.content.replace("{{context}}", testCase.context_content)
-      : `${version.content}\n\n${testCase.context_content}`
+      ? version.content.replace("{{context}}", contextBlock)
+      : `${version.content}\n\n${contextBlock}`
     : version.content;
 
   const turnsText = testCase.turns
     .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
     .join("\n\n");
 
-  return turnsText ? `${systemPrompt}\n\n[Conversation]\n${turnsText}` : systemPrompt;
+  return turnsText ? `${systemPrompt}\n\n[Conversation]\n${turnsText}\n[/Conversation]` : systemPrompt;
 }
 
 function CopyPromptPanel({


### PR DESCRIPTION
## 概要

Closes #81

Run作成画面のプロンプト全文表示・コピーで、コンテキスト情報がプロンプト本文にそのまま混ざらないようにしました。

## 変更内容

- コンテキスト情報を [Context] / [/Context] ブロックで囲むように変更
- {{context}} 差し込み時も、末尾追加時も同じ形式で区切るように変更
- 会話履歴を [Conversation] / [/Conversation] ブロックで囲むように変更

## 確認

- pnpm --filter @prompt-reviewer/ui typecheck
  - 失敗: 既存の型エラーがあります
  - src/components/RunCompareView.tsx の string | undefined 関連
  - src/pages/ScorePage.tsx の number | undefined 関連
  - src/pages/RunsPage.tsx の既存未使用関数 diffLines