### PR TITLE
TestCase作成時のturns任意仕様にテストを合わせる

### DIFF
--- a/doc/api-spec.md
+++ b/doc/api-spec.md
@@ -260,7 +260,7 @@ POST /projects/:projectId/test-cases
 | フィールド | 型 | 必須 | 説明 |
 |---|---|---|---|
 | `title` | string | ✅ | テストケース名 |
-| `turns` | `{role, content}[]` | ✅ | マルチターンの会話履歴 |
+| `turns` | `{role, content}[]` | | マルチターンの会話履歴（未指定時は空配列） |
 | `context_content` | string | | `{{context}}` に挿入するテキスト |
 | `expected_description` | string | | 期待する出力の自由記述 |
 | `display_order` | number | | 一覧の並び順（デフォルト: 0） |

--- a/packages/server/src/routes/test-cases.test.ts
+++ b/packages/server/src/routes/test-cases.test.ts
@@ -193,8 +193,16 @@ describe("POST /api/projects/:projectId/test-cases", () => {
     expect(res.status).toBe(400);
   });
 
-  it("turns が空配列のとき400を返す", async () => {
-    const db = {};
+  it("turns が空配列のとき空の会話履歴として作成する", async () => {
+    const created = { ...sampleTestCase, title: "テスト", turns: JSON.stringify([]) };
+    const values = vi.fn(() => ({
+      returning: () => Promise.resolve([created]),
+    }));
+    const db = {
+      insert: () => ({
+        values,
+      }),
+    };
     const app = buildApp(db);
     const res = await app.request("/api/projects/1/test-cases", {
       method: "POST",
@@ -202,11 +210,27 @@ describe("POST /api/projects/:projectId/test-cases", () => {
       body: JSON.stringify({ title: "テスト", turns: [] }),
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "テスト",
+        turns: "[]",
+      }),
+    );
+    const body = (await res.json()) as ParsedTestCase;
+    expect(body.turns).toEqual([]);
   });
 
-  it("turns が未指定のとき400を返す", async () => {
-    const db = {};
+  it("turns が未指定のとき空の会話履歴として作成する", async () => {
+    const created = { ...sampleTestCase, title: "テスト", turns: JSON.stringify([]) };
+    const values = vi.fn(() => ({
+      returning: () => Promise.resolve([created]),
+    }));
+    const db = {
+      insert: () => ({
+        values,
+      }),
+    };
     const app = buildApp(db);
     const res = await app.request("/api/projects/1/test-cases", {
       method: "POST",
@@ -214,7 +238,15 @@ describe("POST /api/projects/:projectId/test-cases", () => {
       body: JSON.stringify({ title: "テスト" }),
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(201);
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "テスト",
+        turns: "[]",
+      }),
+    );
+    const body = (await res.json()) as ParsedTestCase;
+    expect(body.turns).toEqual([]);
   });
 
   it("マルチターンのturnsが正しく保存・返却される", async () => {


### PR DESCRIPTION
## 概要

Closes #80

TestCase作成APIでは turns を未指定時に空配列として扱う仕様に統一しました。実装の default([]) は維持し、失敗していたテスト期待値とAPI仕様書を更新しています。

## 変更内容

- POST /test-cases で turns が空配列の場合、201で作成されることをテスト
- POST /test-cases で turns が未指定の場合、空配列として保存・返却されることをテスト
- API仕様書の turns を必須から任意に変更し、未指定時は空配列になることを明記

## 確認

- pnpm exec vitest run packages/server/src/routes/test-cases.test.ts: 成功
- pnpm run test: 成功（12ファイル / 186テスト）
- pnpm --filter @prompt-reviewer/server exec tsc --noEmit: 失敗（既存の project-settings / core export 不一致によるエラー）