### PR TITLE
Issue #89 pnpm typecheck の core 型解決を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@prompt-reviewer/core": ["packages/core/src/index.ts"]
+    },
     "resolveJsonModule": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## 概要
- root の typecheck 時に @prompt-reviewer/core が dist 前提で解決される問題を修正
- 	sconfig.json に paths を追加し、packages/core/src/index.ts を参照するよう変更
- clean worktree でも pnpm typecheck が通る状態に修正

## 確認
- pnpm install
- pnpm typecheck

Closes #89