### PR TITLE
Issue #30 コンテキストファイル Viewer / Editor を追加

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,10 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { serve } from "@hono/node-server";
 import { db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
+import { createContextFilesRouter } from "./routes/context-files.js";
 import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
@@ -13,7 +14,9 @@ import { createScoresRouter, createVersionSummaryRouter } from "./routes/scores.
 import { createTestCasesRouter } from "./routes/test-cases.js";
 
 const app = new Hono();
-const uiDistDir = process.env.UI_DIST_DIR ? path.resolve(process.cwd(), process.env.UI_DIST_DIR) : null;
+const uiDistDir = process.env.UI_DIST_DIR
+  ? path.resolve(process.cwd(), process.env.UI_DIST_DIR)
+  : null;
 
 const contentTypes: Record<string, string> = {
   ".css": "text/css; charset=utf-8",
@@ -64,6 +67,7 @@ app.get("/api/health", (c) => {
 });
 
 app.route("/api/projects", createProjectsRouter(db));
+app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));

--- a/packages/server/src/routes/context-files.test.ts
+++ b/packages/server/src/routes/context-files.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import { afterEach, describe, expect, it } from "vitest";
+import { createContextFilesRouter } from "./context-files.js";
+
+async function createTempDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "prompt-reviewer-context-files-"));
+}
+
+function buildApp(baseDir: string) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/context-files", createContextFilesRouter({ baseDir }));
+  return app;
+}
+
+const cleanupTargets: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupTargets.splice(0).map((target) => rm(target, { recursive: true, force: true })),
+  );
+});
+
+describe("context files router", () => {
+  it("GET /api/projects/:projectId/context-files returns uploaded files", async () => {
+    const baseDir = await createTempDir();
+    cleanupTargets.push(baseDir);
+    const projectDir = path.join(baseDir, "12");
+    await mkdir(path.join(projectDir, "docs"), { recursive: true });
+    await writeFile(path.join(projectDir, "docs", "guide.md"), "# guide", {
+      encoding: "utf8",
+      flag: "w",
+    });
+
+    const app = buildApp(baseDir);
+    const res = await app.request("/api/projects/12/context-files");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ path: string; name: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0]?.path).toBe("docs/guide.md");
+    expect(body[0]?.name).toBe("guide.md");
+  });
+
+  it("POST /api/projects/:projectId/context-files creates a file under the project directory", async () => {
+    const baseDir = await createTempDir();
+    cleanupTargets.push(baseDir);
+    const app = buildApp(baseDir);
+
+    const res = await app.request("/api/projects/3/context-files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        file_name: "snapshots/policy.txt",
+        content: "refund within 30 days",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const saved = await readFile(path.join(baseDir, "3", "snapshots", "policy.txt"), "utf8");
+    expect(saved).toBe("refund within 30 days");
+  });
+
+  it("GET /content returns file content", async () => {
+    const baseDir = await createTempDir();
+    cleanupTargets.push(baseDir);
+    const targetPath = path.join(baseDir, "7", "context.md");
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, "hello context", { encoding: "utf8", flag: "w" });
+
+    const app = buildApp(baseDir);
+    const res = await app.request("/api/projects/7/context-files/content?path=context.md");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string; path: string };
+    expect(body.content).toBe("hello context");
+    expect(body.path).toBe("context.md");
+  });
+
+  it("PUT /content updates an existing file", async () => {
+    const baseDir = await createTempDir();
+    cleanupTargets.push(baseDir);
+    const targetPath = path.join(baseDir, "9", "drafts", "memo.md");
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, "before", { encoding: "utf8", flag: "w" });
+
+    const app = buildApp(baseDir);
+    const res = await app.request("/api/projects/9/context-files/content?path=drafts/memo.md", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "after" }),
+    });
+
+    expect(res.status).toBe(200);
+    const saved = await readFile(targetPath, "utf8");
+    expect(saved).toBe("after");
+    const body = (await res.json()) as { content: string };
+    expect(body.content).toBe("after");
+  });
+
+  it("rejects traversal paths", async () => {
+    const baseDir = await createTempDir();
+    cleanupTargets.push(baseDir);
+    const app = buildApp(baseDir);
+
+    const res = await app.request("/api/projects/4/context-files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        file_name: "../escape.txt",
+        content: "bad",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/context-files.ts
+++ b/packages/server/src/routes/context-files.ts
@@ -1,0 +1,251 @@
+import type { Dirent } from "node:fs";
+import { access, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createContextFileSchema = z.object({
+  file_name: z.string().min(1, "file_nameは1文字以上必要です"),
+  content: z.string(),
+  mime_type: z.string().optional(),
+});
+
+const updateContextFileSchema = z.object({
+  content: z.string(),
+});
+
+export type ContextFileSummary = {
+  name: string;
+  path: string;
+  mime_type: string;
+  size: number;
+  updated_at: number;
+};
+
+export type ContextFileDetail = ContextFileSummary & {
+  content: string;
+};
+
+type ContextFilesRouterOptions = {
+  baseDir?: string;
+};
+
+const textMimeTypes: Record<string, string> = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".md": "text/markdown",
+  ".py": "text/x-python",
+  ".sql": "application/sql",
+  ".ts": "text/typescript",
+  ".tsx": "text/tsx",
+  ".txt": "text/plain",
+  ".xml": "application/xml",
+  ".yaml": "application/yaml",
+  ".yml": "application/yaml",
+};
+
+function getBaseDir(options: ContextFilesRouterOptions): string {
+  const configured =
+    options.baseDir ??
+    process.env.CONTEXT_FILES_DIR ??
+    path.resolve(process.cwd(), "data/context-files");
+  return path.resolve(configured);
+}
+
+function parseProjectId(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function inferMimeType(fileName: string): string {
+  const ext = path.extname(fileName).toLowerCase();
+  return textMimeTypes[ext] ?? "text/plain";
+}
+
+function sanitizeRelativePath(input: string): string | null {
+  const normalized = input.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!normalized) return null;
+
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.length === 0) return null;
+  if (parts.some((part) => part === "." || part === "..")) return null;
+
+  return parts.join("/");
+}
+
+function resolveProjectRoot(baseDir: string, projectId: number): string {
+  return path.join(baseDir, String(projectId));
+}
+
+function resolveProjectFilePath(projectRoot: string, relativePath: string): string | null {
+  const safeRelativePath = sanitizeRelativePath(relativePath);
+  if (!safeRelativePath) return null;
+
+  const resolvedPath = path.resolve(projectRoot, safeRelativePath);
+  const relativeToRoot = path.relative(projectRoot, resolvedPath);
+  if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
+    return null;
+  }
+
+  return resolvedPath;
+}
+
+async function listProjectFiles(
+  projectRoot: string,
+  currentDir = projectRoot,
+): Promise<ContextFileSummary[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        return listProjectFiles(projectRoot, fullPath);
+      }
+      if (!entry.isFile()) {
+        return [];
+      }
+
+      const fileStat = await stat(fullPath);
+      const relativePath = path.relative(projectRoot, fullPath).replace(/\\/g, "/");
+      return [
+        {
+          name: entry.name,
+          path: relativePath,
+          mime_type: inferMimeType(entry.name),
+          size: fileStat.size,
+          updated_at: fileStat.mtimeMs,
+        } satisfies ContextFileSummary,
+      ];
+    }),
+  );
+
+  return files.flat().sort((a, b) => a.path.localeCompare(b.path, "ja"));
+}
+
+export function createContextFilesRouter(options: ContextFilesRouterOptions = {}) {
+  const router = new Hono();
+  const baseDir = getBaseDir(options);
+
+  router.get("/", async (c) => {
+    const projectId = parseProjectId(c.req.param("projectId"));
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const projectRoot = resolveProjectRoot(baseDir, projectId);
+    const files = await listProjectFiles(projectRoot);
+    return c.json(files);
+  });
+
+  router.post("/", zValidator("json", createContextFileSchema), async (c) => {
+    const projectId = parseProjectId(c.req.param("projectId"));
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const body = c.req.valid("json");
+    const projectRoot = resolveProjectRoot(baseDir, projectId);
+    const targetPath = resolveProjectFilePath(projectRoot, body.file_name);
+    if (!targetPath) {
+      return c.json({ error: "Invalid file_name" }, 400);
+    }
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, body.content, "utf8");
+
+    const fileStat = await stat(targetPath);
+    return c.json(
+      {
+        name: path.basename(targetPath),
+        path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
+        mime_type: body.mime_type ?? inferMimeType(targetPath),
+        size: fileStat.size,
+        updated_at: fileStat.mtimeMs,
+      } satisfies ContextFileSummary,
+      201,
+    );
+  });
+
+  router.get("/content", async (c) => {
+    const projectId = parseProjectId(c.req.param("projectId"));
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const requestedPath = c.req.query("path");
+    if (!requestedPath) {
+      return c.json({ error: "Missing path" }, 400);
+    }
+
+    const projectRoot = resolveProjectRoot(baseDir, projectId);
+    const targetPath = resolveProjectFilePath(projectRoot, requestedPath);
+    if (!targetPath) {
+      return c.json({ error: "Invalid path" }, 400);
+    }
+
+    try {
+      await access(targetPath);
+    } catch {
+      return c.json({ error: "Context file not found" }, 404);
+    }
+
+    const [content, fileStat] = await Promise.all([readFile(targetPath, "utf8"), stat(targetPath)]);
+    return c.json({
+      name: path.basename(targetPath),
+      path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
+      mime_type: inferMimeType(targetPath),
+      size: fileStat.size,
+      updated_at: fileStat.mtimeMs,
+      content,
+    } satisfies ContextFileDetail);
+  });
+
+  router.put("/content", zValidator("json", updateContextFileSchema), async (c) => {
+    const projectId = parseProjectId(c.req.param("projectId"));
+    if (projectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+
+    const requestedPath = c.req.query("path");
+    if (!requestedPath) {
+      return c.json({ error: "Missing path" }, 400);
+    }
+
+    const projectRoot = resolveProjectRoot(baseDir, projectId);
+    const targetPath = resolveProjectFilePath(projectRoot, requestedPath);
+    if (!targetPath) {
+      return c.json({ error: "Invalid path" }, 400);
+    }
+
+    try {
+      await access(targetPath);
+    } catch {
+      return c.json({ error: "Context file not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    await writeFile(targetPath, body.content, "utf8");
+
+    const fileStat = await stat(targetPath);
+    return c.json({
+      name: path.basename(targetPath),
+      path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
+      mime_type: inferMimeType(targetPath),
+      size: fileStat.size,
+      updated_at: fileStat.mtimeMs,
+      content: body.content,
+    } satisfies ContextFileDetail);
+  });
+
+  return router;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-markdown": "^6.3.4",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-sql": "^6.10.0",
+    "@uiw/react-codemirror": "^4.25.2",
     "@tanstack/react-query": "^5.62.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
     "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/view": "^6.38.6",
     "@uiw/react-codemirror": "^4.25.2",
     "@tanstack/react-query": "^5.62.7",
     "react": "^18.3.1",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { Layout } from "./components/Layout";
+import { ContextFilesPage } from "./pages/ContextFilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { ProjectDetailPage } from "./pages/ProjectDetailPage";
@@ -31,6 +32,7 @@ export function App() {
             <Route index element={<ProjectsPage />} />
             {/* プロジェクト詳細 */}
             <Route path="projects/:id" element={<ProjectDetailPage />} />
+            <Route path="projects/:id/context-files" element={<ContextFilesPage />} />
             <Route path="projects/:id/test-cases" element={<TestCasesPage />} />
             <Route path="projects/:id/prompts" element={<PromptsPage />} />
             <Route path="projects/:id/runs" element={<RunsPage />} />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -15,6 +15,7 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
 function ProjectSubNav({ projectId }: { projectId: string }) {
   const subNavItems = [
     { to: `/projects/${projectId}`, label: "概要", end: true },
+    { to: `/projects/${projectId}/context-files`, label: "コンテキスト" },
     { to: `/projects/${projectId}/test-cases`, label: "テストケース" },
     { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
     { to: `/projects/${projectId}/runs`, label: "Run 一覧" },

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -85,6 +85,43 @@ export function getProject(id: number): Promise<Project> {
   return api.get<Project>(`/projects/${id}`);
 }
 
+export type ContextFileSummary = {
+  name: string;
+  path: string;
+  mime_type: string;
+  size: number;
+  updated_at: number;
+};
+
+export type ContextFileDetail = ContextFileSummary & {
+  content: string;
+};
+
+export function getContextFiles(projectId: number): Promise<ContextFileSummary[]> {
+  return api.get<ContextFileSummary[]>(`/projects/${projectId}/context-files`);
+}
+
+export function getContextFile(projectId: number, filePath: string): Promise<ContextFileDetail> {
+  const params = new URLSearchParams({ path: filePath });
+  return api.get<ContextFileDetail>(`/projects/${projectId}/context-files/content?${params}`);
+}
+
+export function uploadContextFile(
+  projectId: number,
+  data: { file_name: string; content: string; mime_type?: string },
+): Promise<ContextFileSummary> {
+  return api.post<ContextFileSummary>(`/projects/${projectId}/context-files`, data);
+}
+
+export function updateContextFile(
+  projectId: number,
+  filePath: string,
+  data: { content: string },
+): Promise<ContextFileDetail> {
+  const params = new URLSearchParams({ path: filePath });
+  return api.put<ContextFileDetail>(`/projects/${projectId}/context-files/content?${params}`, data);
+}
+
 export function createProject(data: {
   name: string;
   description?: string;

--- a/packages/ui/src/pages/ContextFilesPage.module.css
+++ b/packages/ui/src/pages/ContextFilesPage.module.css
@@ -176,6 +176,7 @@
 .editorArea {
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 :global(.cm-editor) {
@@ -185,6 +186,7 @@
 
 :global(.cm-scroller) {
   font-family: Consolas, "SFMono-Regular", Monaco, monospace;
+  overflow: auto;
 }
 
 @media (max-width: 900px) {
@@ -194,5 +196,9 @@
 
   .sidebar {
     max-height: 280px;
+  }
+
+  .editorArea {
+    min-height: 55vh;
   }
 }

--- a/packages/ui/src/pages/ContextFilesPage.module.css
+++ b/packages/ui/src/pages/ContextFilesPage.module.css
@@ -1,0 +1,198 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.pageHeader {
+  composes: pageHeader from '../styles/shared.module.css';
+  margin-bottom: 12px;
+  gap: 16px;
+}
+
+.pageTitle {
+  composes: pageTitle from '../styles/shared.module.css';
+  margin: 0 0 4px;
+}
+
+.pageDescription {
+  margin: 0;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.fileInput {
+  display: none;
+}
+
+.btnPrimary {
+  composes: btnPrimary from '../styles/shared.module.css';
+  padding: 9px 16px;
+  font-size: 13px;
+}
+
+.btnSave {
+  composes: btnPrimary from '../styles/shared.module.css';
+  padding: 8px 16px;
+  font-size: 13px;
+}
+
+.btnDisabled {
+  composes: btnDisabled from '../styles/shared.module.css';
+}
+
+.statusMessage {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: rgba(166, 227, 161, 0.12);
+  border: 1px solid rgba(166, 227, 161, 0.25);
+  border-radius: 8px;
+  color: var(--c-green);
+  font-size: 13px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.sidebar,
+.viewerPanel {
+  min-height: 0;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.panelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.panelTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-text);
+  word-break: break-word;
+}
+
+.panelSubtitle {
+  margin: 4px 0 0;
+  color: var(--c-muted);
+  font-size: 12px;
+}
+
+.badge {
+  composes: badge from '../styles/shared.module.css';
+  color: var(--c-subtext);
+}
+
+.panelStatus,
+.panelError {
+  margin: 0;
+  padding: 14px 16px;
+  font-size: 13px;
+}
+
+.panelStatus {
+  color: var(--c-muted);
+}
+
+.panelError,
+.emptyViewerError {
+  color: var(--c-danger);
+}
+
+.emptyState,
+.emptyViewer,
+.emptyViewerError {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+  color: var(--c-muted);
+  font-size: 14px;
+}
+
+.fileList {
+  flex: 1;
+  overflow: auto;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fileItem {
+  width: 100%;
+  border: 1px solid var(--c-border);
+  background: var(--c-overlay);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--c-text);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.fileItemActive {
+  border-color: var(--c-accent);
+  background: rgba(203, 166, 247, 0.12);
+}
+
+.fileName {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.filePath,
+.fileMeta {
+  font-size: 12px;
+  color: var(--c-muted);
+  word-break: break-word;
+}
+
+.editorArea {
+  flex: 1;
+  min-height: 0;
+}
+
+:global(.cm-editor) {
+  height: 100%;
+  font-size: 13px;
+}
+
+:global(.cm-scroller) {
+  font-family: Consolas, "SFMono-Regular", Monaco, monospace;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    max-height: 280px;
+  }
+}

--- a/packages/ui/src/pages/ContextFilesPage.tsx
+++ b/packages/ui/src/pages/ContextFilesPage.tsx
@@ -1,0 +1,287 @@
+import { css } from "@codemirror/lang-css";
+import { html } from "@codemirror/lang-html";
+import { javascript } from "@codemirror/lang-javascript";
+import { json } from "@codemirror/lang-json";
+import { markdown } from "@codemirror/lang-markdown";
+import { python } from "@codemirror/lang-python";
+import { sql } from "@codemirror/lang-sql";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import CodeMirror from "@uiw/react-codemirror";
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router";
+import {
+  type ContextFileSummary,
+  getContextFile,
+  getContextFiles,
+  getProject,
+  updateContextFile,
+  uploadContextFile,
+} from "../lib/api";
+import styles from "./ContextFilesPage.module.css";
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getLanguageExtensions(filePath: string) {
+  const lowerPath = filePath.toLowerCase();
+  if (
+    lowerPath.endsWith(".ts") ||
+    lowerPath.endsWith(".tsx") ||
+    lowerPath.endsWith(".js") ||
+    lowerPath.endsWith(".jsx")
+  ) {
+    return [
+      javascript({
+        jsx: lowerPath.endsWith("x"),
+        typescript: lowerPath.endsWith(".ts") || lowerPath.endsWith(".tsx"),
+      }),
+    ];
+  }
+  if (lowerPath.endsWith(".json")) return [json()];
+  if (lowerPath.endsWith(".md")) return [markdown()];
+  if (lowerPath.endsWith(".py")) return [python()];
+  if (lowerPath.endsWith(".sql")) return [sql()];
+  if (lowerPath.endsWith(".css")) return [css()];
+  if (lowerPath.endsWith(".html")) return [html()];
+  return [];
+}
+
+export function ContextFilesPage() {
+  const { id } = useParams<{ id: string }>();
+  const projectId = Number(id);
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [draftContent, setDraftContent] = useState("");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const { data: project } = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => getProject(projectId),
+    enabled: !Number.isNaN(projectId),
+  });
+
+  const filesQuery = useQuery({
+    queryKey: ["context-files", projectId],
+    queryFn: () => getContextFiles(projectId),
+    enabled: !Number.isNaN(projectId),
+  });
+
+  const selectedFileDetailQuery = useQuery({
+    queryKey: ["context-file", projectId, selectedPath],
+    queryFn: () => {
+      if (!selectedPath) {
+        throw new Error("path is required");
+      }
+      return getContextFile(projectId, selectedPath);
+    },
+    enabled: !Number.isNaN(projectId) && selectedPath !== null,
+  });
+
+  useEffect(() => {
+    const files = filesQuery.data ?? [];
+    if (files.length === 0) {
+      setSelectedPath(null);
+      return;
+    }
+
+    if (!selectedPath || !files.some((file) => file.path === selectedPath)) {
+      setSelectedPath(files[0]?.path ?? null);
+    }
+  }, [filesQuery.data, selectedPath]);
+
+  useEffect(() => {
+    if (selectedFileDetailQuery.data) {
+      setDraftContent(selectedFileDetailQuery.data.content);
+    }
+  }, [selectedFileDetailQuery.data]);
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const content = await file.text();
+      return uploadContextFile(projectId, {
+        file_name: file.webkitRelativePath || file.name,
+        content,
+        mime_type: file.type || undefined,
+      });
+    },
+    onSuccess: (created) => {
+      setStatusMessage(`取り込みました: ${created.path}`);
+      void queryClient.invalidateQueries({ queryKey: ["context-files", projectId] });
+      setSelectedPath(created.path);
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      if (!selectedPath) throw new Error("selectedPath is required");
+      return updateContextFile(projectId, selectedPath, { content: draftContent });
+    },
+    onSuccess: (updated) => {
+      setStatusMessage(`保存しました: ${updated.path}`);
+      void queryClient.invalidateQueries({ queryKey: ["context-files", projectId] });
+      void queryClient.invalidateQueries({ queryKey: ["context-file", projectId, updated.path] });
+    },
+  });
+
+  const selectedSummary: ContextFileSummary | undefined = (filesQuery.data ?? []).find(
+    (file) => file.path === selectedPath,
+  );
+  const selectedDetail = selectedFileDetailQuery.data;
+  const isDirty = selectedDetail ? draftContent !== selectedDetail.content : false;
+
+  async function handleFileSelection(event: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) return;
+
+    setStatusMessage(null);
+    const uploaded = await Promise.all(files.map((file) => uploadMutation.mutateAsync(file)));
+    const lastUploaded = uploaded[uploaded.length - 1];
+    if (lastUploaded) {
+      setSelectedPath(lastUploaded.path);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <div>
+          <h2 className={styles.pageTitle}>コンテキスト管理</h2>
+          <p className={styles.pageDescription}>
+            {project
+              ? `${project.name} の参照用スナップショットを管理します。`
+              : "参照用スナップショットを管理します。"}
+          </p>
+        </div>
+        <div className={styles.headerActions}>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".txt,.md,.json,.ts,.tsx,.js,.jsx,.py,.sql,.css,.html,.yml,.yaml"
+            multiple
+            className={styles.fileInput}
+            onChange={(event) => {
+              void handleFileSelection(event);
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className={styles.btnPrimary}
+            disabled={uploadMutation.isPending}
+          >
+            {uploadMutation.isPending ? "取込中..." : "ファイルを取り込む"}
+          </button>
+        </div>
+      </div>
+
+      {statusMessage && <p className={styles.statusMessage}>{statusMessage}</p>}
+
+      <div className={styles.layout}>
+        <section className={styles.sidebar}>
+          <div className={styles.panelHeader}>
+            <span className={styles.panelTitle}>ファイル一覧</span>
+            <span className={styles.badge}>{filesQuery.data?.length ?? 0} 件</span>
+          </div>
+          {filesQuery.isLoading && <p className={styles.panelStatus}>読み込み中...</p>}
+          {filesQuery.isError && <p className={styles.panelError}>一覧の取得に失敗しました。</p>}
+          {!filesQuery.isLoading && !filesQuery.isError && (filesQuery.data?.length ?? 0) === 0 && (
+            <div className={styles.emptyState}>
+              まだファイルがありません。
+              <br />
+              上部のボタンからテキストファイルを取り込んでください。
+            </div>
+          )}
+          <div className={styles.fileList}>
+            {(filesQuery.data ?? []).map((file) => (
+              <button
+                key={file.path}
+                type="button"
+                onClick={() => {
+                  setStatusMessage(null);
+                  setSelectedPath(file.path);
+                }}
+                className={`${styles.fileItem} ${selectedPath === file.path ? styles.fileItemActive : ""}`}
+              >
+                <span className={styles.fileName}>{file.name}</span>
+                <span className={styles.filePath}>{file.path}</span>
+                <span className={styles.fileMeta}>
+                  {formatBytes(file.size)} / {formatDate(file.updated_at)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.viewerPanel}>
+          <div className={styles.panelHeader}>
+            <div>
+              <span className={styles.panelTitle}>
+                {selectedSummary ? selectedSummary.path : "ファイル未選択"}
+              </span>
+              {selectedSummary && (
+                <p className={styles.panelSubtitle}>
+                  {selectedSummary.mime_type} / {formatBytes(selectedSummary.size)}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => saveMutation.mutate()}
+              disabled={!selectedPath || !isDirty || saveMutation.isPending}
+              className={`${styles.btnSave} ${!selectedPath || !isDirty || saveMutation.isPending ? styles.btnDisabled : ""}`}
+            >
+              {saveMutation.isPending ? "保存中..." : "保存"}
+            </button>
+          </div>
+
+          {!selectedPath && (
+            <div className={styles.emptyViewer}>左からファイルを選択してください。</div>
+          )}
+
+          {selectedPath && selectedFileDetailQuery.isLoading && (
+            <div className={styles.emptyViewer}>内容を読み込み中...</div>
+          )}
+
+          {selectedPath && selectedFileDetailQuery.isError && (
+            <div className={styles.emptyViewerError}>内容の読み込みに失敗しました。</div>
+          )}
+
+          {selectedPath && selectedDetail && (
+            <div className={styles.editorArea}>
+              <CodeMirror
+                value={draftContent}
+                height="100%"
+                theme="dark"
+                extensions={getLanguageExtensions(selectedDetail.path)}
+                onChange={(value) => setDraftContent(value)}
+                basicSetup={{
+                  lineNumbers: true,
+                  highlightActiveLine: true,
+                  foldGutter: true,
+                }}
+              />
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/ContextFilesPage.tsx
+++ b/packages/ui/src/pages/ContextFilesPage.tsx
@@ -5,6 +5,7 @@ import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
 import { sql } from "@codemirror/lang-sql";
+import { EditorView } from "@codemirror/view";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useRef, useState } from "react";
@@ -37,6 +38,7 @@ function formatBytes(size: number): string {
 
 function getLanguageExtensions(filePath: string) {
   const lowerPath = filePath.toLowerCase();
+  const baseExtensions = [EditorView.lineWrapping];
   if (
     lowerPath.endsWith(".ts") ||
     lowerPath.endsWith(".tsx") ||
@@ -44,19 +46,20 @@ function getLanguageExtensions(filePath: string) {
     lowerPath.endsWith(".jsx")
   ) {
     return [
+      ...baseExtensions,
       javascript({
         jsx: lowerPath.endsWith("x"),
         typescript: lowerPath.endsWith(".ts") || lowerPath.endsWith(".tsx"),
       }),
     ];
   }
-  if (lowerPath.endsWith(".json")) return [json()];
-  if (lowerPath.endsWith(".md")) return [markdown()];
-  if (lowerPath.endsWith(".py")) return [python()];
-  if (lowerPath.endsWith(".sql")) return [sql()];
-  if (lowerPath.endsWith(".css")) return [css()];
-  if (lowerPath.endsWith(".html")) return [html()];
-  return [];
+  if (lowerPath.endsWith(".json")) return [...baseExtensions, json()];
+  if (lowerPath.endsWith(".md")) return [...baseExtensions, markdown()];
+  if (lowerPath.endsWith(".py")) return [...baseExtensions, python()];
+  if (lowerPath.endsWith(".sql")) return [...baseExtensions, sql()];
+  if (lowerPath.endsWith(".css")) return [...baseExtensions, css()];
+  if (lowerPath.endsWith(".html")) return [...baseExtensions, html()];
+  return baseExtensions;
 }
 
 export function ContextFilesPage() {
@@ -268,7 +271,7 @@ export function ContextFilesPage() {
             <div className={styles.editorArea}>
               <CodeMirror
                 value={draftContent}
-                height="100%"
+                height="70vh"
                 theme="dark"
                 extensions={getLanguageExtensions(selectedDetail.path)}
                 onChange={(value) => setDraftContent(value)}

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -6,7 +6,11 @@ export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
   const projectId = Number(id);
 
-  const { data: project, isLoading, isError } = useQuery({
+  const {
+    data: project,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ["project", projectId],
     queryFn: () => getProject(projectId),
     enabled: !Number.isNaN(projectId),
@@ -32,6 +36,7 @@ export function ProjectDetailPage() {
         }}
       >
         {[
+          { to: "context-files", label: "コンテキスト管理" },
           { to: "test-cases", label: "テストケース管理" },
           { to: "prompts", label: "プロンプト管理" },
           { to: "runs", label: "Run 実行・管理" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@codemirror/lang-sql':
         specifier: ^6.10.0
         version: 6.10.0
+      '@codemirror/view':
+        specifier: ^6.38.6
+        version: 6.41.0
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.97.0(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,33 @@ importers:
 
   packages/ui:
     dependencies:
+      '@codemirror/lang-css':
+        specifier: ^6.3.1
+        version: 6.3.1
+      '@codemirror/lang-html':
+        specifier: ^6.4.11
+        version: 6.4.11
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.4
+        version: 6.2.5
+      '@codemirror/lang-json':
+        specifier: ^6.0.1
+        version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: ^6.3.4
+        version: 6.5.0
+      '@codemirror/lang-python':
+        specifier: ^6.2.1
+        version: 6.2.1
+      '@codemirror/lang-sql':
+        specifier: ^6.10.0
+        version: 6.10.0
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.97.0(react@18.3.1)
+      '@uiw/react-codemirror':
+        specifier: ^4.25.2
+        version: 4.25.9(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -203,6 +227,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -271,6 +299,51 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/search@6.6.0':
+    resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.41.0':
+    resolution: {integrity: sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1031,6 +1104,33 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/python@1.1.18':
+    resolution: {integrity: sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==}
+
   '@libsql/client@0.17.2':
     resolution: {integrity: sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==}
 
@@ -1087,6 +1187,9 @@ packages:
     resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
     cpu: [x64]
     os: [win32]
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
@@ -1325,6 +1428,28 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.9':
+    resolution: {integrity: sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.9':
+    resolution: {integrity: sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1431,6 +1556,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1449,6 +1577,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
@@ -2037,6 +2168,9 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2221,6 +2355,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -2371,6 +2508,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2428,6 +2567,121 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.18
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      crelt: 1.0.6
+
+  '@codemirror/search@6.6.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.41.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2829,6 +3083,51 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/python@1.1.18':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
   '@libsql/client@0.17.2':
     dependencies:
       '@libsql/core': 0.17.2
@@ -2894,6 +3193,8 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.29':
     optional: true
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@neon-rs/load@0.0.4':
     optional: true
@@ -3073,6 +3374,33 @@ snapshots:
       '@types/node': 25.5.2
     optional: true
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.9(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+
+  '@uiw/react-codemirror@4.25.9(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.0)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.41.0
+      '@uiw/codemirror-extensions-basic-setup': 4.25.9(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)
+      codemirror: 6.0.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.5.2)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -3196,6 +3524,16 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3214,6 +3552,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  crelt@1.0.6: {}
 
   cross-fetch@4.1.0:
     dependencies:
@@ -3809,6 +4149,8 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  style-mod@4.1.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3974,6 +4316,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-keyname@2.2.8: {}
 
   web-streams-polyfill@3.3.3:
     optional: true


### PR DESCRIPTION
## 概要
- プロジェクトごとのコンテキストファイル Viewer / Editor を追加
- コンテキストファイルは server 管理ディレクトリ配下のローカルファイルとして保存・編集
- 一覧取得、取込み、内容取得、保存 API を追加

## 実装方針
- 保存先は data/context-files/<projectId>/ を想定
- UI から選択したテキスト/コードファイルをサーバー側へ取り込み
- Viewer / Editor は CodeMirror を利用
- 任意パスの直接編集ではなく、アプリ管理下のコピーを扱う

## 確認
- pnpm typecheck
- pnpm --filter @prompt-reviewer/ui typecheck
- pnpm exec vitest run packages/server/src/routes/context-files.test.ts
- pnpm exec biome check packages/server/src/index.ts packages/server/src/routes/context-files.ts packages/server/src/routes/context-files.test.ts packages/ui/package.json packages/ui/src/App.tsx packages/ui/src/components/Layout.tsx packages/ui/src/lib/api.ts packages/ui/src/pages/ProjectDetailPage.tsx packages/ui/src/pages/ContextFilesPage.tsx packages/ui/src/pages/ContextFilesPage.module.css

Closes #30