### PR TITLE
Run画面の右端に出るページスクロールバーを解消

### DIFF
--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -5,6 +5,11 @@
 
 /* ==================== Page layout ==================== */
 .page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   color: var(--c-text);
 }
 
@@ -490,6 +495,14 @@
   margin-bottom: 20px;
   border-bottom: 1px solid var(--c-border);
   padding-bottom: 0;
+  flex-shrink: 0;
+}
+
+.tabContent {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 8px;
 }
 
 .tabBtn {

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -654,9 +654,10 @@ export function RunsPage() {
         </button>
       </div>
 
-      {/* ============ タブ: Run を作成 ============ */}
-      {activeTab === "create" && (
-        <div>
+      <div className={styles.tabContent}>
+        {/* ============ タブ: Run を作成 ============ */}
+        {activeTab === "create" && (
+          <div>
           {/* Step 1: 選択フォーム */}
           {step === "select" && (
             <div className={styles.selectCard}>
@@ -926,12 +927,12 @@ export function RunsPage() {
               </div>
             </div>
           )}
-        </div>
-      )}
+          </div>
+        )}
 
-      {/* ============ タブ: Run 一覧 ============ */}
-      {activeTab === "list" && (
-        <div>
+        {/* ============ タブ: Run 一覧 ============ */}
+        {activeTab === "list" && (
+          <div>
           <RunCompareBar
             compareRunA={compareRunA}
             compareRunB={compareRunB}
@@ -1043,8 +1044,9 @@ export function RunsPage() {
             }}
             className={styles.compareBarBottom}
           />
-        </div>
-      )}
+          </div>
+        )}
+      </div>
 
       {/* 比較ビュー */}
       {isCompareOpen && compareRunA && compareRunB && (


### PR DESCRIPTION
## 概要
- Run 画面を縦方向の flex レイアウトに変更
- タブ配下のコンテンツだけをスクロール領域に分離
- 保存後表示で右端に出ていたページ全体の縦スクロールバーを解消

## 確認
- pnpm --filter @prompt-reviewer/ui typecheck

Closes #104