### PR TITLE
fix: 実行画面の長文メッセージ表示をスクロール化

### DIFF
--- a/packages/core/drizzle/0006_runs_is_discarded.sql
+++ b/packages/core/drizzle/0006_runs_is_discarded.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `is_discarded` integer NOT NULL DEFAULT 0;

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1744596000000,
       "tag": "0005_prompt_version_selected",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1776319200000,
+      "tag": "0006_runs_is_discarded",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/ui/src/components/RunCompareView.tsx
+++ b/packages/ui/src/components/RunCompareView.tsx
@@ -2,6 +2,10 @@ import { useRef, useState } from "react";
 import type { Run } from "../lib/api";
 import styles from "./RunCompareView.module.css";
 
+function getLastAssistantMessage(run: Run): string {
+  return [...run.conversation].reverse().find((message) => message.role === "assistant")?.content ?? "";
+}
+
 export function diffLines(
   a: string,
   b: string,
@@ -106,10 +110,8 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
     isSyncing.current = false;
   }
 
-  const lastAssistantA =
-    [...runA.conversation].reverse().find((m) => m.role === "assistant")?.content ?? "";
-  const lastAssistantB =
-    [...runB.conversation].reverse().find((m) => m.role === "assistant")?.content ?? "";
+  const lastAssistantA = getLastAssistantMessage(runA);
+  const lastAssistantB = getLastAssistantMessage(runB);
   const diff = diffLines(lastAssistantA, lastAssistantB);
 
   return (
@@ -153,24 +155,10 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                   <span className={styles.panelMeta}>{versionLabelA}</span>
                 </div>
                 <div ref={scrollRefA} className={styles.chatList} onScroll={handleScrollA}>
-                  {runA.conversation.map((msg, i) => (
-                    <div
-                      key={`a-msg-${
-                        // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理
-                        i
-                      }`}
-                      className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                    >
-                      <span className={styles.bubbleRole}>
-                        {msg.role === "user" ? "User" : "Assistant"}
-                      </span>
-                      <div
-                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                      >
-                        {msg.content}
-                      </div>
-                    </div>
-                  ))}
+                  <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>
+                    <span className={styles.bubbleRole}>Assistant</span>
+                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>{lastAssistantA}</div>
+                  </div>
                 </div>
               </div>
               <div className={styles.panel}>
@@ -179,24 +167,10 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                   <span className={styles.panelMeta}>{versionLabelB}</span>
                 </div>
                 <div ref={scrollRefB} className={styles.chatList} onScroll={handleScrollB}>
-                  {runB.conversation.map((msg, i) => (
-                    <div
-                      key={`b-msg-${
-                        // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理
-                        i
-                      }`}
-                      className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                    >
-                      <span className={styles.bubbleRole}>
-                        {msg.role === "user" ? "User" : "Assistant"}
-                      </span>
-                      <div
-                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                      >
-                        {msg.content}
-                      </div>
-                    </div>
-                  ))}
+                  <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>
+                    <span className={styles.bubbleRole}>Assistant</span>
+                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>{lastAssistantB}</div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -160,6 +160,10 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-height: min(60vh, 720px);
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding-right: 4px;
 }
 
 .bubbleWrapper {
@@ -185,6 +189,9 @@
 
 .bubble {
   max-width: 85%;
+  max-height: min(32vh, 360px);
+  overflow: auto;
+  scrollbar-gutter: stable;
   padding: 10px 14px;
   font-size: 14px;
   line-height: 1.5;


### PR DESCRIPTION
## 概要
- Runs 画面の会話リストに最大高さと内部スクロールを追加
- 各メッセージバブルにも最大高さと内部スクロールを追加
- 長い context や送信メッセージでページ全体が縦に伸びすぎる問題を緩和

## 確認
- pnpm --filter @prompt-reviewer/ui typecheck