### PR TITLE
保存済みRun表示の内側スクロールを解消

### DIFF
--- a/packages/ui/src/pages/RunsPage.module.css
+++ b/packages/ui/src/pages/RunsPage.module.css
@@ -171,6 +171,13 @@
   padding-right: 4px;
 }
 
+.chatListStatic {
+  max-height: none;
+  overflow: visible;
+  scrollbar-gutter: auto;
+  padding-right: 0;
+}
+
 .bubbleWrapper {
   display: flex;
   flex-direction: column;

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -873,7 +873,7 @@ export function RunsPage() {
                   {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
                   {selectedTestCase.title} · {formatDate(savedRun.created_at)}
                 </p>
-                <div className={styles.chatList}>
+                <div className={`${styles.chatList} ${styles.chatListStatic}`}>
                   {savedRun.conversation.map((msg, index) => (
                     <div
                       key={`msg-${


### PR DESCRIPTION
## 概要
- 保存後画面の「保存した Run の内容」で残っていた内側スクロールを解消
- saved ステップの会話表示だけ静的レイアウトに切り替え
- Run 一覧や実行中画面の既存スクロール挙動は維持

## 確認
- pnpm --filter @prompt-reviewer/ui typecheck
- Playwright で保存後画面の右から二番目のスクロールバーが消えることを確認