### PR TITLE
Run作成タブの導線と文言を調整

### DIFF
--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -257,6 +257,10 @@
   flex-direction: column;
 }
 
+.inputActionsTop {
+  margin-bottom: 12px;
+}
+
 .btnSave {
   padding: 10px 20px;
   background: var(--c-green);

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -366,6 +366,10 @@ export function RunsPage() {
   }
 
   function handleNewRun() {
+    if (savedRun) {
+      setSelectedVersionId(savedRun.prompt_version_id);
+      setSelectedTestCaseId(savedRun.test_case_id);
+    }
     setSavedRun(null);
     setLlmResponse("");
     setExecuteError(null);
@@ -446,7 +450,7 @@ export function RunsPage() {
           {/* Step 1: 選択フォーム */}
           {step === "select" && (
             <div className={styles.selectCard}>
-              <h3 className={styles.selectCardTitle}>Run を開始する</h3>
+              <h3 className={styles.selectCardTitle}>Run を取得する</h3>
 
               <div className={styles.fieldGroup}>
                 <label htmlFor="select-version" className={styles.fieldLabel}>
@@ -508,7 +512,7 @@ export function RunsPage() {
                 title={!hasApiKey ? "APIキーが未設定です（設定画面で入力してください）" : undefined}
                 className={`${styles.btnStart} ${isStartDisabled ? styles.btnStartDisabled : ""}`}
               >
-                Run を開始
+                Run の取得
               </button>
               {!hasApiKey && (
                 <p className={styles.fieldHint}>
@@ -585,6 +589,17 @@ export function RunsPage() {
                     実行すると応答をストリーミング表示し、完了後に Run として保存します。
                   </p>
 
+                  <div className={styles.inputActionsTop}>
+                    <button
+                      type="button"
+                      onClick={handleExecuteRun}
+                      disabled={isExecuteDisabled}
+                      className={`${styles.btnLlmRun} ${isExecuteDisabled ? styles.btnLlmRunDisabled : ""}`}
+                    >
+                      {executeRunMutation.isPending ? "実行中..." : "実行"}
+                    </button>
+                  </div>
+
                   <textarea
                     value={llmResponse}
                     onChange={(e) => setLlmResponse(e.target.value)}
@@ -594,15 +609,6 @@ export function RunsPage() {
                   />
 
                   <div className={styles.inputActions}>
-                    <button
-                      type="button"
-                      onClick={handleExecuteRun}
-                      disabled={isExecuteDisabled}
-                      className={`${styles.btnLlmRun} ${isExecuteDisabled ? styles.btnLlmRunDisabled : ""}`}
-                    >
-                      {executeRunMutation.isPending ? "実行中..." : "実行"}
-                    </button>
-
                     <button
                       type="button"
                       onClick={handleSaveRun}


### PR DESCRIPTION
## 概要

Run作成タブの導線を少し整理しました。ボタンの意味が伝わりやすいように文言を調整し、再実行時の選択状態も保持するようにしています。

## 変更内容

- `Run を開始する` を `Run を取得する` に変更
- `Run を開始` を `Run の取得` に変更
- `実行` ボタンを LLM応答グループの上に移動
- `新しい Run を作成` を押したとき、前回のプロンプトバージョン / テストケース選択を保持するように変更

## 補足

- 既存の Run破棄PRとは分離した新規PRです
- 変更ファイルは `packages/ui/src/pages/RunsPage.tsx` と `RunsPage.module.css` のみです