### PR TITLE
比較ウィンドウにコピーボタンを追加

### DIFF
--- a/packages/ui/src/components/RunCompareView.module.css
+++ b/packages/ui/src/components/RunCompareView.module.css
@@ -126,6 +126,27 @@
   font-size: 11px;
 }
 
+.btnCopy {
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  color: var(--c-subtext);
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.btnCopy:hover {
+  color: var(--c-text);
+  border-color: var(--c-subtext);
+}
+
+.btnCopied {
+  color: var(--c-green);
+  border-color: var(--c-green);
+}
+
 .chatList {
   flex: 1;
   overflow: auto;

--- a/packages/ui/src/components/RunCompareView.tsx
+++ b/packages/ui/src/components/RunCompareView.tsx
@@ -2,6 +2,23 @@ import { useRef, useState } from "react";
 import type { Run } from "../lib/api";
 import styles from "./RunCompareView.module.css";
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <button type="button" onClick={handleCopy} className={`${styles.btnCopy} ${copied ? styles.btnCopied : ""}`}>
+      {copied ? "コピー済み" : "コピー"}
+    </button>
+  );
+}
+
 function getLastAssistantMessage(run: Run): string {
   return [...run.conversation].reverse().find((message) => message.role === "assistant")?.content ?? "";
 }
@@ -153,6 +170,7 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                 <div className={`${styles.panelHeader} ${styles.panelHeaderA}`}>
                   <span>Run #{runA.id}</span>
                   <span className={styles.panelMeta}>{versionLabelA}</span>
+                  <CopyButton text={lastAssistantA} />
                 </div>
                 <div ref={scrollRefA} className={styles.chatList} onScroll={handleScrollA}>
                   <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>
@@ -165,6 +183,7 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                 <div className={`${styles.panelHeader} ${styles.panelHeaderB}`}>
                   <span>Run #{runB.id}</span>
                   <span className={styles.panelMeta}>{versionLabelB}</span>
+                  <CopyButton text={lastAssistantB} />
                 </div>
                 <div ref={scrollRefB} className={styles.chatList} onScroll={handleScrollB}>
                   <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>


### PR DESCRIPTION
## Summary

- 比較ウィンドウ（並列モード）の各パネルヘッダーにコピーボタンを追加
- `navigator.clipboard.writeText()` で `text/plain` のみクリップボードに書き込む
- Obsidian などのMarkdownエディタへ貼り付けたときに改行が失われる問題を解消
- コピー後1.5秒間「コピー済み」と表示するフィードバックつき

## 背景

ブラウザのコピー操作ではクリップボードに `text/html` と `text/plain` の両方が入る。
Obsidian は `text/html` を優先するが、HTMLテキストノード中の `\n` はHTML仕様上では空白扱いのため改行が失われていた。
コピーボタンで `text/plain` のみを明示的に書き込むことで回避する。

## Test plan

- [ ] 比較ウィンドウを開き、コピーボタンをクリックするとボタンが「コピー済み」に変わる
- [ ] Obsidian に貼り付けたとき、改行が保持されている
- [ ] 1.5秒後にボタンが「コピー」に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)