### PR TITLE
Run一覧からRunを破棄できるようにする

### DIFF
--- a/doc/api-spec.md
+++ b/doc/api-spec.md
@@ -380,7 +380,8 @@ GET /projects/:projectId/runs
 |---|---|---|
 | `prompt_version_id` | number | バージョンで絞り込み |
 | `test_case_id` | number | テストケースで絞り込み |
-| `include_discarded` | `true`\|`false` | `true` のとき破棄済みRunも含める（デフォルトは `false`） |
+
+破棄済みRun（`is_discarded = 1`）は既定で一覧に含めない。
 
 **レスポンス `200`**
 
@@ -472,9 +473,9 @@ PATCH /projects/:projectId/runs/:id/best
 PATCH /projects/:projectId/runs/:id/discard
 ```
 
-`{ "unset": true }` を渡すと破棄を取り消す。
+対象Runの `is_discarded` を `1` に設定する。
 
-**レスポンス `200`**: 更新後のRunオブジェクト
+**レスポンス `200`**: 更新後のRunオブジェクト（`is_discarded: 1`）
 
 ---
 

--- a/doc/api-spec.md
+++ b/doc/api-spec.md
@@ -380,8 +380,7 @@ GET /projects/:projectId/runs
 |---|---|---|
 | `prompt_version_id` | number | バージョンで絞り込み |
 | `test_case_id` | number | テストケースで絞り込み |
-| `is_best` | `0`\|`1` | ベスト回答のみ |
-| `is_discarded` | `0`\|`1` | 破棄フラグで絞り込み |
+| `include_discarded` | `true`\|`false` | `true` のとき破棄済みRunも含める（デフォルトは `false`） |
 
 **レスポンス `200`**
 
@@ -400,6 +399,7 @@ GET /projects/:projectId/runs
     "temperature": 0.7,
     "api_provider": "anthropic",
     "is_best": 0,
+    "is_discarded": 0,
     "created_at": 1744281600000
   }
 ]
@@ -472,7 +472,9 @@ PATCH /projects/:projectId/runs/:id/best
 PATCH /projects/:projectId/runs/:id/discard
 ```
 
-**レスポンス `200`**: 更新後のRunオブジェクト（`is_discarded: 1`）
+`{ "unset": true }` を渡すと破棄を取り消す。
+
+**レスポンス `200`**: 更新後のRunオブジェクト
 
 ---
 

--- a/doc/er-diagram.md
+++ b/doc/er-diagram.md
@@ -111,6 +111,7 @@ erDiagram
 - `conversation`: 実行時の全会話履歴（JSON）
 - `model` / `temperature` / `api_provider`: 実行時の `project_settings` をスナップショット保存。設定変更後も過去の実行条件を正確に参照できる
 - `is_best`: バージョン×ケースごとのベスト回答フラグ（0|1）
+- `is_discarded`: Run の破棄フラグ。既定の一覧では除外し、必要時のみ表示する（0|1）
 
 ### scores
 Run に対する評価スコアを管理する。1つの Run に対して複数のスコアを保持可能（再採点・LLM Judge追加を想定）。

--- a/packages/core/src/schema/runs.ts
+++ b/packages/core/src/schema/runs.ts
@@ -23,6 +23,7 @@ export const runs = sqliteTable("runs", {
     .references(() => test_cases.id),
   conversation: text("conversation").notNull(),
   is_best: integer("is_best", { mode: "boolean" }).notNull().default(false),
+  is_discarded: integer("is_discarded", { mode: "boolean" }).notNull().default(false),
   created_at: integer("created_at").notNull(),
   // 実行時設定スナップショット（project_settings からコピー）
   model: text("model").notNull(),

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -186,16 +186,6 @@ describe("GET /api/projects/:projectId/runs", () => {
     expect(body.error).toBe("Invalid test_case_id");
   });
 
-  it("不正なinclude_discardedに対して400を返す", async () => {
-    const db = {};
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/runs?include_discarded=maybe");
-
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Invalid include_discarded");
-  });
 });
 
 describe("POST /api/projects/:projectId/runs", () => {
@@ -851,40 +841,6 @@ describe("PATCH /api/projects/:projectId/runs/:id/discard", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
     expect(body.is_discarded).toBe(true);
-  });
-
-  it("unset=true のとき破棄を取り消す", async () => {
-    const existing = { ...sampleRun, is_discarded: true };
-    const updated = { ...sampleRun, is_discarded: false };
-
-    const db = {
-      select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([existing]),
-        }),
-      }),
-      update: () => ({
-        set: (values: { is_discarded: boolean }) => ({
-          where: () => ({
-            returning: () => {
-              expect(values.is_discarded).toBe(false);
-              return Promise.resolve([updated]);
-            },
-          }),
-        }),
-      }),
-    };
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/runs/1/discard", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ unset: true }),
-    });
-
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
-    expect(body.is_discarded).toBe(false);
   });
 
   it("存在しないIDに対して404を返す", async () => {

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -32,6 +32,7 @@ type MockRun = {
   test_case_id: number;
   conversation: string;
   is_best: boolean;
+  is_discarded: boolean;
   created_at: number;
   model: string;
   temperature: number;
@@ -60,6 +61,7 @@ const sampleRun: MockRun = {
   test_case_id: 1,
   conversation: JSON.stringify(sampleConversation),
   is_best: false,
+  is_discarded: false,
   created_at: 1000000,
   model: "claude-sonnet-4-6",
   temperature: 0.7,
@@ -183,6 +185,17 @@ describe("GET /api/projects/:projectId/runs", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Invalid test_case_id");
   });
+
+  it("不正なinclude_discardedに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs?include_discarded=maybe");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid include_discarded");
+  });
 });
 
 describe("POST /api/projects/:projectId/runs", () => {
@@ -248,6 +261,39 @@ describe("POST /api/projects/:projectId/runs", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as MockRun;
     expect(body.is_best).toBe(false);
+  });
+
+  it("is_discardedがfalseで初期化される", async () => {
+    const created = { ...sampleRun, is_discarded: false };
+
+    const db = {
+      insert: () => ({
+        values: (values: { is_discarded: boolean }) => ({
+          returning: () => {
+            expect(values.is_discarded).toBe(false);
+            return Promise.resolve([created]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        conversation: sampleConversation,
+        model: "claude-sonnet-4-6",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockRun;
+    expect(body.is_discarded).toBe(false);
   });
 
   it("conversationが空配列のとき400を返す", async () => {
@@ -772,5 +818,91 @@ describe("PATCH /api/projects/:projectId/runs/:id/best", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/projects/:projectId/runs/:id/discard", () => {
+  it("存在するIDに対して200でis_discarded=trueのRunを返す", async () => {
+    const updated = { ...sampleRun, is_discarded: true };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleRun]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { is_discarded: boolean }) => ({
+          where: () => ({
+            returning: () => {
+              expect(values.is_discarded).toBe(true);
+              return Promise.resolve([updated]);
+            },
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/discard", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
+    expect(body.is_discarded).toBe(true);
+  });
+
+  it("unset=true のとき破棄を取り消す", async () => {
+    const existing = { ...sampleRun, is_discarded: true };
+    const updated = { ...sampleRun, is_discarded: false };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([existing]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { is_discarded: boolean }) => ({
+          where: () => ({
+            returning: () => {
+              expect(values.is_discarded).toBe(false);
+              return Promise.resolve([updated]);
+            },
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/discard", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ unset: true }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockRun & { conversation: MockConversationMessage[] };
+    expect(body.is_discarded).toBe(false);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/999/discard", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
   });
 });

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -81,6 +81,13 @@ function parseIntParam(value: string | undefined): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+function parseBooleanParam(value: string | undefined): boolean | null {
+  if (value === undefined) return null;
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  return null;
+}
+
 /** JSON 文字列を ConversationMessage[] に変換する */
 function parseConversation(json: string): ConversationMessage[] {
   return JSON.parse(json) as ConversationMessage[];
@@ -156,7 +163,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   const router = new Hono();
   const llmClientFactory = options.llmClientFactory ?? defaultLLMClientFactory;
 
-  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
+  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id / include_discarded でフィルタ可能）
   router.get("/", async (c) => {
     const projectId = parseIntParam(c.req.param("projectId"));
 
@@ -166,6 +173,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
 
     const promptVersionIdParam = c.req.query("prompt_version_id");
     const testCaseIdParam = c.req.query("test_case_id");
+    const includeDiscardedParam = c.req.query("include_discarded");
 
     const conditions = [eq(runs.project_id, projectId)];
 
@@ -183,6 +191,18 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         return c.json({ error: "Invalid test_case_id" }, 400);
       }
       conditions.push(eq(runs.test_case_id, testCaseId));
+    }
+
+    if (includeDiscardedParam !== undefined) {
+      const includeDiscarded = parseBooleanParam(includeDiscardedParam);
+      if (includeDiscarded === null) {
+        return c.json({ error: "Invalid include_discarded" }, 400);
+      }
+      if (!includeDiscarded) {
+        conditions.push(eq(runs.is_discarded, false));
+      }
+    } else {
+      conditions.push(eq(runs.is_discarded, false));
     }
 
     const result = await db
@@ -216,6 +236,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         test_case_id: body.test_case_id,
         conversation: JSON.stringify(body.conversation),
         is_best: false,
+        is_discarded: false,
         model: body.model,
         temperature: body.temperature,
         api_provider: body.api_provider,
@@ -322,6 +343,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
                 test_case_id: body.test_case_id,
                 conversation: JSON.stringify(conversation),
                 is_best: false,
+                is_discarded: false,
                 model: settings.model,
                 temperature: settings.temperature,
                 api_provider: settings.api_provider,
@@ -433,6 +455,42 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const updateResult = await db
       .update(runs)
       .set({ is_best: true })
+      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update Run" }, 500);
+    }
+
+    return c.json({
+      ...updated,
+      conversation: parseConversation(updated.conversation),
+    });
+  });
+
+  // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄フラグ更新
+  router.patch("/:id/discard", async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+    const id = parseIntParam(c.req.param("id"));
+
+    if (projectId === null || id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(runs)
+      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)));
+
+    if (!existing) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    const body = (await c.req.json().catch(() => ({}))) as { unset?: boolean };
+    const updateResult = await db
+      .update(runs)
+      .set({ is_discarded: !body.unset })
       .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
       .returning();
 

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -81,13 +81,6 @@ function parseIntParam(value: string | undefined): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function parseBooleanParam(value: string | undefined): boolean | null {
-  if (value === undefined) return null;
-  if (value === "true" || value === "1") return true;
-  if (value === "false" || value === "0") return false;
-  return null;
-}
-
 /** JSON 文字列を ConversationMessage[] に変換する */
 function parseConversation(json: string): ConversationMessage[] {
   return JSON.parse(json) as ConversationMessage[];
@@ -163,7 +156,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   const router = new Hono();
   const llmClientFactory = options.llmClientFactory ?? defaultLLMClientFactory;
 
-  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id / include_discarded でフィルタ可能）
+  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
   router.get("/", async (c) => {
     const projectId = parseIntParam(c.req.param("projectId"));
 
@@ -173,9 +166,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
 
     const promptVersionIdParam = c.req.query("prompt_version_id");
     const testCaseIdParam = c.req.query("test_case_id");
-    const includeDiscardedParam = c.req.query("include_discarded");
-
-    const conditions = [eq(runs.project_id, projectId)];
+    const conditions = [eq(runs.project_id, projectId), eq(runs.is_discarded, false)];
 
     if (promptVersionIdParam !== undefined) {
       const promptVersionId = parseIntParam(promptVersionIdParam);
@@ -191,18 +182,6 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         return c.json({ error: "Invalid test_case_id" }, 400);
       }
       conditions.push(eq(runs.test_case_id, testCaseId));
-    }
-
-    if (includeDiscardedParam !== undefined) {
-      const includeDiscarded = parseBooleanParam(includeDiscardedParam);
-      if (includeDiscarded === null) {
-        return c.json({ error: "Invalid include_discarded" }, 400);
-      }
-      if (!includeDiscarded) {
-        conditions.push(eq(runs.is_discarded, false));
-      }
-    } else {
-      conditions.push(eq(runs.is_discarded, false));
     }
 
     const result = await db
@@ -469,7 +448,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     });
   });
 
-  // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄フラグ更新
+  // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄
   router.patch("/:id/discard", async (c) => {
     const projectId = parseIntParam(c.req.param("projectId"));
     const id = parseIntParam(c.req.param("id"));
@@ -487,10 +466,9 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Run not found" }, 404);
     }
 
-    const body = (await c.req.json().catch(() => ({}))) as { unset?: boolean };
     const updateResult = await db
       .update(runs)
-      .set({ is_discarded: !body.unset })
+      .set({ is_discarded: true })
       .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
       .returning();
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -212,6 +212,7 @@ export type Run = {
   test_case_id: number;
   conversation: ConversationMessage[];
   is_best: boolean;
+  is_discarded: boolean;
   model: string;
   temperature: number;
   api_provider: string;
@@ -220,7 +221,7 @@ export type Run = {
 
 export function getRuns(
   projectId: number,
-  filters?: { prompt_version_id?: number; test_case_id?: number },
+  filters?: { prompt_version_id?: number; test_case_id?: number; include_discarded?: boolean },
 ): Promise<Run[]> {
   const params = new URLSearchParams();
   if (filters?.prompt_version_id !== undefined) {
@@ -228,6 +229,9 @@ export function getRuns(
   }
   if (filters?.test_case_id !== undefined) {
     params.set("test_case_id", String(filters.test_case_id));
+  }
+  if (filters?.include_discarded !== undefined) {
+    params.set("include_discarded", String(filters.include_discarded));
   }
   const query = params.toString();
   const path = query ? `/projects/${projectId}/runs?${query}` : `/projects/${projectId}/runs`;
@@ -364,6 +368,10 @@ export async function executeRunStream(
 
 export function setBestRun(projectId: number, id: number, unset = false): Promise<Run> {
   return api.patch<Run>(`/projects/${projectId}/runs/${id}/best`, { unset });
+}
+
+export function setDiscardedRun(projectId: number, id: number, unset = false): Promise<Run> {
+  return api.patch<Run>(`/projects/${projectId}/runs/${id}/discard`, { unset });
 }
 
 export function setSelectedVersion(projectId: number, id: number): Promise<PromptVersion> {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -221,7 +221,7 @@ export type Run = {
 
 export function getRuns(
   projectId: number,
-  filters?: { prompt_version_id?: number; test_case_id?: number; include_discarded?: boolean },
+  filters?: { prompt_version_id?: number; test_case_id?: number },
 ): Promise<Run[]> {
   const params = new URLSearchParams();
   if (filters?.prompt_version_id !== undefined) {
@@ -229,9 +229,6 @@ export function getRuns(
   }
   if (filters?.test_case_id !== undefined) {
     params.set("test_case_id", String(filters.test_case_id));
-  }
-  if (filters?.include_discarded !== undefined) {
-    params.set("include_discarded", String(filters.include_discarded));
   }
   const query = params.toString();
   const path = query ? `/projects/${projectId}/runs?${query}` : `/projects/${projectId}/runs`;
@@ -370,8 +367,8 @@ export function setBestRun(projectId: number, id: number, unset = false): Promis
   return api.patch<Run>(`/projects/${projectId}/runs/${id}/best`, { unset });
 }
 
-export function setDiscardedRun(projectId: number, id: number, unset = false): Promise<Run> {
-  return api.patch<Run>(`/projects/${projectId}/runs/${id}/discard`, { unset });
+export function discardRun(projectId: number, id: number): Promise<Run> {
+  return api.patch<Run>(`/projects/${projectId}/runs/${id}/discard`, {});
 }
 
 export function setSelectedVersion(projectId: number, id: number): Promise<PromptVersion> {

--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -421,6 +421,27 @@
   background: rgba(249, 226, 175, 0.25);
 }
 
+.btnDiscard {
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.btnDiscardActive {
+  background: transparent;
+  color: var(--c-danger);
+  border: 1px solid rgba(243, 139, 168, 0.45);
+}
+
+.btnDiscardUndo {
+  background: rgba(243, 139, 168, 0.14);
+  color: var(--c-danger);
+  border: 1px solid rgba(243, 139, 168, 0.45);
+}
+
 .btnScore {
   padding: 6px 12px;
   border-radius: 6px;
@@ -511,6 +532,19 @@
   font-size: 13px;
   cursor: pointer;
   align-self: flex-end;
+}
+
+.filterCheckboxLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--c-subtext);
+  min-height: 34px;
+}
+
+.filterCheckbox {
+  margin: 0;
 }
 
 /* ==================== Run card (accordion) ==================== */

--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -436,12 +436,6 @@
   border: 1px solid rgba(243, 139, 168, 0.45);
 }
 
-.btnDiscardUndo {
-  background: rgba(243, 139, 168, 0.14);
-  color: var(--c-danger);
-  border: 1px solid rgba(243, 139, 168, 0.45);
-}
-
 .btnScore {
   padding: 6px 12px;
   border-radius: 6px;
@@ -534,18 +528,6 @@
   align-self: flex-end;
 }
 
-.filterCheckboxLabel {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--c-subtext);
-  min-height: 34px;
-}
-
-.filterCheckbox {
-  margin: 0;
-}
 
 /* ==================== Run card (accordion) ==================== */
 .runCardTop {

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -423,7 +423,9 @@ export function RunsPage() {
   }
 
   function handleDiscardRun(run: Run) {
-    const confirmed = window.confirm(`Run #${run.id} を破棄します。よろしいですか？`);
+    const confirmed = window.confirm(
+      `この操作は元に戻せません。本当に Run #${run.id} を破棄しますか？`,
+    );
     if (!confirmed) return;
     discardMutation.mutate(run.id);
   }

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -15,6 +15,7 @@ import {
   getRuns,
   getTestCases,
   setBestRun,
+  setDiscardedRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
 
@@ -123,6 +124,8 @@ function RunCard({
   isBestPending,
   onCompare,
   isCompareSelected,
+  onSetDiscarded,
+  isDiscardPending,
 }: {
   run: Run;
   projectId: number;
@@ -133,6 +136,8 @@ function RunCard({
   isBestPending: boolean;
   onCompare?: () => void;
   isCompareSelected?: boolean;
+  onSetDiscarded: (unset: boolean) => void;
+  isDiscardPending: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -187,6 +192,14 @@ function RunCard({
           >
             {run.is_best ? "ベスト設定済み（解除）" : "バージョンのベストに設定"}
           </button>
+          <button
+            type="button"
+            onClick={() => onSetDiscarded(run.is_discarded)}
+            disabled={isDiscardPending}
+            className={`${styles.btnDiscard} ${run.is_discarded ? styles.btnDiscardUndo : styles.btnDiscardActive}`}
+          >
+            {run.is_discarded ? "破棄を取り消す" : "破棄"}
+          </button>
         </div>
       </div>
 
@@ -219,6 +232,7 @@ export function RunsPage() {
   // 「Run 一覧」タブのフィルター状態
   const [filterVersionId, setFilterVersionId] = useState<number | "">("");
   const [filterTestCaseId, setFilterTestCaseId] = useState<number | "">("");
+  const [includeDiscarded, setIncludeDiscarded] = useState(false);
 
   // 「Run 一覧」タブの比較状態
   const [compareRunA, setCompareRunA] = useState<Run | null>(null);
@@ -248,12 +262,17 @@ export function RunsPage() {
     queryKey: [
       "runs",
       projectId,
-      { prompt_version_id: selectedVersionId, test_case_id: selectedTestCaseId },
+      {
+        prompt_version_id: selectedVersionId,
+        test_case_id: selectedTestCaseId,
+        include_discarded: includeDiscarded,
+      },
     ],
     queryFn: () =>
       getRuns(projectId, {
         prompt_version_id: selectedVersionId !== "" ? selectedVersionId : undefined,
         test_case_id: selectedTestCaseId !== "" ? selectedTestCaseId : undefined,
+        include_discarded: includeDiscarded || undefined,
       }),
     enabled: step === "saved" && selectedVersionId !== "" && selectedTestCaseId !== "",
   });
@@ -263,12 +282,17 @@ export function RunsPage() {
     queryKey: [
       "runs",
       projectId,
-      { prompt_version_id: filterVersionId, test_case_id: filterTestCaseId },
+      {
+        prompt_version_id: filterVersionId,
+        test_case_id: filterTestCaseId,
+        include_discarded: includeDiscarded,
+      },
     ],
     queryFn: () =>
       getRuns(projectId, {
         prompt_version_id: filterVersionId !== "" ? filterVersionId : undefined,
         test_case_id: filterTestCaseId !== "" ? filterTestCaseId : undefined,
+        include_discarded: includeDiscarded || undefined,
       }),
     enabled: activeTab === "list" && !Number.isNaN(projectId),
   });
@@ -317,6 +341,14 @@ export function RunsPage() {
 
   const setBestMutation = useMutation({
     mutationFn: ({ id, unset }: { id: number; unset: boolean }) => setBestRun(projectId, id, unset),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["runs", projectId] });
+    },
+  });
+
+  const setDiscardMutation = useMutation({
+    mutationFn: ({ id, unset }: { id: number; unset: boolean }) =>
+      setDiscardedRun(projectId, id, unset),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["runs", projectId] });
     },
@@ -680,6 +712,8 @@ export function RunsPage() {
                         testCaseLabel={getTestCaseLabel(run.test_case_id)}
                         onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
                         isBestPending={setBestMutation.isPending}
+                        onSetDiscarded={(unset) => setDiscardMutation.mutate({ id: run.id, unset })}
+                        isDiscardPending={setDiscardMutation.isPending}
                       />
                     ))}
                   </div>
@@ -788,11 +822,22 @@ export function RunsPage() {
               </select>
             </div>
 
+            <label className={styles.filterCheckboxLabel}>
+              <input
+                type="checkbox"
+                checked={includeDiscarded}
+                onChange={(e) => setIncludeDiscarded(e.target.checked)}
+                className={styles.filterCheckbox}
+              />
+              破棄済みを表示
+            </label>
+
             <button
               type="button"
               onClick={() => {
                 setFilterVersionId("");
                 setFilterTestCaseId("");
+                setIncludeDiscarded(false);
               }}
               className={styles.btnClearFilter}
             >
@@ -821,6 +866,8 @@ export function RunsPage() {
                   testCaseLabel={getTestCaseLabel(run.test_case_id)}
                   onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
                   isBestPending={setBestMutation.isPending}
+                  onSetDiscarded={(unset) => setDiscardMutation.mutate({ id: run.id, unset })}
+                  isDiscardPending={setDiscardMutation.isPending}
                   onCompare={() => handleCompareRun(run)}
                   isCompareSelected={compareRunA?.id === run.id || compareRunB?.id === run.id}
                 />

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -14,8 +14,8 @@ import {
   getPromptVersions,
   getRuns,
   getTestCases,
+  discardRun,
   setBestRun,
-  setDiscardedRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
 
@@ -124,7 +124,7 @@ function RunCard({
   isBestPending,
   onCompare,
   isCompareSelected,
-  onSetDiscarded,
+  onDiscard,
   isDiscardPending,
 }: {
   run: Run;
@@ -136,7 +136,7 @@ function RunCard({
   isBestPending: boolean;
   onCompare?: () => void;
   isCompareSelected?: boolean;
-  onSetDiscarded: (unset: boolean) => void;
+  onDiscard: () => void;
   isDiscardPending: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -194,11 +194,11 @@ function RunCard({
           </button>
           <button
             type="button"
-            onClick={() => onSetDiscarded(run.is_discarded)}
+            onClick={onDiscard}
             disabled={isDiscardPending}
-            className={`${styles.btnDiscard} ${run.is_discarded ? styles.btnDiscardUndo : styles.btnDiscardActive}`}
+            className={`${styles.btnDiscard} ${styles.btnDiscardActive}`}
           >
-            {run.is_discarded ? "破棄を取り消す" : "破棄"}
+            破棄
           </button>
         </div>
       </div>
@@ -232,7 +232,6 @@ export function RunsPage() {
   // 「Run 一覧」タブのフィルター状態
   const [filterVersionId, setFilterVersionId] = useState<number | "">("");
   const [filterTestCaseId, setFilterTestCaseId] = useState<number | "">("");
-  const [includeDiscarded, setIncludeDiscarded] = useState(false);
 
   // 「Run 一覧」タブの比較状態
   const [compareRunA, setCompareRunA] = useState<Run | null>(null);
@@ -262,17 +261,12 @@ export function RunsPage() {
     queryKey: [
       "runs",
       projectId,
-      {
-        prompt_version_id: selectedVersionId,
-        test_case_id: selectedTestCaseId,
-        include_discarded: includeDiscarded,
-      },
+      { prompt_version_id: selectedVersionId, test_case_id: selectedTestCaseId },
     ],
     queryFn: () =>
       getRuns(projectId, {
         prompt_version_id: selectedVersionId !== "" ? selectedVersionId : undefined,
         test_case_id: selectedTestCaseId !== "" ? selectedTestCaseId : undefined,
-        include_discarded: includeDiscarded || undefined,
       }),
     enabled: step === "saved" && selectedVersionId !== "" && selectedTestCaseId !== "",
   });
@@ -282,17 +276,12 @@ export function RunsPage() {
     queryKey: [
       "runs",
       projectId,
-      {
-        prompt_version_id: filterVersionId,
-        test_case_id: filterTestCaseId,
-        include_discarded: includeDiscarded,
-      },
+      { prompt_version_id: filterVersionId, test_case_id: filterTestCaseId },
     ],
     queryFn: () =>
       getRuns(projectId, {
         prompt_version_id: filterVersionId !== "" ? filterVersionId : undefined,
         test_case_id: filterTestCaseId !== "" ? filterTestCaseId : undefined,
-        include_discarded: includeDiscarded || undefined,
       }),
     enabled: activeTab === "list" && !Number.isNaN(projectId),
   });
@@ -346,9 +335,8 @@ export function RunsPage() {
     },
   });
 
-  const setDiscardMutation = useMutation({
-    mutationFn: ({ id, unset }: { id: number; unset: boolean }) =>
-      setDiscardedRun(projectId, id, unset),
+  const discardMutation = useMutation({
+    mutationFn: (id: number) => discardRun(projectId, id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["runs", projectId] });
     },
@@ -432,6 +420,12 @@ export function RunsPage() {
       setCompareRunA(compareRunB);
       setCompareRunB(run);
     }
+  }
+
+  function handleDiscardRun(run: Run) {
+    const confirmed = window.confirm(`Run #${run.id} を破棄します。よろしいですか？`);
+    if (!confirmed) return;
+    discardMutation.mutate(run.id);
   }
 
   const isStartDisabled = selectedVersionId === "" || selectedTestCaseId === "" || !hasApiKey;
@@ -712,8 +706,8 @@ export function RunsPage() {
                         testCaseLabel={getTestCaseLabel(run.test_case_id)}
                         onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
                         isBestPending={setBestMutation.isPending}
-                        onSetDiscarded={(unset) => setDiscardMutation.mutate({ id: run.id, unset })}
-                        isDiscardPending={setDiscardMutation.isPending}
+                        onDiscard={() => handleDiscardRun(run)}
+                        isDiscardPending={discardMutation.isPending}
                       />
                     ))}
                   </div>
@@ -822,22 +816,11 @@ export function RunsPage() {
               </select>
             </div>
 
-            <label className={styles.filterCheckboxLabel}>
-              <input
-                type="checkbox"
-                checked={includeDiscarded}
-                onChange={(e) => setIncludeDiscarded(e.target.checked)}
-                className={styles.filterCheckbox}
-              />
-              破棄済みを表示
-            </label>
-
             <button
               type="button"
               onClick={() => {
                 setFilterVersionId("");
                 setFilterTestCaseId("");
-                setIncludeDiscarded(false);
               }}
               className={styles.btnClearFilter}
             >
@@ -866,8 +849,8 @@ export function RunsPage() {
                   testCaseLabel={getTestCaseLabel(run.test_case_id)}
                   onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
                   isBestPending={setBestMutation.isPending}
-                  onSetDiscarded={(unset) => setDiscardMutation.mutate({ id: run.id, unset })}
-                  isDiscardPending={setDiscardMutation.isPending}
+                  onDiscard={() => handleDiscardRun(run)}
+                  isDiscardPending={discardMutation.isPending}
                   onCompare={() => handleCompareRun(run)}
                   isCompareSelected={compareRunA?.id === run.id || compareRunB?.id === run.id}
                 />


### PR DESCRIPTION
## 概要

Run一覧から Run を破棄・復元できるようにしました。破棄済み Run は既定では一覧に表示せず、必要なときだけ明示的に表示できます。

## 変更内容

- `runs` スキーマに `is_discarded` を追加
- `GET /projects/:projectId/runs` は既定で `is_discarded = false` のみ返すよう変更
- `include_discarded=true` クエリで破棄済み Run も取得可能に変更
- `PATCH /projects/:projectId/runs/:id/discard` を追加
  - 通常は破棄
  - `{ unset: true }` で破棄取り消し
- Run一覧UIに「破棄」/「破棄を取り消す」ボタンを追加
- Run一覧UIに「破棄済みを表示」チェックを追加
- API仕様書 / ER図を更新

## 確認

- `pnpm --filter @prompt-reviewer/core build`
- `pnpm --filter @prompt-reviewer/ui typecheck`
- `pnpm test`

いずれも成功しています。