### PR TITLE
ローカル試用版の起動導線を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Server
-PORT=3001
-DB_PATH=./data/prompt-reviewer.db
+# Local / Server
+PORT=3000
+DB_PATH=./data/prompt-reviewer.sqlite
+UI_DIST_DIR=./packages/ui/dist
 ANTHROPIC_API_KEY=
 
 # UI (Vite)

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 PORT=3000
 DB_PATH=./data/prompt-reviewer.sqlite
 UI_DIST_DIR=./packages/ui/dist
+OPEN_BROWSER_ON_START=true
 ANTHROPIC_API_KEY=
 
 # UI (Vite)

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ src-tauri/target/
 *.db
 *.db-shm
 *.db-wal
+data/*.sqlite
+data/*.sqlite-shm
+data/*.sqlite-wal
+
+# TypeScript build info
+*.tsbuildinfo
 
 # env
 .env

--- a/README.local.md
+++ b/README.local.md
@@ -1,0 +1,73 @@
+# prompt-reviewer Local Trial
+
+ローカル試用版は、build 済みの UI を Hono サーバーが配信する単一のローカル Web アプリとして起動します。
+
+## 必要環境
+
+- Node.js 20+
+- pnpm 9+
+
+## ローカル試用の起動
+
+初回セットアップ:
+
+```bash
+pnpm setup:local
+```
+
+上記で以下をまとめて実行します。
+
+- 依存パッケージのインストール
+- `@prompt-reviewer/core` の build
+- `@prompt-reviewer/ui` の build
+- SQLite への migration
+
+起動:
+
+```bash
+pnpm start:local
+```
+
+起動後はブラウザで `http://localhost:3000` を開いてください。
+
+## データ保存先
+
+ローカル試用版の SQLite DB は以下に作成されます。
+
+```text
+data/prompt-reviewer.sqlite
+```
+
+## 主要コマンド
+
+```bash
+# UI/core の build
+pnpm build:local
+
+# DB migration
+pnpm migrate:local
+
+# サンプルデータ投入
+pnpm seed:local
+
+# ローカル試用版の起動
+pnpm start:local
+```
+
+## 環境変数
+
+必要に応じて `.env.example` を参考に環境変数を設定できます。
+
+| 変数名 | デフォルト値 | 説明 |
+|---|---|---|
+| `PORT` | `3000` | ローカル試用版サーバーのポート |
+| `DB_PATH` | `./data/prompt-reviewer.sqlite` | SQLite DB ファイルの保存先 |
+| `UI_DIST_DIR` | `./packages/ui/dist` | 配信する build 済み UI のディレクトリ |
+
+`pnpm start:local` は `UI_DIST_DIR` に build 済み UI が存在しない場合は起動せず、`pnpm build:local` の実行を促します。
+
+## 補足
+
+- API は `/api/*` で配信されます
+- UI は server 側から同一オリジンで配信されます
+- 開発用の `pnpm dev` は従来どおり Vite (5173) + API server (3001) の分離起動です

--- a/README.local.md
+++ b/README.local.md
@@ -28,7 +28,7 @@ pnpm setup:local
 pnpm start:local
 ```
 
-起動後はブラウザで `http://localhost:3000` を開いてください。
+起動後は既定ブラウザで `http://localhost:3000` が自動で開きます。
 
 ## データ保存先
 
@@ -63,6 +63,7 @@ pnpm start:local
 | `PORT` | `3000` | ローカル試用版サーバーのポート |
 | `DB_PATH` | `./data/prompt-reviewer.sqlite` | SQLite DB ファイルの保存先 |
 | `UI_DIST_DIR` | `./packages/ui/dist` | 配信する build 済み UI のディレクトリ |
+| `OPEN_BROWSER_ON_START` | `true` | `pnpm start:local` 実行時に既定ブラウザを自動起動するか |
 
 `pnpm start:local` は `UI_DIST_DIR` に build 済み UI が存在しない場合は起動せず、`pnpm build:local` の実行を促します。
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pnpm setup:local
 pnpm start:local
 ```
 
-ブラウザで http://localhost:3000 を開くと利用できます。詳細は [README.local.md](README.local.md) を参照してください。
+`pnpm start:local` で既定ブラウザが自動で開きます。詳細は [README.local.md](README.local.md) を参照してください。
 
 ### 環境変数
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ pnpm dev
 
 ブラウザで http://localhost:5173 を開くと UI にアクセスできます。
 
+## ローカル試用版
+
+build 済み UI を server から配信するローカル試用版も利用できます。
+
+```bash
+pnpm setup:local
+pnpm start:local
+```
+
+ブラウザで http://localhost:3000 を開くと利用できます。詳細は [README.local.md](README.local.md) を参照してください。
+
 ### 環境変数
 
 `.env.example` をコピーして `.env` を作成し、必要に応じて値を変更してください。

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently -n core,server,ui -c yellow,blue,green \"pnpm --filter @prompt-reviewer/core build:watch\" \"pnpm --filter @prompt-reviewer/server dev\" \"pnpm --filter @prompt-reviewer/ui dev\"",
+    "setup:local": "node scripts/local.mjs setup",
+    "build:local": "node scripts/local.mjs build",
+    "migrate:local": "node scripts/local.mjs migrate",
+    "seed:local": "node scripts/local.mjs seed",
+    "start:local": "node scripts/local.mjs start",
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",

--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -1,4 +1,17 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { defineConfig } from "drizzle-kit";
+
+function resolveDrizzleDbUrl(): string {
+  const configuredPath = process.env.DB_PATH ?? "../../dev.db";
+
+  if (/^(file:|libsql:|https?:|wss?:)/.test(configuredPath)) {
+    return configuredPath;
+  }
+
+  const absolutePath = path.resolve(process.cwd(), configuredPath);
+  return pathToFileURL(absolutePath).href;
+}
 
 export default defineConfig({
   dialect: "sqlite",
@@ -11,6 +24,6 @@ export default defineConfig({
   ],
   out: "./drizzle",
   dbCredentials: {
-    url: process.env.DB_PATH ?? "../../dev.db",
+    url: resolveDrizzleDbUrl(),
   },
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,8 @@ import { serve } from "@hono/node-server";
 import { db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
@@ -11,6 +13,42 @@ import { createScoresRouter, createVersionSummaryRouter } from "./routes/scores.
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
 const app = new Hono();
+const uiDistDir = process.env.UI_DIST_DIR ? path.resolve(process.cwd(), process.env.UI_DIST_DIR) : null;
+
+const contentTypes: Record<string, string> = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+function resolveUiFilePath(requestPath: string): string | null {
+  if (!uiDistDir) return null;
+
+  const safePath = requestPath === "/" ? "index.html" : requestPath.replace(/^\/+/, "");
+  const resolvedPath = path.resolve(uiDistDir, safePath);
+  const relativePath = path.relative(uiDistDir, resolvedPath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return resolvedPath;
+}
+
+async function readUiFile(filePath: string | null): Promise<Uint8Array | null> {
+  if (!filePath) return null;
+
+  try {
+    return await readFile(filePath);
+  } catch {
+    return null;
+  }
+}
 
 app.use(
   "/*",
@@ -33,6 +71,42 @@ app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
 app.route("/api/projects/:projectId/score-progression", createScoreProgressionRouter(db));
 app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db));
+app.get("*", async (c) => {
+  if (!uiDistDir) {
+    return c.notFound();
+  }
+
+  const requestPath = c.req.path;
+  if (requestPath.startsWith("/api/")) {
+    return c.notFound();
+  }
+
+  const assetFilePath = resolveUiFilePath(requestPath);
+  const asset = await readUiFile(assetFilePath);
+  if (asset && assetFilePath) {
+    return new Response(asset, {
+      headers: {
+        "Content-Type": contentTypes[path.extname(assetFilePath)] ?? "application/octet-stream",
+      },
+    });
+  }
+
+  if (path.extname(requestPath)) {
+    return c.notFound();
+  }
+
+  const indexFilePath = resolveUiFilePath("/index.html");
+  const indexHtml = await readUiFile(indexFilePath);
+  if (!indexHtml) {
+    return c.notFound();
+  }
+
+  return new Response(indexHtml, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+});
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/scripts/local.mjs
+++ b/scripts/local.mjs
@@ -1,0 +1,79 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const dataDir = path.resolve(repoRoot, "data");
+const dbPath = path.resolve(dataDir, "prompt-reviewer.sqlite");
+const uiDistDir = path.resolve(repoRoot, "packages", "ui", "dist");
+const port = process.env.PORT ?? "3000";
+const commandRunner =
+  process.platform === "win32"
+    ? { command: "pwsh", baseArgs: ["-Command", "pnpm"] }
+    : { command: "pnpm", baseArgs: [] };
+
+function ensureDataDir() {
+  mkdirSync(dataDir, { recursive: true });
+}
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function runPnpm(args, env = process.env) {
+  run(commandRunner.command, [...commandRunner.baseArgs, ...args], env);
+}
+
+const localEnv = {
+  ...process.env,
+  DB_PATH: process.env.DB_PATH ?? dbPath,
+  UI_DIST_DIR: process.env.UI_DIST_DIR ?? uiDistDir,
+  PORT: port,
+};
+
+const action = process.argv[2];
+
+switch (action) {
+  case "setup":
+    ensureDataDir();
+    runPnpm(["install"]);
+    runPnpm(["--filter", "@prompt-reviewer/core", "build"], localEnv);
+    runPnpm(["--filter", "@prompt-reviewer/ui", "build"], localEnv);
+    runPnpm(["--filter", "@prompt-reviewer/core", "migrate"], localEnv);
+    break;
+  case "build":
+    ensureDataDir();
+    runPnpm(["--filter", "@prompt-reviewer/core", "build"], localEnv);
+    runPnpm(["--filter", "@prompt-reviewer/ui", "build"], localEnv);
+    break;
+  case "migrate":
+    ensureDataDir();
+    runPnpm(["--filter", "@prompt-reviewer/core", "migrate"], localEnv);
+    break;
+  case "seed":
+    ensureDataDir();
+    runPnpm(["--filter", "@prompt-reviewer/core", "seed"], localEnv);
+    break;
+  case "start":
+    ensureDataDir();
+    if (!existsSync(path.join(uiDistDir, "index.html"))) {
+      console.error("UI build output was not found. Run `pnpm build:local` first.");
+      process.exit(1);
+    }
+    runPnpm(["--filter", "@prompt-reviewer/server", "start"], localEnv);
+    break;
+  default:
+    console.error("Usage: node scripts/local.mjs <setup|build|migrate|seed|start>");
+    process.exit(1);
+}

--- a/scripts/local.mjs
+++ b/scripts/local.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +10,7 @@ const dataDir = path.resolve(repoRoot, "data");
 const dbPath = path.resolve(dataDir, "prompt-reviewer.sqlite");
 const uiDistDir = path.resolve(repoRoot, "packages", "ui", "dist");
 const port = process.env.PORT ?? "3000";
+const appUrl = process.env.LOCAL_APP_URL ?? `http://localhost:${port}`;
 const commandRunner =
   process.platform === "win32"
     ? { command: "pwsh", baseArgs: ["-Command", "pnpm"] }
@@ -35,11 +36,40 @@ function runPnpm(args, env = process.env) {
   run(commandRunner.command, [...commandRunner.baseArgs, ...args], env);
 }
 
+function shouldOpenBrowser() {
+  return process.env.OPEN_BROWSER_ON_START !== "false";
+}
+
+function openBrowser(url) {
+  const spawnOptions = {
+    cwd: repoRoot,
+    detached: true,
+    stdio: "ignore",
+  };
+
+  if (process.platform === "win32") {
+    spawn(
+      "pwsh",
+      ["-NoProfile", "-Command", `Start-Sleep -Seconds 2; Start-Process '${url}'`],
+      spawnOptions,
+    ).unref();
+    return;
+  }
+
+  if (process.platform === "darwin") {
+    spawn("sh", ["-c", `sleep 2; open '${url}'`], spawnOptions).unref();
+    return;
+  }
+
+  spawn("sh", ["-c", `sleep 2; xdg-open '${url}'`], spawnOptions).unref();
+}
+
 const localEnv = {
   ...process.env,
   DB_PATH: process.env.DB_PATH ?? dbPath,
   UI_DIST_DIR: process.env.UI_DIST_DIR ?? uiDistDir,
   PORT: port,
+  LOCAL_APP_URL: appUrl,
 };
 
 const action = process.argv[2];
@@ -70,6 +100,9 @@ switch (action) {
     if (!existsSync(path.join(uiDistDir, "index.html"))) {
       console.error("UI build output was not found. Run `pnpm build:local` first.");
       process.exit(1);
+    }
+    if (shouldOpenBrowser()) {
+      openBrowser(appUrl);
     }
     runPnpm(["--filter", "@prompt-reviewer/server", "start"], localEnv);
     break;


### PR DESCRIPTION
## 概要

Closes #84

ローカル試用版を Node.js + SQLite + build 済み UI + Hono server の単一ローカル Web アプリとして起動できるようにしました。

## 変更内容

- ルートにローカル試用向けスクリプトを追加
  - `pnpm setup:local`
  - `pnpm build:local`
  - `pnpm migrate:local`
  - `pnpm seed:local`
  - `pnpm start:local`
- `scripts/local.mjs` を追加し、`DB_PATH` / `UI_DIST_DIR` / `PORT` をまとめて扱うように変更
- server が build 済み UI を同一オリジンで配信できるように変更
- `drizzle.config.ts` で Windows の絶対パスでも migration が動くように `file:` URL 変換を追加
- `.env.example` をローカル試用版向けに更新
- `README.local.md` を追加し、既存 `README.md` からリンク
- SQLite と tsbuildinfo の生成物を `.gitignore` に追加

## 確認

- `pnpm --filter @prompt-reviewer/ui typecheck`
- `pnpm build:local`
- `pnpm migrate:local`
- `pnpm typecheck`
- `pnpm test`
- `pnpm start:local` を一時起動して以下を確認
  - `GET /api/health` が 200
  - `GET /` が 200
  - 返却内容に HTML を含むこと