### PR TITLE
Issue #107 新ドメインモデル向けのスキーマ追加

### DIFF
--- a/doc/api-spec.md
+++ b/doc/api-spec.md
@@ -1,18 +1,20 @@
 # API仕様
 
-prompt-reviewer の REST API（Hono / Node.js）
+prompt-reviewer の REST API 案（Hono / Node.js）
 
-ベースURL: `http://localhost:3001`
+ベースURL: `http://localhost:3001/api`
 
----
+この仕様は、`project` を所有単位ではなく分類ラベルとして扱う新データモデルに基づく。
 
 ## 共通仕様
 
 ### レスポンス形式
+
 すべてのレスポンスは `application/json`。
 
 ### タイムスタンプ
-`created_at` / `updated_at` は **Unix タイムスタンプ（ミリ秒）**。
+
+`created_at` / `updated_at` は Unix タイムスタンプ（ミリ秒）。
 
 ### エラーレスポンス
 
@@ -24,33 +26,34 @@ prompt-reviewer の REST API（Hono / Node.js）
 
 | ステータス | 説明 |
 |---|---|
-| `400` | バリデーションエラー（必須項目不足・型不一致など） |
+| `400` | バリデーションエラー |
 | `404` | リソースが見つからない |
+| `409` | 一意制約違反や競合 |
 | `500` | サーバー内部エラー |
 
----
+### 分類ラベルの考え方
+
+- `projects` は Gmail のラベルのような分類用途で使う
+- `test_cases` / `prompt_versions` / `context_assets` は `project` に所属しなくても存在できる
+- `未分類` は `project` レコードではなく、ラベルが 1 件も付いていない状態を指す
 
 ## ヘルスチェック
 
-```
-GET /health
-```
+### `GET /health`
 
-**レスポンス**
+**レスポンス `200`**
 
 ```json
 { "status": "ok" }
 ```
 
----
-
 ## Projects
 
-### プロジェクト一覧取得
+分類ラベルを管理する API。
 
-```
-GET /projects
-```
+### `GET /projects`
+
+ラベル一覧を返す。
 
 **レスポンス `200`**
 
@@ -58,162 +61,166 @@ GET /projects
 [
   {
     "id": 1,
-    "name": "カスタマーサポートBot改善",
-    "description": "問い合わせ対応精度を上げるプロジェクト",
+    "name": "返金対応",
+    "description": "返金問い合わせ系の分類",
     "created_at": 1744281600000,
     "updated_at": 1744281600000
   }
 ]
 ```
 
----
+### `POST /projects`
 
-### プロジェクト作成
-
-```
-POST /projects
-```
+ラベルを作成する。
 
 **リクエストボディ**
 
 ```json
 {
-  "name": "カスタマーサポートBot改善",
-  "description": "問い合わせ対応精度を上げるプロジェクト"
+  "name": "返金対応",
+  "description": "返金問い合わせ系の分類"
 }
 ```
 
 | フィールド | 型 | 必須 | 説明 |
 |---|---|---|---|
-| `name` | string | ✅ | プロジェクト名 |
-| `description` | string | | プロジェクト説明 |
+| `name` | string | ✅ | ラベル名 |
+| `description` | string | | 説明 |
 
-**レスポンス `201`**
+### `GET /projects/:id`
 
-```json
-{
-  "id": 1,
-  "name": "カスタマーサポートBot改善",
-  "description": "問い合わせ対応精度を上げるプロジェクト",
-  "created_at": 1744281600000,
-  "updated_at": 1744281600000
-}
-```
+ラベル詳細を返す。
 
----
+### `PATCH /projects/:id`
 
-### プロジェクト取得
+ラベル名または説明を更新する。
 
-```
-GET /projects/:id
-```
+### `DELETE /projects/:id`
 
-**レスポンス `200`**
+ラベルを削除する。資産本体は削除せず、中間テーブルの関連付けのみ解除される。
 
-```json
-{
-  "id": 1,
-  "name": "カスタマーサポートBot改善",
-  "description": "問い合わせ対応精度を上げるプロジェクト",
-  "created_at": 1744281600000,
-  "updated_at": 1744281600000,
-  "settings": {
-    "id": 1,
-    "model": "claude-opus-4-5",
-    "temperature": 0.7,
-    "api_provider": "anthropic"
-  }
-}
-```
+**レスポンス `204`**
 
----
+## Context Assets
 
-### プロジェクト更新
+再利用可能なコンテキスト素材を管理する API。
 
-```
-PUT /projects/:id
-```
+### `GET /context-assets`
 
-**リクエストボディ**（変更するフィールドのみ）
+コンテキスト素材一覧を返す。
 
-```json
-{
-  "name": "新しいプロジェクト名",
-  "description": "更新された説明"
-}
-```
+クエリパラメータ:
 
-**レスポンス `200`**: 更新後のプロジェクトオブジェクト
-
----
-
-### プロジェクト削除
-
-```
-DELETE /projects/:id
-```
-
-**レスポンス `204`**: ボディなし
-
----
-
-## Project Settings
-
-### 設定取得
-
-```
-GET /projects/:id/settings
-```
-
-**レスポンス `200`**
-
-```json
-{
-  "id": 1,
-  "project_id": 1,
-  "model": "claude-opus-4-5",
-  "temperature": 0.7,
-  "api_provider": "anthropic",
-  "created_at": 1744281600000,
-  "updated_at": 1744281600000
-}
-```
-
----
-
-### 設定更新
-
-```
-PUT /projects/:id/settings
-```
-
-**リクエストボディ**（変更するフィールドのみ）
-
-```json
-{
-  "model": "claude-sonnet-4-6",
-  "temperature": 0.5,
-  "api_provider": "anthropic"
-}
-```
-
-| フィールド | 型 | 説明 |
+| パラメータ | 型 | 説明 |
 |---|---|---|
-| `model` | string | 使用するLLMモデルID |
-| `temperature` | number | 0.0〜2.0 |
-| `api_provider` | `"anthropic"` \| `"openai"` | APIプロバイダー |
+| `project_id` | number | 指定ラベルが付いた素材に絞り込む |
+| `unclassified` | boolean | 未分類のみ返す |
+| `linked_to` | string | `test_case:12` / `prompt_family:4` のような関連先で絞り込む |
+| `q` | string | `name` / `path` に対する検索文字列 |
 
-**レスポンス `200`**: 更新後の設定オブジェクト
+**レスポンス `200`**
 
----
+```json
+[
+  {
+    "id": 10,
+    "name": "refund-policy.md",
+    "path": "policies/refund-policy.md",
+    "mime_type": "text/markdown",
+    "content_hash": "sha256:...",
+    "created_at": 1744281600000,
+    "updated_at": 1744281600000
+  }
+]
+```
+
+### `POST /context-assets`
+
+素材を作成する。
+
+**リクエストボディ**
+
+```json
+{
+  "name": "refund-policy.md",
+  "path": "policies/refund-policy.md",
+  "content": "購入から30日以内であれば返金可能です。",
+  "mime_type": "text/markdown"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `name` | string | ✅ | 表示名 |
+| `path` | string | ✅ | 論理パスまたは元ファイル名 |
+| `content` | string | ✅ | 素材本文 |
+| `mime_type` | string | ✅ | MIME タイプ |
+
+### `GET /context-assets/:id`
+
+素材詳細を返す。
+
+**レスポンス `200`**
+
+```json
+{
+  "id": 10,
+  "name": "refund-policy.md",
+  "path": "policies/refund-policy.md",
+  "content": "購入から30日以内であれば返金可能です。",
+  "mime_type": "text/markdown",
+  "content_hash": "sha256:...",
+  "created_at": 1744281600000,
+  "updated_at": 1744281600000
+}
+```
+
+### `PATCH /context-assets/:id`
+
+素材の表示名、パス、本文、MIME タイプを更新する。
+
+**リクエストボディ例**
+
+```json
+{
+  "name": "refund-policy-v2.md",
+  "content": "購入から45日以内であれば返金可能です。"
+}
+```
+
+### `DELETE /context-assets/:id`
+
+素材を削除する。
+
+**レスポンス `204`**
+
+### `PUT /context-assets/:id/projects`
+
+素材に付与するラベル一覧を全置換する。
+
+**リクエストボディ**
+
+```json
+{
+  "project_ids": [1, 5]
+}
+```
 
 ## Test Cases
 
-### テストケース一覧取得
+テストケース本体を管理する API。
 
-```
-GET /projects/:projectId/test-cases
-```
+### `GET /test-cases`
+
+テストケース一覧を返す。
+
+クエリパラメータ:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `project_id` | number | 指定ラベルが付いたテストケースに絞り込む |
+| `unclassified` | boolean | 未分類のみ返す |
+| `q` | string | タイトル検索 |
 
 **レスポンス `200`**
 
@@ -221,13 +228,12 @@ GET /projects/:projectId/test-cases
 [
   {
     "id": 1,
-    "project_id": 1,
     "title": "返金手続きの問い合わせ",
     "turns": [
       { "role": "user", "content": "返金の手続きを教えてください" }
     ],
     "context_content": "【返金ポリシー】購入から30日以内であれば返金可能です。",
-    "expected_description": "丁寧に返金手続きのステップを案内すること",
+    "expected_description": "丁寧に返金手続きを案内すること",
     "display_order": 0,
     "created_at": 1744281600000,
     "updated_at": 1744281600000
@@ -235,13 +241,9 @@ GET /projects/:projectId/test-cases
 ]
 ```
 
----
+### `POST /test-cases`
 
-### テストケース作成
-
-```
-POST /projects/:projectId/test-cases
-```
+テストケースを作成する。
 
 **リクエストボディ**
 
@@ -252,7 +254,7 @@ POST /projects/:projectId/test-cases
     { "role": "user", "content": "返金の手続きを教えてください" }
   ],
   "context_content": "【返金ポリシー】購入から30日以内であれば返金可能です。",
-  "expected_description": "丁寧に返金手続きのステップを案内すること",
+  "expected_description": "丁寧に返金手続きを案内すること",
   "display_order": 0
 }
 ```
@@ -260,331 +262,548 @@ POST /projects/:projectId/test-cases
 | フィールド | 型 | 必須 | 説明 |
 |---|---|---|---|
 | `title` | string | ✅ | テストケース名 |
-| `turns` | `{role, content}[]` | | マルチターンの会話履歴（未指定時は空配列） |
-| `context_content` | string | | `{{context}}` に挿入するテキスト |
+| `turns` | `{role, content}[]` | | マルチターン会話履歴 |
+| `context_content` | string | | 実行時に埋め込む最終コンテキスト |
 | `expected_description` | string | | 期待する出力の自由記述 |
-| `display_order` | number | | 一覧の並び順（デフォルト: 0） |
+| `display_order` | number | | 一覧表示順 |
 
-**レスポンス `201`**: 作成されたテストケースオブジェクト
+### `GET /test-cases/:id`
 
----
+テストケース詳細を返す。
 
-### テストケース取得
+### `PATCH /test-cases/:id`
 
-```
-GET /projects/:projectId/test-cases/:id
-```
+テストケースを更新する。
 
-**レスポンス `200`**: テストケースオブジェクト
+### `DELETE /test-cases/:id`
 
----
+テストケースを削除する。
 
-### テストケース更新
+**レスポンス `204`**
 
-```
-PUT /projects/:projectId/test-cases/:id
-```
+### `PUT /test-cases/:id/projects`
 
-**レスポンス `200`**: 更新後のテストケースオブジェクト
-
----
-
-### テストケース削除
-
-```
-DELETE /projects/:projectId/test-cases/:id
-```
-
-**レスポンス `204`**: ボディなし
-
----
-
-## Prompt Versions
-
-### バージョン一覧取得
-
-```
-GET /projects/:projectId/prompt-versions
-```
-
-**レスポンス `200`**
-
-```json
-[
-  {
-    "id": 1,
-    "project_id": 1,
-    "version": 1,
-    "name": "初期バージョン",
-    "memo": "ベースラインとして作成",
-    "content": "あなたはカスタマーサポートの担当者です...",
-    "parent_version_id": null,
-    "created_at": 1744281600000
-  }
-]
-```
-
----
-
-### バージョン作成
-
-```
-POST /projects/:projectId/prompt-versions
-```
+テストケースに付与するラベル一覧を全置換する。
 
 **リクエストボディ**
 
 ```json
 {
-  "name": "改善版v2",
-  "memo": "返金フローの説明を追加",
-  "content": "あなたはカスタマーサポートの担当者です...",
-  "parent_version_id": 1
+  "project_ids": [1, 5]
 }
 ```
 
-| フィールド | 型 | 必須 | 説明 |
-|---|---|---|---|
-| `name` | string | | バージョン名 |
-| `memo` | string | | 変更メモ |
-| `content` | string | ✅ | システムプロンプト本文 |
-| `parent_version_id` | number | | 分岐元バージョンID |
+### `PUT /test-cases/:id/context-assets`
 
-`version` はサーバー側でプロジェクト内の連番として自動採番。
+テストケースに関連付ける素材一覧を全置換する。
 
-**レスポンス `201`**: 作成されたバージョンオブジェクト
+**リクエストボディ**
 
----
-
-### バージョン取得
-
-```
-GET /projects/:projectId/prompt-versions/:id
+```json
+{
+  "context_asset_ids": [10, 12, 18]
+}
 ```
 
-**レスポンス `200`**: バージョンオブジェクト
+補足:
+- これは「関連素材」の管理用 API
+- 実行時に使う最終文面は引き続き `context_content` に保存する
 
----
+## Prompt Families
 
-## Runs
+同一系統のプロンプト群を管理する API。
 
-### Run一覧取得
+### `GET /prompt-families`
 
-```
-GET /projects/:projectId/runs
-```
+プロンプト系統一覧を返す。
 
 クエリパラメータ:
 
 | パラメータ | 型 | 説明 |
 |---|---|---|
-| `prompt_version_id` | number | バージョンで絞り込み |
-| `test_case_id` | number | テストケースで絞り込み |
-
-破棄済みRun（`is_discarded = 1`）は既定で一覧に含めない。
+| `q` | string | 系統名検索 |
 
 **レスポンス `200`**
 
 ```json
 [
   {
-    "id": 1,
-    "project_id": 1,
-    "prompt_version_id": 1,
-    "test_case_id": 1,
-    "conversation": [
-      { "role": "user", "content": "返金の手続きを教えてください" },
-      { "role": "assistant", "content": "ご不便をおかけして..." }
-    ],
-    "model": "claude-opus-4-5",
-    "temperature": 0.7,
-    "api_provider": "anthropic",
-    "is_best": 0,
-    "is_discarded": 0,
-    "created_at": 1744281600000
-  }
-]
-```
-
----
-
-### Run作成
-
-```
-POST /projects/:projectId/runs
-```
-
-**リクエストボディ**
-
-```json
-{
-  "prompt_version_id": 1,
-  "test_case_id": 1,
-  "conversation": [
-    { "role": "user", "content": "返金の手続きを教えてください" },
-    { "role": "assistant", "content": "ご不便をおかけして..." }
-  ],
-  "model": "claude-opus-4-5",
-  "temperature": 0.7,
-  "api_provider": "anthropic"
-}
-```
-
-| フィールド | 型 | 必須 | 説明 |
-|---|---|---|---|
-| `prompt_version_id` | number | ✅ | 使用したプロンプトバージョンID |
-| `test_case_id` | number | ✅ | 対象テストケースID |
-| `conversation` | `{role, content}[]` | ✅ | 実行時の全会話履歴 |
-| `model` | string | ✅ | 実行時のモデルID（`project_settings` からコピー） |
-| `temperature` | number | ✅ | 実行時のtemperature（`project_settings` からコピー） |
-| `api_provider` | `"anthropic"` \| `"openai"` | ✅ | 実行時のAPIプロバイダー（`project_settings` からコピー） |
-
-> `model` / `temperature` / `api_provider` はサーバー側で `project_settings` から自動取得することも可能だが、クライアントが明示的に渡すことで「表示中の設定と実行時の設定のズレ」を防ぐ。
-
-**レスポンス `201`**: 作成されたRunオブジェクト（スコアフィールドは含まない）
-
----
-
-### Run取得
-
-```
-GET /projects/:projectId/runs/:id
-```
-
-**レスポンス `200`**: Runオブジェクト
-
----
-
-### ベスト回答フラグ設定
-
-```
-PATCH /projects/:projectId/runs/:id/best
-```
-
-バージョン×テストケースの組み合わせで他のRunの `is_best` を `0` にリセットし、対象Runを `1` に設定する。
-
-**レスポンス `200`**: 更新後のRunオブジェクト
-
----
-
-### Run破棄
-
-```
-PATCH /projects/:projectId/runs/:id/discard
-```
-
-対象Runの `is_discarded` を `1` に設定する。
-
-**レスポンス `200`**: 更新後のRunオブジェクト（`is_discarded: 1`）
-
----
-
-## Scores
-
-Run に対する評価スコアを管理する。`runs` テーブルとは分離され、1つの Run に対して複数のスコアレコードを保持できる。
-
-### スコア一覧取得
-
-```
-GET /projects/:projectId/runs/:runId/scores
-```
-
-**レスポンス `200`**
-
-```json
-[
-  {
-    "id": 1,
-    "run_id": 1,
-    "human_score": 4,
-    "human_comment": "手順が明確で良い",
-    "judge_score": null,
-    "judge_reason": null,
-    "is_discarded": 0,
+    "id": 4,
+    "name": "返金対応プロンプト",
+    "description": "返金問い合わせに対応するプロンプト系列",
     "created_at": 1744281600000,
     "updated_at": 1744281600000
   }
 ]
 ```
 
----
+### `POST /prompt-families`
 
-### スコア作成
-
-```
-POST /projects/:projectId/runs/:runId/scores
-```
+プロンプト系統を作成する。
 
 **リクエストボディ**
 
 ```json
 {
-  "human_score": 4,
-  "human_comment": "手順が明確で良い"
+  "name": "返金対応プロンプト",
+  "description": "返金問い合わせに対応するプロンプト系列"
 }
 ```
 
-| フィールド | 型 | 必須 | 説明 |
-|---|---|---|---|
-| `human_score` | number | | 1〜5点（NULL=未採点） |
-| `human_comment` | string | | フリーテキストコメント |
+### `GET /prompt-families/:id`
 
-**レスポンス `201`**: 作成されたScoreオブジェクト
+プロンプト系統詳細を返す。
 
----
+### `PATCH /prompt-families/:id`
 
-### スコア更新
+プロンプト系統を更新する。
 
-```
-PATCH /projects/:projectId/runs/:runId/scores/:id
-```
+### `DELETE /prompt-families/:id`
 
-**リクエストボディ**（変更するフィールドのみ）
+プロンプト系統を削除する。
+
+**レスポンス `204`**
+
+### `PUT /prompt-families/:id/context-assets`
+
+プロンプト系統に関連付ける素材一覧を全置換する。
+
+**リクエストボディ**
 
 ```json
 {
-  "human_score": 5,
-  "human_comment": "完璧な回答"
+  "context_asset_ids": [4, 7]
 }
 ```
 
-**レスポンス `200`**: 更新後のScoreオブジェクト
+## Prompt Versions
 
----
+プロンプトバージョンを管理する API。
 
-### スコア破棄
+### `GET /prompt-versions`
 
-```
-PATCH /projects/:projectId/runs/:runId/scores/:id/discard
-```
+プロンプトバージョン一覧を返す。
 
-`is_discarded` を `1` に設定する。不正データや再採点後の古いスコアを無効化する際に使用。
+クエリパラメータ:
 
-**レスポンス `200`**: 更新後のScoreオブジェクト（`is_discarded: 1`）
-
----
-
-## 集計
-
-### バージョン別平均スコア
-
-`scores` テーブルの `human_score`（`is_discarded = 0` のもの）を集計する。
-
-```
-GET /projects/:projectId/stats/scores
-```
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `prompt_family_id` | number | 系統で絞り込む |
+| `project_id` | number | 指定ラベルが付いたバージョンに絞り込む |
+| `selected_only` | boolean | `is_selected = true` のみ返す |
 
 **レスポンス `200`**
 
 ```json
 [
   {
-    "prompt_version_id": 1,
-    "version": 1,
-    "name": "初期バージョン",
-    "avg_score": 3.5,
-    "run_count": 4,
-    "scored_count": 2
+    "id": 10,
+    "prompt_family_id": 4,
+    "version": 3,
+    "name": "返金対応 v3",
+    "memo": "確認質問を先に入れる",
+    "content": "あなたは返金問い合わせ対応ボットです。",
+    "workflow_definition": null,
+    "parent_version_id": 8,
+    "is_selected": true,
+    "created_at": 1744281600000
   }
 ]
 ```
+
+### `POST /prompt-versions`
+
+プロンプトバージョンを作成する。
+
+**リクエストボディ**
+
+```json
+{
+  "prompt_family_id": 4,
+  "name": "返金対応 v3",
+  "memo": "確認質問を先に入れる",
+  "content": "あなたは返金問い合わせ対応ボットです。",
+  "workflow_definition": null,
+  "parent_version_id": 8
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `prompt_family_id` | number | ✅ | 所属する系列 ID |
+| `name` | string | | バージョン名 |
+| `memo` | string | | 変更メモ |
+| `content` | string | ✅ | システムプロンプト本文 |
+| `workflow_definition` | object | | 将来のステップ定義 |
+| `parent_version_id` | number | | 分岐元バージョン ID |
+
+`version` は `prompt_family` 内の連番としてサーバー側で自動採番する。
+
+### `GET /prompt-versions/:id`
+
+プロンプトバージョン詳細を返す。
+
+### `PATCH /prompt-versions/:id`
+
+プロンプトバージョンを更新する。
+
+### `POST /prompt-versions/:id/branch`
+
+既存バージョンを分岐元にして新しいバージョンを作る。
+
+### `PATCH /prompt-versions/:id/selected`
+
+対象バージョンを `is_selected = true` にする。
+
+### `PUT /prompt-versions/:id/projects`
+
+プロンプトバージョンに付与するラベル一覧を全置換する。
+
+**リクエストボディ**
+
+```json
+{
+  "project_ids": [1, 5]
+}
+```
+
+## Execution Profiles
+
+Run 実行時の設定テンプレートを管理する API。
+
+### `GET /execution-profiles`
+
+設定一覧を返す。
+
+**レスポンス `200`**
+
+```json
+[
+  {
+    "id": 2,
+    "name": "Claude Sonnet 低温度",
+    "description": "比較用の低温度設定",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.2,
+    "api_provider": "anthropic",
+    "created_at": 1744281600000,
+    "updated_at": 1744281600000
+  }
+]
+```
+
+### `POST /execution-profiles`
+
+設定を作成する。
+
+**リクエストボディ**
+
+```json
+{
+  "name": "Claude Sonnet 低温度",
+  "description": "比較用の低温度設定",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.2,
+  "api_provider": "anthropic"
+}
+```
+
+### `GET /execution-profiles/:id`
+
+設定詳細を返す。
+
+### `PATCH /execution-profiles/:id`
+
+設定を更新する。
+
+### `DELETE /execution-profiles/:id`
+
+設定を削除する。過去の Run はスナップショット値を持つため参照可能。
+
+**レスポンス `204`**
+
+### `POST /execution-profiles/models`
+
+指定プロバイダ・API キーで利用可能なモデル一覧を取得する。
+
+**リクエストボディ**
+
+```json
+{
+  "api_provider": "anthropic",
+  "api_key": "..."
+}
+```
+
+## Runs
+
+プロンプトバージョン × テストケース × 実行設定の実行結果を管理する API。
+
+### `GET /runs`
+
+Run 一覧を返す。
+
+クエリパラメータ:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `prompt_version_id` | number | プロンプトバージョンで絞り込む |
+| `test_case_id` | number | テストケースで絞り込む |
+| `execution_profile_id` | number | 実行設定で絞り込む |
+| `project_id` | number | プロンプト側ラベル基準で絞り込む |
+| `include_discarded` | boolean | 破棄済み Run も含める |
+
+補足:
+- `project_id` は `prompt_version_projects` に指定ラベルが付いた `prompt_version` の Run を返す
+- `test_case_projects` は `runs` のラベル絞り込みには使わない
+- 破棄済み Run は既定で含めない
+
+**レスポンス `200`**
+
+```json
+[
+  {
+    "id": 100,
+    "prompt_version_id": 10,
+    "test_case_id": 1,
+    "execution_profile_id": 2,
+    "conversation": [
+      { "role": "user", "content": "返金の手続きを教えてください" },
+      { "role": "assistant", "content": "購入日を確認させてください。" }
+    ],
+    "execution_trace": null,
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.2,
+    "api_provider": "anthropic",
+    "is_best": false,
+    "is_discarded": false,
+    "created_at": 1744281600000
+  }
+]
+```
+
+### `POST /runs`
+
+Run を手動保存する。
+
+**リクエストボディ**
+
+```json
+{
+  "prompt_version_id": 10,
+  "test_case_id": 1,
+  "execution_profile_id": 2,
+  "conversation": [
+    { "role": "user", "content": "返金の手続きを教えてください" },
+    { "role": "assistant", "content": "購入日を確認させてください。" }
+  ],
+  "execution_trace": null
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `prompt_version_id` | number | ✅ | 使用したプロンプトバージョン |
+| `test_case_id` | number | ✅ | 対象テストケース |
+| `execution_profile_id` | number | ✅ | 実行設定 |
+| `conversation` | `{role, content}[]` | ✅ | 実行時の全会話履歴 |
+| `execution_trace` | object[] \| null | | ステップ実行ログ |
+
+補足:
+- `model` / `temperature` / `api_provider` はサーバー側で `execution_profile` から取得してスナップショット保存する
+
+### `POST /runs/execute`
+
+LLM を使って Run を実行し、SSE で進捗を返す。
+
+**リクエストボディ**
+
+```json
+{
+  "prompt_version_id": 10,
+  "test_case_id": 1,
+  "execution_profile_id": 2,
+  "api_key": "..."
+}
+```
+
+SSE イベント:
+- `delta`
+- `step-start`
+- `step-delta`
+- `step-complete`
+- `run`
+- `error`
+
+### `GET /runs/:id`
+
+Run 詳細を返す。
+
+### `PATCH /runs/:id/best`
+
+対象 Run の `is_best` を更新する。
+
+**リクエストボディ**
+
+```json
+{
+  "unset": false
+}
+```
+
+補足:
+- `unset = false` の場合、同一 `prompt_version_id × test_case_id` の他 Run の `is_best` は `false` にリセットする
+
+### `PATCH /runs/:id/discard`
+
+対象 Run の `is_discarded` を更新する。
+
+**リクエストボディ**
+
+```json
+{
+  "is_discarded": true
+}
+```
+
+## Scores
+
+Run に対する評価スコアを管理する API。
+
+現行 UI は 1 Run = 1 Score の使い方に寄っているが、データモデル上は複数保持できる。
+
+### `GET /runs/:runId/scores`
+
+指定 Run のスコア一覧を返す。
+
+**レスポンス `200`**
+
+```json
+[
+  {
+    "id": 1,
+    "run_id": 100,
+    "human_score": 4,
+    "human_comment": "確認質問が適切",
+    "judge_score": null,
+    "judge_reason": null,
+    "is_discarded": false,
+    "created_at": 1744281600000,
+    "updated_at": 1744281600000
+  }
+]
+```
+
+### `POST /runs/:runId/scores`
+
+スコアを作成する。
+
+**リクエストボディ**
+
+```json
+{
+  "human_score": 4,
+  "human_comment": "確認質問が適切"
+}
+```
+
+### `GET /runs/:runId/score`
+
+現行 UI 互換のため、非破棄スコア 1 件を返す簡易エンドポイント。
+
+補足:
+- 複数存在する場合の選択ルールは別途固定する
+- 新規 UI では `GET /runs/:runId/scores` を優先する
+
+### `PATCH /runs/:runId/score`
+
+現行 UI 互換の簡易更新エンドポイント。
+
+### `PATCH /runs/:runId/scores/:id`
+
+スコアを更新する。
+
+**リクエストボディ例**
+
+```json
+{
+  "human_score": 5,
+  "human_comment": "完璧な回答",
+  "is_discarded": false
+}
+```
+
+### `PATCH /runs/:runId/scores/:id/discard`
+
+対象スコアの `is_discarded` を `true` にする。
+
+## Score Progression
+
+スコア推移を返す API。
+
+### `GET /score-progression`
+
+クエリパラメータ:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `project_id` | number | プロンプト側ラベル基準で絞り込む |
+| `prompt_family_id` | number | 系列単位で絞り込む |
+| `score_type` | string | `human` または `judge` |
+
+補足:
+- `project_id` は `runs` と同様に `prompt_version_projects` 基準で解釈する
+
+**レスポンス `200`**
+
+```json
+{
+  "versionSummaries": [
+    {
+      "versionId": 10,
+      "versionNumber": 3,
+      "versionName": "返金対応 v3",
+      "avgHumanScore": 4.2,
+      "avgJudgeScore": null,
+      "runCount": 5,
+      "scoredCount": 4
+    }
+  ],
+  "testCaseBreakdown": [
+    {
+      "testCaseId": 1,
+      "testCaseTitle": "返金手続きの問い合わせ",
+      "versions": [
+        {
+          "versionId": 10,
+          "versionNumber": 3,
+          "versionName": "返金対応 v3",
+          "humanScore": 4,
+          "judgeScore": null,
+          "runId": 100
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 互換レイヤの扱い
+
+旧 API との互換が必要な場合は、当面次のパスを互換レイヤとして残せる。
+
+- `/projects/:projectId/test-cases`
+- `/projects/:projectId/prompt-versions`
+- `/projects/:projectId/runs`
+- `/projects/:projectId/context-files`
+- `/projects/:projectId/settings`
+
+ただし新規実装は、以下を正とする。
+
+- `/test-cases`
+- `/prompt-families`
+- `/prompt-versions`
+- `/context-assets`
+- `/execution-profiles`
+- `/runs`
+

--- a/doc/er-diagram.md
+++ b/doc/er-diagram.md
@@ -1,6 +1,14 @@
 # ER図
 
-prompt-reviewer のデータベーススキーマ（Drizzle ORM / SQLite）
+prompt-reviewer のデータベーススキーマ案（Drizzle ORM / SQLite）
+
+## 設計方針
+
+- `test_cases` と `prompt_versions` は `project` から独立したグローバル資産として扱う
+- `context_assets` も独立したグローバル資産として扱う
+- `projects` は所有単位ではなく、後から付与できる分類ラベルとして扱う
+- `project_settings` は廃止し、実行条件は `execution_profiles` として独立管理する
+- `未分類` は実テーブルのレコードではなく、「ラベルが1件も付いていない状態」を指す
 
 ## テーブル関連図
 
@@ -14,19 +22,8 @@ erDiagram
         integer updated_at "NOT NULL (Unix timestamp)"
     }
 
-    project_settings {
-        integer id PK "AUTO INCREMENT"
-        integer project_id FK "NOT NULL → projects.id"
-        text model "NOT NULL, default: claude-opus-4-5"
-        real temperature "NOT NULL, default: 0.7"
-        text api_provider "NOT NULL, enum: anthropic|openai, default: anthropic"
-        integer created_at "NOT NULL (Unix timestamp)"
-        integer updated_at "NOT NULL (Unix timestamp)"
-    }
-
     test_cases {
         integer id PK "AUTO INCREMENT"
-        integer project_id FK "NOT NULL → projects.id"
         text title "NOT NULL"
         text turns "NOT NULL (JSON: [{role, content}])"
         text context_content "NOT NULL, default: ''"
@@ -36,27 +33,84 @@ erDiagram
         integer updated_at "NOT NULL (Unix timestamp)"
     }
 
+    context_assets {
+        integer id PK "AUTO INCREMENT"
+        text name "NOT NULL"
+        text path "NOT NULL"
+        text content "NOT NULL"
+        text mime_type "NOT NULL"
+        integer created_at "NOT NULL (Unix timestamp)"
+        integer updated_at "NOT NULL (Unix timestamp)"
+    }
+
     prompt_versions {
         integer id PK "AUTO INCREMENT"
-        integer project_id FK "NOT NULL → projects.id"
-        integer version "NOT NULL (自動採番)"
+        integer prompt_family_id FK "NOT NULL → prompt_families.id"
+        integer version "NOT NULL (family内で自動採番)"
         text name
         text memo
         text content "NOT NULL (システムプロンプト本文)"
+        text workflow_definition
         integer parent_version_id FK "→ prompt_versions.id (分岐元)"
+        integer is_selected "NOT NULL, default: 0 (0|1)"
         integer created_at "NOT NULL (Unix timestamp)"
+    }
+
+    prompt_families {
+        integer id PK "AUTO INCREMENT"
+        text name
+        text description
+        integer created_at "NOT NULL (Unix timestamp)"
+        integer updated_at "NOT NULL (Unix timestamp)"
+    }
+
+    test_case_projects {
+        integer test_case_id FK "NOT NULL → test_cases.id"
+        integer project_id FK "NOT NULL → projects.id"
+        integer created_at "NOT NULL (Unix timestamp)"
+    }
+
+    test_case_context_assets {
+        integer test_case_id FK "NOT NULL → test_cases.id"
+        integer context_asset_id FK "NOT NULL → context_assets.id"
+        integer created_at "NOT NULL (Unix timestamp)"
+    }
+
+    prompt_version_projects {
+        integer prompt_version_id FK "NOT NULL → prompt_versions.id"
+        integer project_id FK "NOT NULL → projects.id"
+        integer created_at "NOT NULL (Unix timestamp)"
+    }
+
+    prompt_family_context_assets {
+        integer prompt_family_id FK "NOT NULL → prompt_families.id"
+        integer context_asset_id FK "NOT NULL → context_assets.id"
+        integer created_at "NOT NULL (Unix timestamp)"
+    }
+
+    execution_profiles {
+        integer id PK "AUTO INCREMENT"
+        text name "NOT NULL"
+        text description
+        text model "NOT NULL, default: claude-opus-4-5"
+        real temperature "NOT NULL, default: 0.7"
+        text api_provider "NOT NULL, enum: anthropic|openai, default: anthropic"
+        integer created_at "NOT NULL (Unix timestamp)"
+        integer updated_at "NOT NULL (Unix timestamp)"
     }
 
     runs {
         integer id PK "AUTO INCREMENT"
-        integer project_id FK "NOT NULL → projects.id"
         integer prompt_version_id FK "NOT NULL → prompt_versions.id"
         integer test_case_id FK "NOT NULL → test_cases.id"
+        integer execution_profile_id FK "NOT NULL → execution_profiles.id"
         text conversation "NOT NULL (JSON: [{role, content}])"
+        text execution_trace "nullable (JSON)"
         text model "NOT NULL (実行時スナップショット)"
         real temperature "NOT NULL (実行時スナップショット)"
         text api_provider "NOT NULL, enum: anthropic|openai (実行時スナップショット)"
         integer is_best "NOT NULL, default: 0 (0|1)"
+        integer is_discarded "NOT NULL, default: 0 (0|1)"
         integer created_at "NOT NULL (Unix timestamp)"
     }
 
@@ -72,51 +126,458 @@ erDiagram
         integer updated_at "NOT NULL (Unix timestamp)"
     }
 
-    projects ||--|| project_settings : "1:1"
-    projects ||--o{ test_cases : "1:N"
-    projects ||--o{ prompt_versions : "1:N"
-    projects ||--o{ runs : "1:N"
+    prompt_families ||--o{ prompt_versions : "1:N"
     prompt_versions ||--o{ prompt_versions : "self-ref (分岐)"
     prompt_versions ||--o{ runs : "1:N"
     test_cases ||--o{ runs : "1:N"
+    execution_profiles ||--o{ runs : "1:N"
     runs ||--o{ scores : "1:N"
+
+    test_cases ||--o{ test_case_projects : "1:N"
+    projects ||--o{ test_case_projects : "1:N"
+    test_cases ||--o{ test_case_context_assets : "1:N"
+    context_assets ||--o{ test_case_context_assets : "1:N"
+    prompt_versions ||--o{ prompt_version_projects : "1:N"
+    projects ||--o{ prompt_version_projects : "1:N"
+    prompt_families ||--o{ prompt_family_context_assets : "1:N"
+    context_assets ||--o{ prompt_family_context_assets : "1:N"
 ```
 
 ## テーブル説明
 
 ### projects
-システムプロンプト改善の作業単位。プロジェクトは複数のテストケースとプロンプトバージョンを持つ。
+分類用のラベル。`test_cases` や `prompt_versions` の所有者ではなく、後から複数付与できる。
 
-### project_settings
-プロジェクトごとのLLM設定（モデル・temperature・APIプロバイダー）。プロジェクトと1:1で紐づく。  
-**APIキーは別管理**（セキュリティ上、DBには保存しない）。
+- 通常のプロジェクトと `未分類` は区別する
+- `未分類` は `projects` の実レコードではなく、中間テーブルに紐付けがない状態として表現する
 
 ### test_cases
-システムプロンプトを評価するためのマルチターン入力ケース。
+システムプロンプトを評価するためのマルチターン入力ケース。単独で存在でき、どの `project` にも属さない状態を許容する。
+
 - `title`: テストケースの名前
-- `turns`: `[{role: "user"|"assistant", content: string}]` 形式のJSON文字列
-- `context_content`: `{{context}}` プレースホルダーに挿入するテキスト（単一のテキストブロック）
-- `expected_description`: 期待する出力の自由記述（任意）
-- `display_order`: 一覧表示時の並び順（デフォルト0）
+- `turns`: `[{role: "user"|"assistant", content: string}]` 形式の JSON 文字列
+- `context_content`: `{{context}}` プレースホルダーに挿入するテキスト
+- `expected_description`: 期待する出力の自由記述
+- `display_order`: 一覧表示上の並び順。グローバルな既定順として保持する
+
+### context_assets
+コンテキスト素材の実体。テストケースやプロンプト系統に取り込む前の再利用可能なテキスト資産として扱う。
+
+- `name`: UI 上の表示名
+- `path`: 元ファイル名や論理パス。現行のファイル選択 UI を引き継ぐために保持する
+- `content`: 素材本文
+- `mime_type`: テキスト種別
+- どの `project` にも属さない状態を許容する
+
+### prompt_families
+同一系統のプロンプト群を束ねるための親概念。
+
+- 「全く別のプロンプト」を誤って同じ履歴系列に積まないための単位
+- `prompt_versions.version` の採番スコープを持つ
+- 必須ではないが、プロンプト履歴を安定して扱うために導入する
 
 ### prompt_versions
-システムプロンプトのバージョン履歴。
-- `version`: プロジェクト内で自動採番
-- `parent_version_id`: 分岐元バージョンのID（ツリー構造で管理）
-- 破棄しない限り全バージョンを保持
+システムプロンプトのバージョン履歴。`project` には直接所属せず、`prompt_family` に属する。
+
+- `version`: `prompt_family` 内で自動採番
+- `parent_version_id`: 分岐元バージョン
+- `workflow_definition`: 将来のステップ実行定義
+- `is_selected`: UI 上で現在選択中の候補を示すフラグ
+
+### test_case_projects
+`test_cases` と `projects` の多対多を表す中間テーブル。
+
+- 1つのテストケースに複数ラベルを付与できる
+- ラベルが0件なら未分類として扱う
+- 重複付与を防ぐため、実装時は `UNIQUE(test_case_id, project_id)` を付ける前提
+
+### test_case_context_assets
+`test_cases` と `context_assets` の多対多を表す中間テーブル。
+
+- 1つのテストケースに複数の素材を関連付けできる
+- 1つの素材を複数のテストケースで使い回せる
+- 取り込み後の最終テキストは引き続き `test_cases.context_content` に保存する
+- 実装時は `UNIQUE(test_case_id, context_asset_id)` を付ける前提
+
+### prompt_version_projects
+`prompt_versions` と `projects` の多対多を表す中間テーブル。
+
+- 1つのプロンプトバージョンに複数ラベルを付与できる
+- ラベルが0件でも保存できる
+- 実装時は `UNIQUE(prompt_version_id, project_id)` を付ける前提
+
+### prompt_family_context_assets
+`prompt_families` と `context_assets` の多対多を表す中間テーブル。
+
+- プロンプト系統ごとの設計資料、ルール集、評価メモを関連付けできる
+- `prompt_version` ではなく `prompt_family` に付けることで、系列全体で共有しやすくする
+- 実装時は `UNIQUE(prompt_family_id, context_asset_id)` を付ける前提
+
+### execution_profiles
+Run 実行時に参照する実行条件テンプレート。旧 `project_settings` を置き換える。
+
+- `model` / `temperature` / `api_provider` を保持する
+- `project` から独立しており、同じ設定を複数のテストケースやプロンプトで再利用できる
+- API キーのような秘匿情報は引き続き別管理
 
 ### runs
-プロンプトバージョン × テストケースの実行結果。同一の組み合わせで複数回保持可能。
-- `project_id`: 所属プロジェクト（外部キー）
-- `conversation`: 実行時の全会話履歴（JSON）
-- `model` / `temperature` / `api_provider`: 実行時の `project_settings` をスナップショット保存。設定変更後も過去の実行条件を正確に参照できる
-- `is_best`: バージョン×ケースごとのベスト回答フラグ（0|1）
-- `is_discarded`: Run の破棄フラグ。既定の一覧では除外し、必要時のみ表示する（0|1）
+`prompt_version` × `test_case` × `execution_profile` の実行結果。
+
+- `project_id` は持たない
+- 一覧上で project ごとに絞り込む場合は、`prompt_version_projects` を基準に判定する
+- `model` / `temperature` / `api_provider` は `execution_profile` 参照時の値をスナップショット保存する
+- `is_best`: バージョン×ケースごとのベスト回答フラグ
+- `is_discarded`: Run の破棄フラグ
 
 ### scores
-Run に対する評価スコアを管理する。1つの Run に対して複数のスコアを保持可能（再採点・LLM Judge追加を想定）。
-- `human_score`: 人間が付けた1〜5点のスコア（NULL=未採点）
-- `human_comment`: 人間によるフリーテキストコメント（任意）
-- `judge_score`: LLM Judge が付けた1〜5点のスコア（フェーズ2実装、フェーズ1はNULL）
-- `judge_reason`: LLM Judge の評価理由（フェーズ2実装、フェーズ1はNULL）
-- `is_discarded`: 廃棄フラグ。不正データや再実行後に無効化したスコアに使用（0|1）
+Run に対する評価スコアを管理する。1つの Run に対して複数のスコアを保持可能。
+
+- `human_score`: 人間が付けた 1〜5 点のスコア
+- `human_comment`: 人間によるフリーテキストコメント
+- `judge_score`: LLM Judge が付けた 1〜5 点のスコア
+- `judge_reason`: LLM Judge の評価理由
+- `is_discarded`: 無効化したスコアを表すフラグ
+
+## 補足
+
+### project をラベル扱いにした理由
+
+- テストケースとプロンプトを先に作り、あとから分類できる
+- 同一資産を複数の文脈で再利用できる
+- `default project` を作らずに `未分類` を自然に表現できる
+
+### context_assets を独立させた理由
+
+- 素材置き場として再利用しやすい
+- テストケース専用素材とプロンプト系統の参考資料を同じ枠組みで扱える
+- 取り込み前の素材と、実行時に使う `context_content` の責務を分離できる
+
+### 今後の実装上の論点
+
+- `context-files` のファイルシステム保存を続けるか、`context_assets.content` に DB 保存へ寄せるか決める必要がある
+- API は `/projects/:projectId/...` 前提なので、資産中心の URL に再設計が必要
+- `runs` の project 絞り込みはプロンプト側ラベル基準で API に明記する必要がある
+
+## context_assets 保存方式の比較
+
+### 案1: ファイルシステム主体
+
+概要:
+`context_assets` テーブルにはメタデータだけを持ち、本文は `data/context-assets/<asset-id>` のようなファイルとして保存する。
+
+想定カラム:
+- `id`
+- `name`
+- `path`
+- `mime_type`
+- `storage_key`
+- `size`
+- `content_hash`
+- `created_at`
+- `updated_at`
+
+長所:
+- 既存の `context-files` 実装に近く、移行コストが低い
+- 大きめのテキストでも DB を膨らませにくい
+- 将来バイナリ添付を扱いたくなった時に拡張しやすい
+
+短所:
+- DB とファイルの整合性管理が必要になる
+- バックアップ、コピー、削除が二相管理になる
+- Cloudflare Workers のような「ローカル FS 前提でない環境」と相性が悪い
+- トランザクション境界が分かれるため、更新失敗時の後始末が増える
+
+向いている場合:
+- ローカル利用が中心
+- 既存実装を活かして早く移行したい
+- ファイルとしての入出力を今後も重視する
+
+### 案2: DB 主体
+
+概要:
+`context_assets.content` に本文をそのまま保存し、必要なら `path` は論理名として保持する。
+
+想定カラム:
+- `id`
+- `name`
+- `path`
+- `content`
+- `mime_type`
+- `content_hash`
+- `created_at`
+- `updated_at`
+
+長所:
+- 整合性が高い。作成・更新・削除を 1 トランザクションで扱いやすい
+- SQLite / PostgreSQL / D1 など環境差を吸収しやすい
+- バックアップとエクスポートが単純になる
+- 現在の用途が「テキストを選んで取り込む」中心なので責務に合っている
+
+短所:
+- 非常に大きいテキストを大量保存すると DB サイズが増えやすい
+- OS 上のファイルとして直接触るワークフローには向かない
+- 将来バイナリ管理まで広げるなら別設計が必要
+
+向いている場合:
+- テキスト資産が中心
+- 複数実行環境に持っていきたい
+- アプリ全体を DB 中心で一貫させたい
+
+### 推奨
+
+第一候補は DB 主体。
+
+理由:
+- 現在の `context-files` は実質的に「テキスト素材ライブラリ」であり、汎用ファイルストレージではない
+- このプロダクトは SQLite を中心にしつつ他 DB へ持っていく前提なので、ファイルシステム依存を減らしたほうが将来の移植性が高い
+- `test_cases.context_content` に取り込むという現行 UX とも整合する
+
+例外:
+- ローカル専用ツールとして割り切り、Markdown やテキストを外部エディタで直接編集したい要求が強いなら、短期的にはファイルシステム主体もあり
+
+### 推奨移行方針
+
+1. まずは `context_assets` を DB 主体で追加する
+2. 現行の `context-files` API は互換レイヤとして残し、裏側では `context_assets` を読む
+3. UI の `コンテキスト管理` を `project` 基準から独立資産基準へ移す
+4. 安定後に `/projects/:projectId/context-files` を段階的に廃止する
+
+## API 再設計案
+
+### 基本方針
+
+- 親子 URL ではなく、資産中心の URL にする
+- `project` は所有者ではなくフィルタ条件として扱う
+- `runs` 一覧の `project_id` フィルタはプロンプト側ラベル基準にする
+
+### context_assets API
+
+一覧取得:
+`GET /api/context-assets`
+
+クエリ例:
+- `project_id=3`
+- `unclassified=true`
+- `linked_to=test_case:12`
+- `linked_to=prompt_family:4`
+- `q=refund`
+
+レスポンス例:
+
+```json
+[
+  {
+    "id": 10,
+    "name": "refund-policy.md",
+    "path": "policies/refund-policy.md",
+    "mime_type": "text/markdown",
+    "updated_at": 1744281600000
+  }
+]
+```
+
+詳細取得:
+`GET /api/context-assets/:id`
+
+作成:
+`POST /api/context-assets`
+
+```json
+{
+  "name": "refund-policy.md",
+  "path": "policies/refund-policy.md",
+  "content": "購入から30日以内であれば返金可能です。",
+  "mime_type": "text/markdown"
+}
+```
+
+更新:
+`PATCH /api/context-assets/:id`
+
+```json
+{
+  "name": "refund-policy-v2.md",
+  "content": "購入から45日以内であれば返金可能です。"
+}
+```
+
+削除:
+`DELETE /api/context-assets/:id`
+
+### context_assets 関連付け API
+
+テストケースへ関連付け:
+`PUT /api/test-cases/:id/context-assets`
+
+```json
+{
+  "context_asset_ids": [10, 12, 18]
+}
+```
+
+プロンプト系統へ関連付け:
+`PUT /api/prompt-families/:id/context-assets`
+
+```json
+{
+  "context_asset_ids": [4, 7]
+}
+```
+
+補足:
+- まずは全置換 `PUT` にすると実装が単純
+- 差分更新が必要になったら `POST` / `DELETE` を個別追加する
+
+### test_cases API
+
+一覧:
+`GET /api/test-cases`
+
+クエリ例:
+- `project_id=3`
+- `unclassified=true`
+
+詳細:
+`GET /api/test-cases/:id`
+
+作成:
+`POST /api/test-cases`
+
+```json
+{
+  "title": "返金手続きの問い合わせ",
+  "turns": [
+    { "role": "user", "content": "返金の手続きを教えてください" }
+  ],
+  "context_content": "【返金ポリシー】購入から30日以内であれば返金可能です。",
+  "expected_description": "丁寧に返金手続きを案内すること"
+}
+```
+
+更新:
+`PATCH /api/test-cases/:id`
+
+### prompt_families / prompt_versions API
+
+プロンプト系統一覧:
+`GET /api/prompt-families`
+
+プロンプト版一覧:
+`GET /api/prompt-versions?prompt_family_id=4`
+
+プロンプト版作成:
+`POST /api/prompt-versions`
+
+```json
+{
+  "prompt_family_id": 4,
+  "content": "あなたは返金問い合わせ対応ボットです。",
+  "name": "返金対応 v3",
+  "memo": "確認質問を先に入れる"
+}
+```
+
+### projects ラベル API
+
+一覧:
+`GET /api/projects`
+
+資産へのラベル付け:
+- `PUT /api/test-cases/:id/projects`
+- `PUT /api/prompt-versions/:id/projects`
+
+例:
+
+```json
+{
+  "project_ids": [1, 5]
+}
+```
+
+### runs API
+
+一覧:
+`GET /api/runs`
+
+クエリ例:
+- `prompt_version_id=10`
+- `test_case_id=5`
+- `execution_profile_id=2`
+- `project_id=3`
+
+`project_id` の意味:
+- `prompt_version_projects` にそのラベルが付いた `prompt_version` の Run のみ返す
+- `test_case_projects` は `runs` の project 絞り込み条件には使わない
+
+詳細:
+`GET /api/runs/:id`
+
+作成:
+`POST /api/runs`
+
+```json
+{
+  "prompt_version_id": 10,
+  "test_case_id": 5,
+  "execution_profile_id": 2,
+  "conversation": [
+    { "role": "user", "content": "返金できますか？" }
+  ]
+}
+```
+
+実行:
+`POST /api/runs/execute`
+
+```json
+{
+  "prompt_version_id": 10,
+  "test_case_id": 5,
+  "execution_profile_id": 2,
+  "api_key": "..."
+}
+```
+
+### execution_profiles API
+
+一覧:
+`GET /api/execution-profiles`
+
+作成:
+`POST /api/execution-profiles`
+
+```json
+{
+  "name": "Claude Sonnet 低温度",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.2,
+  "api_provider": "anthropic"
+}
+```
+
+更新:
+`PATCH /api/execution-profiles/:id`
+
+## 移行コストの見立て
+
+### DB 主体にした場合
+
+- ルーター: `context-files.ts` を `context-assets.ts` に置換
+- UI: `ContextFilesPage` を `ContextAssetsPage` に置換
+- テストケース編集: `projectId` 前提の素材取得を独立 API 呼び出しへ変更
+- DB: `context_assets` と中間テーブルの追加、既存 `data/context-files` からの取り込みスクリプトが必要
+
+評価:
+- 初期移行コストは中程度
+- 以後の構造はかなり安定する
+
+### ファイルシステム主体にした場合
+
+- ルーター: 現行コードをかなり再利用できる
+- UI: API パス変更中心で済みやすい
+- DB: メタデータだけ追加すればよい
+- ただし、将来のマルチ環境対応時に再設計コストが残る
+
+評価:
+- 初期移行コストは低い
+- 将来コストは高くなりやすい

--- a/doc/migration-plan.md
+++ b/doc/migration-plan.md
@@ -1,0 +1,925 @@
+# Migration Plan
+
+`doc/er-diagram.md` と `doc/api-spec.md` に基づく、`project` 親子モデルから「独立資産 + 分類ラベル」モデルへの移行計画。
+
+## 目的
+
+- `projects` を所有単位から分類ラベルへ再定義する
+- `test_cases` / `prompt_versions` / `context_assets` を独立資産として扱う
+- `project_settings` を廃止し、`execution_profiles` へ置き換える
+- `runs` の `project` 絞り込みをプロンプト側ラベル基準に統一する
+- 既存 UI を大きく壊さず、互換レイヤを挟んで段階的に移行する
+
+## 前提
+
+- 既存の `/projects/:projectId/...` API は一気に削除しない
+- DB は SQLite を主対象にしつつ、将来の PostgreSQL / D1 移植性を維持する
+- `context_assets` は DB 主体で保存する
+- スコープは「ドメインモデル移行 + API/UI 移行」。LLM 機能追加は含めない
+
+## 移行方針
+
+### 1. 互換性を保ちながら新モデルを追加する
+
+- 先に新テーブルと新 API を足す
+- 旧 API は互換レイヤとして残し、裏側を新モデルへ寄せる
+- UI は画面単位で順次新 API に切り替える
+
+### 2. データ移行は「二重読み取り -> 一括移行 -> 旧経路削除」の順に進める
+
+- まず新旧どちらのデータも扱えるサーバー状態を作る
+- その後に既存データを新スキーマへ移す
+- UI とサーバーの参照先が完全に新スキーマへ移ったあとで旧経路を削除する
+
+### 3. 依存の強い箇所から順に分割する
+
+優先順位:
+1. スキーマ追加
+2. `execution_profiles`
+3. `prompt_families` / `prompt_versions`
+4. `context_assets`
+5. `test_cases`
+6. `runs`
+7. UI 導線刷新
+8. 互換レイヤ削除
+
+## フェーズ構成
+
+### Phase 0: 移行準備
+
+- 仕様凍結
+- 実装順の合意
+- 旧 API 互換方針の確定
+
+### Phase 1: スキーマ追加と移行基盤
+
+- 新テーブル追加
+- 中間テーブル追加
+- 既存データ移行スクリプト追加
+- 新旧差分検証のテスト追加
+
+### Phase 2: サーバー API の新旧共存
+
+- 新 API ルーター追加
+- 旧 API の内部実装を新モデル寄りに変更
+- `project_settings` と `context-files` の互換経路を作る
+
+### Phase 3: UI の新モデル対応
+
+- `execution_profiles` 導入
+- `prompt_families` 導入
+- `context_assets` 管理画面への置換
+- `projects` をラベル UI に変更
+
+### Phase 4: データ移行と切り替え
+
+- ローカル DB を移行
+- 互換 API 利用箇所を除去
+- 旧カラム / 旧ルート削除
+
+## Issue 一覧
+
+以下は、依存順に並べた実装 Issue 草案。各 Issue は単体でレビュー可能な粒度にしている。
+
+---
+
+## Issue 1: 新ドメインモデル用スキーマを追加する
+
+### 目的
+
+新データモデルの土台となるテーブルを Drizzle schema と migration に追加する。
+
+### 対象
+
+- `packages/core/src/schema/`
+- `packages/core/drizzle/`
+- `packages/core/drizzle.config.ts`
+- 必要なら `packages/core/scripts/check-db-schema.mjs`
+
+### 実装内容
+
+- `prompt_families` テーブルを追加
+- `execution_profiles` テーブルを追加
+- `context_assets` テーブルを追加
+- `test_case_projects` 中間テーブルを追加
+- `prompt_version_projects` 中間テーブルを追加
+- `test_case_context_assets` 中間テーブルを追加
+- `prompt_family_context_assets` 中間テーブルを追加
+- `prompt_versions.project_id` を将来的に廃止する前提で、新設計に必要なカラムを整理
+- `runs.execution_profile_id` を追加
+- 一意制約を追加
+  - `UNIQUE(test_case_id, project_id)`
+  - `UNIQUE(prompt_version_id, project_id)`
+  - `UNIQUE(test_case_id, context_asset_id)`
+  - `UNIQUE(prompt_family_id, context_asset_id)`
+
+### 完了条件
+
+- Drizzle schema が新 ER 図と整合している
+- migration ファイルが生成済み
+- schema 検証スクリプトが通る
+
+### テスト
+
+- schema の型テスト
+- `check-db-schema.mjs` の期待カラム更新
+
+### 依存
+
+- なし
+
+---
+
+## Issue 2: 既存データを新スキーマへ移す移行方針とスクリプトを作成する
+
+### 目的
+
+旧テーブル/旧ファイル構造のデータを、新テーブルへ安全に移す。
+
+### 対象
+
+- `packages/core/scripts/`
+- 必要なら `scripts/`
+- `README.md` または `README.local.md`
+
+### 実装内容
+
+- 既存 `projects` をそのままラベルとして流用する方針を明文化
+- 既存 `prompt_versions.project_id` から `prompt_version_projects` を生成
+- 既存 `test_cases.project_id` から `test_case_projects` を生成
+- 既存 `project_settings` から `execution_profiles` を生成
+- 既存 `runs` に `execution_profile_id` を補完するルールを実装
+- 既存 `data/context-files/<projectId>/...` を走査し、`context_assets` と関連テーブルへ変換するスクリプトを作成
+- 重複ファイルの扱いを決める
+  - 初期実装は project ごとに別 asset でも可
+
+### 完了条件
+
+- 空でない既存 DB に対して移行スクリプトが動く
+- 主要データが新テーブルへコピーされる
+- 再実行時の挙動が明確
+
+### テスト
+
+- サンプル DB を使った移行テスト
+- `context-files` 取り込みテスト
+
+### 依存
+
+- Issue 1
+
+---
+
+## Issue 3: `execution_profiles` の schema/export と API ルーターを追加する
+
+### 目的
+
+旧 `project_settings` を置き換える新 API を追加する。
+
+### 対象
+
+- `packages/core/src/schema/index.ts`
+- `packages/server/src/routes/execution-profiles.ts` 新規
+- `packages/server/src/routes/execution-profiles.test.ts` 新規
+- `packages/server/src/index.ts`
+
+### 実装内容
+
+- `GET /api/execution-profiles`
+- `POST /api/execution-profiles`
+- `GET /api/execution-profiles/:id`
+- `PATCH /api/execution-profiles/:id`
+- `DELETE /api/execution-profiles/:id`
+- `POST /api/execution-profiles/models`
+- モデル一覧取得ロジックを `project-settings` ルーターから切り出す
+
+### 完了条件
+
+- `execution_profiles` CRUD が API から利用できる
+- モデル一覧取得 API が新経路で使える
+
+### テスト
+
+- CRUD テスト
+- バリデーションテスト
+- モデル一覧取得テスト
+
+### 依存
+
+- Issue 1
+
+---
+
+## Issue 4: `project_settings` を互換レイヤ化する
+
+### 目的
+
+旧 UI を壊さずに、`project_settings` API を `execution_profiles` ベースへ寄せる。
+
+### 対象
+
+- `packages/server/src/routes/project-settings.ts`
+- `packages/server/src/routes/project-settings.test.ts`
+
+### 実装内容
+
+- `GET /api/projects/:projectId/settings` を、対応する既定 `execution_profile` を返す実装に寄せる
+- `PUT /api/projects/:projectId/settings` を、内部的には `execution_profiles` を更新/作成する挙動へ変更
+- 互換のためレスポンス形は当面維持
+- project ごとの既定 profile 選定ルールを明文化
+
+### 完了条件
+
+- 旧 settings UI から操作しても新テーブル側が更新される
+- 既存テストが通る
+
+### テスト
+
+- 互換レスポンステスト
+- 新旧整合テスト
+
+### 依存
+
+- Issue 2
+- Issue 3
+
+---
+
+## Issue 5: `prompt_families` API を追加する
+
+### 目的
+
+プロンプトの系列単位を扱う API を追加する。
+
+### 対象
+
+- `packages/core/src/schema/`
+- `packages/server/src/routes/prompt-families.ts` 新規
+- `packages/server/src/routes/prompt-families.test.ts` 新規
+- `packages/server/src/index.ts`
+
+### 実装内容
+
+- `GET /api/prompt-families`
+- `POST /api/prompt-families`
+- `GET /api/prompt-families/:id`
+- `PATCH /api/prompt-families/:id`
+- `DELETE /api/prompt-families/:id`
+- 検索・ページ内並び順に必要な最小限のクエリ対応
+
+### 完了条件
+
+- prompt family の CRUD が成立する
+
+### テスト
+
+- CRUD テスト
+- 404 / 400 テスト
+
+### 依存
+
+- Issue 1
+
+---
+
+## Issue 6: `prompt_versions` を `prompt_family` 前提へ移行する
+
+### 目的
+
+`prompt_versions` の主従を `project` から `prompt_family` に切り替える。
+
+### 対象
+
+- `packages/core/src/schema/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.test.ts`
+
+### 実装内容
+
+- `GET /api/prompt-versions`
+- `POST /api/prompt-versions`
+- `GET /api/prompt-versions/:id`
+- `PATCH /api/prompt-versions/:id`
+- `POST /api/prompt-versions/:id/branch`
+- `PATCH /api/prompt-versions/:id/selected`
+- `prompt_family_id` ベースで `version` を採番する
+- `PUT /api/prompt-versions/:id/projects` を追加する
+
+### 完了条件
+
+- 新 API で prompt version の一覧/作成/分岐/選択が可能
+- `project_id` 依存なしで動作する
+
+### テスト
+
+- family 単位の連番採番テスト
+- branch テスト
+- selected 切り替えテスト
+- ラベル付けテスト
+
+### 依存
+
+- Issue 1
+- Issue 2
+- Issue 5
+
+---
+
+## Issue 7: 旧 `prompt-versions` API を互換レイヤ化する
+
+### 目的
+
+既存 UI の `/projects/:projectId/prompt-versions` を新モデル上で動かす。
+
+### 対象
+
+- `packages/server/src/routes/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.test.ts`
+
+### 実装内容
+
+- 旧 `/api/projects/:projectId/prompt-versions` を維持しつつ、内部的には `prompt_version_projects` でフィルタする
+- 旧レスポンスに必要な `project_id` は互換のため補完する
+- family が複数 project にラベル付けされている場合の挙動を明示
+
+### 完了条件
+
+- 既存 UI が壊れない
+- 新旧 API の結果が矛盾しない
+
+### テスト
+
+- project フィルタ互換テスト
+- legacy path の CRUD テスト
+
+### 依存
+
+- Issue 6
+
+---
+
+## Issue 8: `context_assets` API を追加する
+
+### 目的
+
+旧 `context-files` を置き換える独立資産 API を追加する。
+
+### 対象
+
+- `packages/server/src/routes/context-assets.ts` 新規
+- `packages/server/src/routes/context-assets.test.ts` 新規
+- `packages/server/src/index.ts`
+
+### 実装内容
+
+- `GET /api/context-assets`
+- `POST /api/context-assets`
+- `GET /api/context-assets/:id`
+- `PATCH /api/context-assets/:id`
+- `DELETE /api/context-assets/:id`
+- `PUT /api/context-assets/:id/projects`
+- `linked_to=test_case:*` / `linked_to=prompt_family:*` フィルタ対応
+- `q`, `project_id`, `unclassified` フィルタ対応
+
+### 完了条件
+
+- DB 保存の context asset CRUD が成立する
+
+### テスト
+
+- CRUD テスト
+- フィルタテスト
+- ラベル付けテスト
+
+### 依存
+
+- Issue 1
+
+---
+
+## Issue 9: 旧 `context-files` API を互換レイヤ化する
+
+### 目的
+
+既存 `ContextFilesPage` と `TestCasesPage` の素材取り込みを、新 `context_assets` で裏打ちする。
+
+### 対象
+
+- `packages/server/src/routes/context-files.ts`
+- `packages/server/src/routes/context-files.test.ts`
+
+### 実装内容
+
+- 旧 `GET /api/projects/:projectId/context-files` を、project ラベル付きの `context_assets` 一覧に変換して返す
+- 旧 `POST /api/projects/:projectId/context-files` を、内部的には `context_assets` 作成 + project ラベル付けに変換する
+- 旧 `GET/PUT /content` も `context_assets` ベースへ置換する
+- path ベース指定と asset ID ベース内部処理の対応を持つ
+
+### 完了条件
+
+- 旧 UI からのコンテキスト一覧/編集/取り込みが動く
+
+### テスト
+
+- 既存互換テスト更新
+- project フィルタ互換テスト
+
+### 依存
+
+- Issue 2
+- Issue 8
+
+---
+
+## Issue 10: `test_cases` API を独立資産化する
+
+### 目的
+
+テストケース API を project 親子モデルから独立資産モデルへ移す。
+
+### 対象
+
+- `packages/server/src/routes/test-cases.ts`
+- `packages/server/src/routes/test-cases.test.ts`
+
+### 実装内容
+
+- `GET /api/test-cases`
+- `POST /api/test-cases`
+- `GET /api/test-cases/:id`
+- `PATCH /api/test-cases/:id`
+- `DELETE /api/test-cases/:id`
+- `PUT /api/test-cases/:id/projects`
+- `PUT /api/test-cases/:id/context-assets`
+- `project_id` / `unclassified` / `q` フィルタ対応
+
+### 完了条件
+
+- project 非依存で test case CRUD が成立する
+- context asset 関連付けが可能
+
+### テスト
+
+- CRUD テスト
+- ラベル付けテスト
+- context asset 関連付けテスト
+
+### 依存
+
+- Issue 1
+- Issue 8
+
+---
+
+## Issue 11: 旧 `test-cases` API を互換レイヤ化する
+
+### 目的
+
+既存 UI の `/projects/:projectId/test-cases` を新モデル上で動かす。
+
+### 対象
+
+- `packages/server/src/routes/test-cases.ts`
+- `packages/server/src/routes/test-cases.test.ts`
+
+### 実装内容
+
+- 旧 path を維持しつつ内部的には `test_case_projects` で project フィルタする
+- 互換レスポンス用の `project_id` を補完する
+- 新旧 API 間のバリデーション差分を吸収する
+
+### 完了条件
+
+- 既存 UI が壊れない
+
+### テスト
+
+- 旧 path 互換テスト
+- 新旧 API 同値テスト
+
+### 依存
+
+- Issue 10
+
+---
+
+## Issue 12: `runs` API を `execution_profile` / prompt-label 基準に移行する
+
+### 目的
+
+Run API を新モデルへ移し、`project` 絞り込みをプロンプト側ラベル基準に統一する。
+
+### 対象
+
+- `packages/server/src/routes/runs.ts`
+- `packages/server/src/routes/runs.test.ts`
+- `packages/server/src/routes/score-progression.ts`
+
+### 実装内容
+
+- `GET /api/runs`
+- `POST /api/runs`
+- `POST /api/runs/execute`
+- `GET /api/runs/:id`
+- `PATCH /api/runs/:id/best`
+- `PATCH /api/runs/:id/discard`
+- `project_id` フィルタを `prompt_version_projects` 基準で実装
+- Run 作成時に `execution_profile` から snapshot を保存
+- score progression の集計条件も同じ基準にそろえる
+
+### 完了条件
+
+- 新 API で runs の CRUD/execute が成立する
+- score progression が新フィルタ定義で動く
+
+### テスト
+
+- project フィルタの基準テスト
+- execution_profile snapshot テスト
+- best/discard テスト
+- progression 集計テスト
+
+### 依存
+
+- Issue 3
+- Issue 6
+- Issue 10
+
+---
+
+## Issue 13: 旧 `runs` / `score-progression` API を互換レイヤ化する
+
+### 目的
+
+既存 Runs / Score / Progression 画面を壊さずに新モデルへつなぐ。
+
+### 対象
+
+- `packages/server/src/routes/runs.ts`
+- `packages/server/src/routes/score-progression.ts`
+
+### 実装内容
+
+- `/api/projects/:projectId/runs` を新 `runs` API の project フィルタへ委譲
+- `/api/projects/:projectId/score-progression` を新集計へ委譲
+- legacy response shape の `project_id` を補完
+
+### 完了条件
+
+- 既存 UI から Run 一覧/実行/推移表示が継続利用できる
+
+### テスト
+
+- legacy path 互換テスト
+
+### 依存
+
+- Issue 12
+
+---
+
+## Issue 14: UI API クライアントを新エンドポイントへ対応させる
+
+### 目的
+
+新 API を呼ぶフロント API クライアントを追加する。
+
+### 対象
+
+- `packages/ui/src/lib/api.ts`
+
+### 実装内容
+
+- `getContextAssets` / `createContextAsset` / `updateContextAsset` / `deleteContextAsset`
+- `getPromptFamilies` / `createPromptFamily`
+- `getExecutionProfiles` / `createExecutionProfile` / `updateExecutionProfile`
+- 独立 `getTestCases` / `getPromptVersions` / `getRuns` を追加
+- 旧メソッドは互換利用のため一旦残す
+
+### 完了条件
+
+- UI から新 API を呼ぶための関数群がそろう
+
+### テスト
+
+- 必要なら API クライアント単体テスト
+
+### 依存
+
+- Issue 3
+- Issue 6
+- Issue 8
+- Issue 10
+- Issue 12
+
+---
+
+## Issue 15: Project Settings 画面を Execution Profiles 画面へ置き換える
+
+### 目的
+
+`ProjectSettingsPage` を廃止し、独立した `ExecutionProfilesPage` を導入する。
+
+### 対象
+
+- `packages/ui/src/pages/ProjectSettingsPage.tsx`
+- `packages/ui/src/pages/ProjectSettingsPage.module.css`
+- `packages/ui/src/pages/ExecutionProfilesPage.tsx` 新規
+- `packages/ui/src/pages/ExecutionProfilesPage.module.css` 新規
+- `packages/ui/src/App.tsx`
+- `packages/ui/src/components/Layout.tsx`
+
+### 実装内容
+
+- execution profiles 一覧/作成/編集 UI を作る
+- モデル一覧取得 UI を新 API に接続
+- 旧 project settings 画面導線を新画面へ差し替える
+
+### 完了条件
+
+- settings 依存なしで実行設定を管理できる
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 14
+
+---
+
+## Issue 16: Prompts 画面を Prompt Families + Prompt Versions モデルへ置き換える
+
+### 目的
+
+`PromptsPage` を project 前提から family 前提へ移す。
+
+### 対象
+
+- `packages/ui/src/pages/PromptsPage.tsx`
+- `packages/ui/src/pages/PromptsPage.module.css`
+
+### 実装内容
+
+- prompt family の選択 UI を追加
+- family 単位の version 履歴表示に変更
+- project ラベルはフィルタ/タグ表示として扱う
+- version 作成・branch・selected 更新を新 API に接続
+
+### 完了条件
+
+- prompt family ベースで UI が成立する
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 14
+
+---
+
+## Issue 17: ContextFiles 画面を ContextAssets 画面へ置き換える
+
+### 目的
+
+旧 `ContextFilesPage` を、独立資産を扱う `ContextAssetsPage` に置き換える。
+
+### 対象
+
+- `packages/ui/src/pages/ContextFilesPage.tsx`
+- `packages/ui/src/pages/ContextFilesPage.module.css`
+- `packages/ui/src/pages/ContextAssetsPage.tsx` 新規
+- `packages/ui/src/pages/ContextAssetsPage.module.css` 新規
+- `packages/ui/src/App.tsx`
+
+### 実装内容
+
+- context assets 一覧/作成/編集/削除 UI を作る
+- project ラベルによるフィルタを追加
+- `linked_to` による関連状況表示を追加
+- 旧 page からの導線を新 page へ差し替える
+
+### 完了条件
+
+- コンテキスト素材を独立画面で管理できる
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 14
+
+---
+
+## Issue 18: Test Cases 画面を独立資産 + context assets 関連付け対応へ移す
+
+### 目的
+
+`TestCasesPage` から `projectId` 前提を外し、context asset 関連付けを扱えるようにする。
+
+### 対象
+
+- `packages/ui/src/pages/TestCasesPage.tsx`
+- `packages/ui/src/pages/TestCasesPage.module.css`
+
+### 実装内容
+
+- 画面 URL を `/test-cases` 基準へ変更
+- project はフィルタまたはタグ編集として扱う
+- コンテキスト取り込み UI を `context_assets` 一覧から取得する実装へ変更
+- 取り込み後は `context_content` 保存を維持
+- 必要なら関連 asset の一覧表示を追加
+
+### 完了条件
+
+- project 親子に依存せず test cases を管理できる
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 14
+- Issue 17
+
+---
+
+## Issue 19: Runs / Score / Progression 画面を新フィルタモデルへ移す
+
+### 目的
+
+Run 関連 UI を project 親子から独立させ、プロンプト側ラベル基準に合わせる。
+
+### 対象
+
+- `packages/ui/src/pages/RunsPage.tsx`
+- `packages/ui/src/pages/ScorePage.tsx`
+- `packages/ui/src/pages/ScoreProgressionPage.tsx`
+- 関連 CSS
+
+### 実装内容
+
+- projectId 付き URL 前提を外す
+- prompt version / prompt family / execution profile / project label フィルタを追加
+- score progression の `project` フィルタを prompt 側ラベル基準で表示に反映する
+- Run 実行 UI で `execution_profile` を選択可能にする
+
+### 完了条件
+
+- Run 作成/一覧/採点/推移表示が新 API で動く
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 14
+- Issue 15
+- Issue 16
+- Issue 18
+
+---
+
+## Issue 20: Projects 画面を「ラベル管理画面」へ再設計する
+
+### 目的
+
+`ProjectsPage` / `ProjectDetailPage` を、所有単位 UI からラベル管理 UI へ置き換える。
+
+### 対象
+
+- `packages/ui/src/pages/ProjectsPage.tsx`
+- `packages/ui/src/pages/ProjectDetailPage.tsx`
+- 関連 CSS
+- `packages/ui/src/components/Layout.tsx`
+
+### 実装内容
+
+- projects 一覧をラベル管理 UI に変更
+- ラベルの作成/編集/削除に特化する
+- project detail の配下ページ導線を廃止または再設計する
+- 全体ナビゲーションを資産中心に組み替える
+
+### 完了条件
+
+- project が「分類ラベル」として UI 上で一貫している
+
+### テスト
+
+- 必要ならコンポーネントテスト
+
+### 依存
+
+- Issue 15
+- Issue 16
+- Issue 17
+- Issue 18
+- Issue 19
+
+---
+
+## Issue 21: 旧 API / 旧 UI 導線の削除
+
+### 目的
+
+互換レイヤと旧前提コードを取り除く。
+
+### 対象
+
+- `packages/server/src/routes/project-settings.ts`
+- `packages/server/src/routes/context-files.ts`
+- legacy `/projects/:projectId/...` ルーティング
+- 旧 UI ページ/導線
+
+### 実装内容
+
+- 互換ルート削除
+- 旧 API クライアント削除
+- 旧ページ/コンポーネント削除
+- 不要テスト削除
+- ドキュメント更新
+
+### 完了条件
+
+- 旧 project 親子前提コードが repo に残っていない
+- README / doc が現状と一致する
+
+### テスト
+
+- `pnpm run typecheck`
+- `pnpm run test`
+- `pnpm run check`
+
+### 依存
+
+- Issue 4
+- Issue 7
+- Issue 9
+- Issue 11
+- Issue 13
+- Issue 20
+
+---
+
+## 推奨実装順
+
+1. Issue 1
+2. Issue 2
+3. Issue 3
+4. Issue 4
+5. Issue 5
+6. Issue 6
+7. Issue 7
+8. Issue 8
+9. Issue 9
+10. Issue 10
+11. Issue 11
+12. Issue 12
+13. Issue 13
+14. Issue 14
+15. Issue 15
+16. Issue 16
+17. Issue 17
+18. Issue 18
+19. Issue 19
+20. Issue 20
+21. Issue 21
+
+## 並行化しやすい組み合わせ
+
+- Issue 3 と Issue 5 は並行しやすい
+- Issue 8 と Issue 10 は API 層として並行しやすい
+- Issue 15 / 16 / 17 は UI 画面単位で並行しやすい
+
+ただし以下は直列で進めるべき:
+
+- Issue 1 -> Issue 2
+- Issue 6 -> Issue 7
+- Issue 10 -> Issue 11
+- Issue 12 -> Issue 13
+- Issue 20 -> Issue 21
+
+## リスク
+
+- `runs.execution_profile_id` の埋め方を誤ると、過去 Run の意味づけが壊れる
+- `context-files` 取り込みで asset 重複が多発すると UI が煩雑になる
+- 旧 UI 互換で `project_id` を補完する期間は、概念上のねじれが残る
+- `prompt_family` 導入時に既存 prompt version の系列分けルールを誤ると、履歴の意味が崩れる
+
+## 最初のマイルストーン
+
+まずは次の 4 Issue を最初のマイルストーンにするとよい。
+
+- Issue 1: 新ドメインモデル用スキーマを追加する
+- Issue 2: 既存データを新スキーマへ移す移行方針とスクリプトを作成する
+- Issue 3: `execution_profiles` の schema/export と API ルーターを追加する
+- Issue 5: `prompt_families` API を追加する
+
+ここまで終わると、新旧共存のベースができる。

--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
   dialect: "sqlite",
   schema: [
     "./src/schema/projects.ts",
+    "./src/schema/prompt-families.ts",
+    "./src/schema/execution-profiles.ts",
+    "./src/schema/context-assets.ts",
+    "./src/schema/project-links.ts",
     "./src/schema/test-cases.ts",
     "./src/schema/prompt-versions.ts",
     "./src/schema/runs.ts",

--- a/packages/core/drizzle/0009_brief_hiroim.sql
+++ b/packages/core/drizzle/0009_brief_hiroim.sql
@@ -1,0 +1,108 @@
+CREATE TABLE `prompt_families` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text,
+	`description` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `execution_profiles` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`model` text DEFAULT 'claude-opus-4-5' NOT NULL,
+	`temperature` real DEFAULT 0.7 NOT NULL,
+	`api_provider` text DEFAULT 'anthropic' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `context_assets` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`path` text NOT NULL,
+	`content` text NOT NULL,
+	`mime_type` text NOT NULL,
+	`content_hash` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `prompt_family_context_assets` (
+	`prompt_family_id` integer NOT NULL,
+	`context_asset_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`prompt_family_id`, `context_asset_id`),
+	FOREIGN KEY (`prompt_family_id`) REFERENCES `prompt_families`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`context_asset_id`) REFERENCES `context_assets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `prompt_version_projects` (
+	`prompt_version_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`prompt_version_id`, `project_id`),
+	FOREIGN KEY (`prompt_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `test_case_context_assets` (
+	`test_case_id` integer NOT NULL,
+	`context_asset_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`test_case_id`, `context_asset_id`),
+	FOREIGN KEY (`test_case_id`) REFERENCES `test_cases`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`context_asset_id`) REFERENCES `context_assets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `test_case_projects` (
+	`test_case_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`test_case_id`, `project_id`),
+	FOREIGN KEY (`test_case_id`) REFERENCES `test_cases`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_runs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`execution_profile_id` integer,
+	`project_id` integer NOT NULL,
+	`prompt_version_id` integer NOT NULL,
+	`test_case_id` integer NOT NULL,
+	`conversation` text NOT NULL,
+	`execution_trace` text,
+	`is_best` integer DEFAULT false NOT NULL,
+	`is_discarded` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	`model` text NOT NULL,
+	`temperature` real NOT NULL,
+	`api_provider` text NOT NULL,
+	FOREIGN KEY (`execution_profile_id`) REFERENCES `execution_profiles`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`prompt_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`test_case_id`) REFERENCES `test_cases`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_runs`("id", "execution_profile_id", "project_id", "prompt_version_id", "test_case_id", "conversation", "execution_trace", "is_best", "is_discarded", "created_at", "model", "temperature", "api_provider") SELECT "id", NULL, "project_id", "prompt_version_id", "test_case_id", "conversation", "execution_trace", "is_best", "is_discarded", "created_at", "model", "temperature", "api_provider" FROM `runs`;--> statement-breakpoint
+DROP TABLE `runs`;--> statement-breakpoint
+ALTER TABLE `__new_runs` RENAME TO `runs`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_scores` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`run_id` integer NOT NULL,
+	`human_score` integer,
+	`human_comment` text,
+	`judge_score` integer,
+	`judge_reason` text,
+	`is_discarded` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`run_id`) REFERENCES `runs`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_scores`("id", "run_id", "human_score", "human_comment", "judge_score", "judge_reason", "is_discarded", "created_at", "updated_at") SELECT "id", "run_id", "human_score", "human_comment", "judge_score", "judge_reason", "is_discarded", "created_at", "updated_at" FROM `scores`;--> statement-breakpoint
+DROP TABLE `scores`;--> statement-breakpoint
+ALTER TABLE `__new_scores` RENAME TO `scores`;--> statement-breakpoint
+ALTER TABLE `prompt_versions` ADD `prompt_family_id` integer REFERENCES prompt_families(id);

--- a/packages/core/drizzle/0010_colorful_plazm.sql
+++ b/packages/core/drizzle/0010_colorful_plazm.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `context_asset_projects` (
+	`context_asset_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`context_asset_id`, `project_id`),
+	FOREIGN KEY (`context_asset_id`) REFERENCES `context_assets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/packages/core/drizzle/meta/0009_snapshot.json
+++ b/packages/core/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1044 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "469b52c7-0e58-4fcb-91c1-79355e19998a",
+  "prevId": "a7b53b3a-b43e-403c-bb64-404274bdda61",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_families": {
+      "name": "prompt_families",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_profiles": {
+      "name": "execution_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_assets": {
+      "name": "context_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_family_context_assets": {
+      "name": "prompt_family_context_assets",
+      "columns": {
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "prompt_families",
+          "columnsFrom": [
+            "prompt_family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_family_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "prompt_family_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": [
+            "context_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_family_context_assets_prompt_family_id_context_asset_id_pk": {
+          "columns": [
+            "prompt_family_id",
+            "context_asset_id"
+          ],
+          "name": "prompt_family_context_assets_prompt_family_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_version_projects": {
+      "name": "prompt_version_projects",
+      "columns": {
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_version_projects_prompt_version_id_prompt_versions_id_fk": {
+          "name": "prompt_version_projects_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "prompt_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_version_projects_project_id_projects_id_fk": {
+          "name": "prompt_version_projects_project_id_projects_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_version_projects_prompt_version_id_project_id_pk": {
+          "columns": [
+            "prompt_version_id",
+            "project_id"
+          ],
+          "name": "prompt_version_projects_prompt_version_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_context_assets": {
+      "name": "test_case_context_assets",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_context_assets_test_case_id_test_cases_id_fk": {
+          "name": "test_case_context_assets_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "test_case_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": [
+            "context_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_context_assets_test_case_id_context_asset_id_pk": {
+          "columns": [
+            "test_case_id",
+            "context_asset_id"
+          ],
+          "name": "test_case_context_assets_test_case_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_projects": {
+      "name": "test_case_projects",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_projects_test_case_id_test_cases_id_fk": {
+          "name": "test_case_projects_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_projects_project_id_projects_id_fk": {
+          "name": "test_case_projects_project_id_projects_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_projects_test_case_id_project_id_pk": {
+          "columns": [
+            "test_case_id",
+            "project_id"
+          ],
+          "name": "test_case_projects_test_case_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_definition": {
+          "name": "workflow_definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_versions_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_families",
+          "columnsFrom": [
+            "prompt_family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "execution_profile_id": {
+          "name": "execution_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_execution_profile_id_execution_profiles_id_fk": {
+          "name": "runs_execution_profile_id_execution_profiles_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "execution_profiles",
+          "columnsFrom": [
+            "execution_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "prompt_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_reason": {
+          "name": "judge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_run_id_runs_id_fk": {
+          "name": "scores_run_id_runs_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/0010_snapshot.json
+++ b/packages/core/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1015 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a21ed24a-cb48-45e8-b378-de09f03324c5",
+  "prevId": "469b52c7-0e58-4fcb-91c1-79355e19998a",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_families": {
+      "name": "prompt_families",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_profiles": {
+      "name": "execution_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_assets": {
+      "name": "context_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_asset_projects": {
+      "name": "context_asset_projects",
+      "columns": {
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "context_asset_projects_context_asset_id_context_assets_id_fk": {
+          "name": "context_asset_projects_context_asset_id_context_assets_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_asset_projects_project_id_projects_id_fk": {
+          "name": "context_asset_projects_project_id_projects_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "context_asset_projects_context_asset_id_project_id_pk": {
+          "columns": ["context_asset_id", "project_id"],
+          "name": "context_asset_projects_context_asset_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_family_context_assets": {
+      "name": "prompt_family_context_assets",
+      "columns": {
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "prompt_families",
+          "columnsFrom": ["prompt_family_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_family_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "prompt_family_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_family_context_assets_prompt_family_id_context_asset_id_pk": {
+          "columns": ["prompt_family_id", "context_asset_id"],
+          "name": "prompt_family_context_assets_prompt_family_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_version_projects": {
+      "name": "prompt_version_projects",
+      "columns": {
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_version_projects_prompt_version_id_prompt_versions_id_fk": {
+          "name": "prompt_version_projects_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["prompt_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_version_projects_project_id_projects_id_fk": {
+          "name": "prompt_version_projects_project_id_projects_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_version_projects_prompt_version_id_project_id_pk": {
+          "columns": ["prompt_version_id", "project_id"],
+          "name": "prompt_version_projects_prompt_version_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_context_assets": {
+      "name": "test_case_context_assets",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_context_assets_test_case_id_test_cases_id_fk": {
+          "name": "test_case_context_assets_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "test_case_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_context_assets_test_case_id_context_asset_id_pk": {
+          "columns": ["test_case_id", "context_asset_id"],
+          "name": "test_case_context_assets_test_case_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_projects": {
+      "name": "test_case_projects",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_projects_test_case_id_test_cases_id_fk": {
+          "name": "test_case_projects_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_projects_project_id_projects_id_fk": {
+          "name": "test_case_projects_project_id_projects_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_projects_test_case_id_project_id_pk": {
+          "columns": ["test_case_id", "project_id"],
+          "name": "test_case_projects_test_case_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_definition": {
+          "name": "workflow_definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_versions_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_families",
+          "columnsFrom": ["prompt_family_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["parent_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "execution_profile_id": {
+          "name": "execution_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_execution_profile_id_execution_profiles_id_fk": {
+          "name": "runs_execution_profile_id_execution_profiles_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "execution_profiles",
+          "columnsFrom": ["execution_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["prompt_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_reason": {
+          "name": "judge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_run_id_runs_id_fk": {
+          "name": "scores_run_id_runs_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776517166552,
       "tag": "0009_brief_hiroim",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1776517669294,
+      "tag": "0010_colorful_plazm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776412800000,
       "tag": "0008_runs_execution_trace_fix",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1776517166552,
+      "tag": "0009_brief_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/scripts/check-db-schema.mjs
+++ b/packages/core/scripts/check-db-schema.mjs
@@ -36,6 +36,7 @@ const expectedSchema = {
     "created_at",
     "updated_at",
   ],
+  context_asset_projects: ["context_asset_id", "project_id", "created_at"],
   test_case_projects: ["test_case_id", "project_id", "created_at"],
   prompt_version_projects: ["prompt_version_id", "project_id", "created_at"],
   test_case_context_assets: ["test_case_id", "context_asset_id", "created_at"],

--- a/packages/core/scripts/check-db-schema.mjs
+++ b/packages/core/scripts/check-db-schema.mjs
@@ -1,11 +1,12 @@
-import Database from "better-sqlite3";
 import path from "node:path";
+import Database from "better-sqlite3";
 
 const configuredPath = process.argv[2] ?? process.env.DB_PATH ?? "../../dev.db";
 const resolvedPath = path.resolve(process.cwd(), configuredPath);
 
 const expectedSchema = {
   projects: ["id", "name", "description", "created_at", "updated_at"],
+  prompt_families: ["id", "name", "description", "created_at", "updated_at"],
   project_settings: [
     "id",
     "project_id",
@@ -15,6 +16,30 @@ const expectedSchema = {
     "created_at",
     "updated_at",
   ],
+  execution_profiles: [
+    "id",
+    "name",
+    "description",
+    "model",
+    "temperature",
+    "api_provider",
+    "created_at",
+    "updated_at",
+  ],
+  context_assets: [
+    "id",
+    "name",
+    "path",
+    "content",
+    "mime_type",
+    "content_hash",
+    "created_at",
+    "updated_at",
+  ],
+  test_case_projects: ["test_case_id", "project_id", "created_at"],
+  prompt_version_projects: ["prompt_version_id", "project_id", "created_at"],
+  test_case_context_assets: ["test_case_id", "context_asset_id", "created_at"],
+  prompt_family_context_assets: ["prompt_family_id", "context_asset_id", "created_at"],
   test_cases: [
     "id",
     "project_id",
@@ -28,6 +53,7 @@ const expectedSchema = {
   ],
   prompt_versions: [
     "id",
+    "prompt_family_id",
     "project_id",
     "version",
     "name",
@@ -40,6 +66,7 @@ const expectedSchema = {
   ],
   runs: [
     "id",
+    "execution_profile_id",
     "project_id",
     "prompt_version_id",
     "test_case_id",
@@ -66,7 +93,10 @@ const expectedSchema = {
 };
 
 function getColumns(db, tableName) {
-  return db.prepare(`PRAGMA table_info(${tableName})`).all().map((column) => column.name);
+  return db
+    .prepare(`PRAGMA table_info(${tableName})`)
+    .all()
+    .map((column) => column.name);
 }
 
 function formatList(values) {

--- a/packages/core/src/schema/context-assets.test.ts
+++ b/packages/core/src/schema/context-assets.test.ts
@@ -1,0 +1,40 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { ContextAsset, NewContextAsset } from "./context-assets.js";
+
+describe("context_assets スキーマ型定義", () => {
+  it("ContextAsset の必須フィールド型が正しい", () => {
+    type RequiredFields = {
+      id: number;
+      name: string;
+      path: string;
+      content: string;
+      mime_type: string;
+      created_at: number;
+      updated_at: number;
+    };
+
+    expectTypeOf<
+      Pick<
+        ContextAsset,
+        "id" | "name" | "path" | "content" | "mime_type" | "created_at" | "updated_at"
+      >
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("ContextAsset の content_hash は null 許容", () => {
+    expectTypeOf<ContextAsset["content_hash"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("NewContextAsset は id なしで作成できる", () => {
+    const asset: NewContextAsset = {
+      name: "refund-policy.md",
+      path: "policies/refund-policy.md",
+      content: "購入から30日以内であれば返金可能です。",
+      mime_type: "text/markdown",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+    };
+
+    expectTypeOf(asset).toMatchTypeOf<NewContextAsset>();
+  });
+});

--- a/packages/core/src/schema/context-assets.ts
+++ b/packages/core/src/schema/context-assets.ts
@@ -1,0 +1,19 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * コンテキスト素材テーブル
+ * テストケースやプロンプト系列で再利用するテキスト資産を管理する
+ */
+export const context_assets = sqliteTable("context_assets", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  path: text("path").notNull(),
+  content: text("content").notNull(),
+  mime_type: text("mime_type").notNull(),
+  content_hash: text("content_hash"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export type ContextAsset = typeof context_assets.$inferSelect;
+export type NewContextAsset = typeof context_assets.$inferInsert;

--- a/packages/core/src/schema/execution-profiles.test.ts
+++ b/packages/core/src/schema/execution-profiles.test.ts
@@ -1,0 +1,37 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { ExecutionProfile, NewExecutionProfile } from "./execution-profiles.js";
+
+describe("execution_profiles スキーマ型定義", () => {
+  it("ExecutionProfile の必須フィールド型が正しい", () => {
+    type RequiredFields = {
+      id: number;
+      name: string;
+      model: string;
+      temperature: number;
+      api_provider: "anthropic" | "openai";
+      created_at: number;
+      updated_at: number;
+    };
+
+    expectTypeOf<
+      Pick<
+        ExecutionProfile,
+        "id" | "name" | "model" | "temperature" | "api_provider" | "created_at" | "updated_at"
+      >
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("ExecutionProfile の description は null 許容", () => {
+    expectTypeOf<ExecutionProfile["description"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("NewExecutionProfile はデフォルト付きカラムを省略できる", () => {
+    const profile: NewExecutionProfile = {
+      name: "Claude デフォルト",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+    };
+
+    expectTypeOf(profile).toMatchTypeOf<NewExecutionProfile>();
+  });
+});

--- a/packages/core/src/schema/execution-profiles.ts
+++ b/packages/core/src/schema/execution-profiles.ts
@@ -1,0 +1,21 @@
+import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * 実行設定テーブル
+ * Run 実行時に参照するモデル設定を独立資産として管理する
+ */
+export const execution_profiles = sqliteTable("execution_profiles", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  model: text("model").notNull().default("claude-opus-4-5"),
+  temperature: real("temperature").notNull().default(0.7),
+  api_provider: text("api_provider", { enum: ["anthropic", "openai"] })
+    .notNull()
+    .default("anthropic"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export type ExecutionProfile = typeof execution_profiles.$inferSelect;
+export type NewExecutionProfile = typeof execution_profiles.$inferInsert;

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -3,6 +3,10 @@
  * 全テーブル定義と型定義をまとめてエクスポートする
  */
 export * from "./projects";
+export * from "./prompt-families";
+export * from "./execution-profiles";
+export * from "./context-assets";
+export * from "./project-links";
 export * from "./test-cases";
 export * from "./prompt-versions";
 export * from "./runs";

--- a/packages/core/src/schema/project-links.test.ts
+++ b/packages/core/src/schema/project-links.test.ts
@@ -1,5 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest";
 import type {
+  ContextAssetProject,
+  NewContextAssetProject,
   NewPromptFamilyContextAsset,
   NewPromptVersionProject,
   NewTestCaseContextAsset,
@@ -27,6 +29,11 @@ describe("project_links スキーマ型定義", () => {
     expectTypeOf<TestCaseContextAsset["context_asset_id"]>().toEqualTypeOf<number>();
   });
 
+  it("ContextAssetProject は複合キーの構成要素を持つ", () => {
+    expectTypeOf<ContextAssetProject["context_asset_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<ContextAssetProject["project_id"]>().toEqualTypeOf<number>();
+  });
+
   it("PromptFamilyContextAsset は複合キーの構成要素を持つ", () => {
     expectTypeOf<PromptFamilyContextAsset["prompt_family_id"]>().toEqualTypeOf<number>();
     expectTypeOf<PromptFamilyContextAsset["context_asset_id"]>().toEqualTypeOf<number>();
@@ -48,6 +55,11 @@ describe("project_links スキーマ型定義", () => {
       context_asset_id: 3,
       created_at: Date.now(),
     };
+    const contextAssetProject: NewContextAssetProject = {
+      context_asset_id: 3,
+      project_id: 2,
+      created_at: Date.now(),
+    };
     const promptFamilyContextAsset: NewPromptFamilyContextAsset = {
       prompt_family_id: 1,
       context_asset_id: 3,
@@ -57,6 +69,7 @@ describe("project_links スキーマ型定義", () => {
     expectTypeOf(testCaseProject).toMatchTypeOf<NewTestCaseProject>();
     expectTypeOf(promptVersionProject).toMatchTypeOf<NewPromptVersionProject>();
     expectTypeOf(testCaseContextAsset).toMatchTypeOf<NewTestCaseContextAsset>();
+    expectTypeOf(contextAssetProject).toMatchTypeOf<NewContextAssetProject>();
     expectTypeOf(promptFamilyContextAsset).toMatchTypeOf<NewPromptFamilyContextAsset>();
   });
 });

--- a/packages/core/src/schema/project-links.test.ts
+++ b/packages/core/src/schema/project-links.test.ts
@@ -1,0 +1,62 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type {
+  NewPromptFamilyContextAsset,
+  NewPromptVersionProject,
+  NewTestCaseContextAsset,
+  NewTestCaseProject,
+  PromptFamilyContextAsset,
+  PromptVersionProject,
+  TestCaseContextAsset,
+  TestCaseProject,
+} from "./project-links.js";
+
+describe("project_links スキーマ型定義", () => {
+  it("TestCaseProject は複合キーの構成要素を持つ", () => {
+    expectTypeOf<TestCaseProject["test_case_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<TestCaseProject["project_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<TestCaseProject["created_at"]>().toEqualTypeOf<number>();
+  });
+
+  it("PromptVersionProject は複合キーの構成要素を持つ", () => {
+    expectTypeOf<PromptVersionProject["prompt_version_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<PromptVersionProject["project_id"]>().toEqualTypeOf<number>();
+  });
+
+  it("TestCaseContextAsset は複合キーの構成要素を持つ", () => {
+    expectTypeOf<TestCaseContextAsset["test_case_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<TestCaseContextAsset["context_asset_id"]>().toEqualTypeOf<number>();
+  });
+
+  it("PromptFamilyContextAsset は複合キーの構成要素を持つ", () => {
+    expectTypeOf<PromptFamilyContextAsset["prompt_family_id"]>().toEqualTypeOf<number>();
+    expectTypeOf<PromptFamilyContextAsset["context_asset_id"]>().toEqualTypeOf<number>();
+  });
+
+  it("各中間テーブルの Insert 型を生成できる", () => {
+    const testCaseProject: NewTestCaseProject = {
+      test_case_id: 1,
+      project_id: 2,
+      created_at: Date.now(),
+    };
+    const promptVersionProject: NewPromptVersionProject = {
+      prompt_version_id: 1,
+      project_id: 2,
+      created_at: Date.now(),
+    };
+    const testCaseContextAsset: NewTestCaseContextAsset = {
+      test_case_id: 1,
+      context_asset_id: 3,
+      created_at: Date.now(),
+    };
+    const promptFamilyContextAsset: NewPromptFamilyContextAsset = {
+      prompt_family_id: 1,
+      context_asset_id: 3,
+      created_at: Date.now(),
+    };
+
+    expectTypeOf(testCaseProject).toMatchTypeOf<NewTestCaseProject>();
+    expectTypeOf(promptVersionProject).toMatchTypeOf<NewPromptVersionProject>();
+    expectTypeOf(testCaseContextAsset).toMatchTypeOf<NewTestCaseContextAsset>();
+    expectTypeOf(promptFamilyContextAsset).toMatchTypeOf<NewPromptFamilyContextAsset>();
+  });
+});

--- a/packages/core/src/schema/project-links.ts
+++ b/packages/core/src/schema/project-links.ts
@@ -40,6 +40,23 @@ export const prompt_version_projects = sqliteTable(
 );
 
 /**
+ * コンテキスト素材とラベルの関連
+ */
+export const context_asset_projects = sqliteTable(
+  "context_asset_projects",
+  {
+    context_asset_id: integer("context_asset_id")
+      .notNull()
+      .references(() => context_assets.id),
+    project_id: integer("project_id")
+      .notNull()
+      .references(() => projects.id),
+    created_at: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.context_asset_id, table.project_id] })],
+);
+
+/**
  * テストケースとコンテキスト素材の関連
  */
 export const test_case_context_assets = sqliteTable(
@@ -77,6 +94,8 @@ export type TestCaseProject = typeof test_case_projects.$inferSelect;
 export type NewTestCaseProject = typeof test_case_projects.$inferInsert;
 export type PromptVersionProject = typeof prompt_version_projects.$inferSelect;
 export type NewPromptVersionProject = typeof prompt_version_projects.$inferInsert;
+export type ContextAssetProject = typeof context_asset_projects.$inferSelect;
+export type NewContextAssetProject = typeof context_asset_projects.$inferInsert;
 export type TestCaseContextAsset = typeof test_case_context_assets.$inferSelect;
 export type NewTestCaseContextAsset = typeof test_case_context_assets.$inferInsert;
 export type PromptFamilyContextAsset = typeof prompt_family_context_assets.$inferSelect;

--- a/packages/core/src/schema/project-links.ts
+++ b/packages/core/src/schema/project-links.ts
@@ -1,0 +1,83 @@
+import { integer, primaryKey, sqliteTable } from "drizzle-orm/sqlite-core";
+import { context_assets } from "./context-assets";
+import { projects } from "./projects";
+import { prompt_families } from "./prompt-families";
+import { prompt_versions } from "./prompt-versions";
+import { test_cases } from "./test-cases";
+
+/**
+ * テストケースとラベルの関連
+ */
+export const test_case_projects = sqliteTable(
+  "test_case_projects",
+  {
+    test_case_id: integer("test_case_id")
+      .notNull()
+      .references(() => test_cases.id),
+    project_id: integer("project_id")
+      .notNull()
+      .references(() => projects.id),
+    created_at: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.test_case_id, table.project_id] })],
+);
+
+/**
+ * プロンプトバージョンとラベルの関連
+ */
+export const prompt_version_projects = sqliteTable(
+  "prompt_version_projects",
+  {
+    prompt_version_id: integer("prompt_version_id")
+      .notNull()
+      .references(() => prompt_versions.id),
+    project_id: integer("project_id")
+      .notNull()
+      .references(() => projects.id),
+    created_at: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.prompt_version_id, table.project_id] })],
+);
+
+/**
+ * テストケースとコンテキスト素材の関連
+ */
+export const test_case_context_assets = sqliteTable(
+  "test_case_context_assets",
+  {
+    test_case_id: integer("test_case_id")
+      .notNull()
+      .references(() => test_cases.id),
+    context_asset_id: integer("context_asset_id")
+      .notNull()
+      .references(() => context_assets.id),
+    created_at: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.test_case_id, table.context_asset_id] })],
+);
+
+/**
+ * プロンプト系列とコンテキスト素材の関連
+ */
+export const prompt_family_context_assets = sqliteTable(
+  "prompt_family_context_assets",
+  {
+    prompt_family_id: integer("prompt_family_id")
+      .notNull()
+      .references(() => prompt_families.id),
+    context_asset_id: integer("context_asset_id")
+      .notNull()
+      .references(() => context_assets.id),
+    created_at: integer("created_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.prompt_family_id, table.context_asset_id] })],
+);
+
+export type TestCaseProject = typeof test_case_projects.$inferSelect;
+export type NewTestCaseProject = typeof test_case_projects.$inferInsert;
+export type PromptVersionProject = typeof prompt_version_projects.$inferSelect;
+export type NewPromptVersionProject = typeof prompt_version_projects.$inferInsert;
+export type TestCaseContextAsset = typeof test_case_context_assets.$inferSelect;
+export type NewTestCaseContextAsset = typeof test_case_context_assets.$inferInsert;
+export type PromptFamilyContextAsset = typeof prompt_family_context_assets.$inferSelect;
+export type NewPromptFamilyContextAsset = typeof prompt_family_context_assets.$inferInsert;

--- a/packages/core/src/schema/prompt-families.test.ts
+++ b/packages/core/src/schema/prompt-families.test.ts
@@ -1,0 +1,32 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { NewPromptFamily, PromptFamily } from "./prompt-families.js";
+
+describe("prompt_families スキーマ型定義", () => {
+  it("PromptFamily 型は基本フィールドを持つ", () => {
+    type RequiredFields = {
+      id: number;
+      created_at: number;
+      updated_at: number;
+    };
+
+    expectTypeOf<
+      Pick<PromptFamily, "id" | "created_at" | "updated_at">
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("PromptFamily の name と description は null 許容", () => {
+    expectTypeOf<PromptFamily["name"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<PromptFamily["description"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("NewPromptFamily は id なしで作成できる", () => {
+    const family: NewPromptFamily = {
+      name: "返金対応",
+      description: "返金問い合わせ用プロンプト系列",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+    };
+
+    expectTypeOf(family).toMatchTypeOf<NewPromptFamily>();
+  });
+});

--- a/packages/core/src/schema/prompt-families.ts
+++ b/packages/core/src/schema/prompt-families.ts
@@ -1,0 +1,16 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * プロンプト系列テーブル
+ * 同一系統のプロンプトバージョンを束ねる単位を管理する
+ */
+export const prompt_families = sqliteTable("prompt_families", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name"),
+  description: text("description"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export type PromptFamily = typeof prompt_families.$inferSelect;
+export type NewPromptFamily = typeof prompt_families.$inferInsert;

--- a/packages/core/src/schema/prompt-versions.test.ts
+++ b/packages/core/src/schema/prompt-versions.test.ts
@@ -13,13 +13,17 @@ describe("prompt_versions スキーマ型定義", () => {
     it("PromptVersion 型は必須フィールドを持つ", () => {
       type RequiredFields = {
         id: number;
+        prompt_family_id: number | null;
         project_id: number;
         version: number;
         content: string;
         created_at: number;
       };
       expectTypeOf<
-        Pick<PromptVersion, "id" | "project_id" | "version" | "content" | "created_at">
+        Pick<
+          PromptVersion,
+          "id" | "prompt_family_id" | "project_id" | "version" | "content" | "created_at"
+        >
       >().toMatchTypeOf<RequiredFields>();
     });
 
@@ -96,4 +100,11 @@ describe("prompt_versions スキーマ型定義", () => {
       expectTypeOf(namedVersion).toMatchTypeOf<NewPromptVersion>();
     });
   });
+});
+it("PromptVersion の prompt_family_id は移行期間中 number | null 型", () => {
+  expectTypeOf<PromptVersion["prompt_family_id"]>().toEqualTypeOf<number | null>();
+});
+
+it("NewPromptVersion の prompt_family_id は移行期間中オプショナル", () => {
+  expectTypeOf<NewPromptVersion["prompt_family_id"]>().toEqualTypeOf<number | null | undefined>();
 });

--- a/packages/core/src/schema/prompt-versions.ts
+++ b/packages/core/src/schema/prompt-versions.ts
@@ -1,5 +1,6 @@
 import { type AnySQLiteColumn, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { projects } from "./projects";
+import { prompt_families } from "./prompt-families";
 
 /**
  * プロンプトバージョンテーブル
@@ -7,6 +8,8 @@ import { projects } from "./projects";
  */
 export const prompt_versions = sqliteTable("prompt_versions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  // 互換期間中は project_id と併存し、後続 Issue で prompt_family_id を必須化する。
+  prompt_family_id: integer("prompt_family_id").references(() => prompt_families.id),
   project_id: integer("project_id")
     .notNull()
     .references(() => projects.id),

--- a/packages/core/src/schema/runs.test.ts
+++ b/packages/core/src/schema/runs.test.ts
@@ -13,6 +13,7 @@ describe("runs スキーマ型定義", () => {
     it("Run 型は必須フィールドを持つ", () => {
       type RequiredFields = {
         id: number;
+        execution_profile_id: number | null;
         project_id: number;
         prompt_version_id: number;
         test_case_id: number;
@@ -28,6 +29,7 @@ describe("runs スキーマ型定義", () => {
         Pick<
           Run,
           | "id"
+          | "execution_profile_id"
           | "project_id"
           | "prompt_version_id"
           | "test_case_id"
@@ -40,6 +42,10 @@ describe("runs スキーマ型定義", () => {
           | "api_provider"
         >
       >().toMatchTypeOf<RequiredFields>();
+    });
+
+    it("Run の execution_profile_id は移行期間中 number | null 型", () => {
+      expectTypeOf<Run["execution_profile_id"]>().toEqualTypeOf<number | null>();
     });
 
     it("Run の conversation は string 型（JSONシリアライズ済み）", () => {
@@ -100,6 +106,10 @@ describe("runs スキーマ型定義", () => {
 
     it("NewRun の is_best はデフォルト値があるためオプショナル", () => {
       expectTypeOf<NewRun["is_best"]>().toEqualTypeOf<boolean | undefined>();
+    });
+
+    it("NewRun の execution_profile_id は移行期間中オプショナル", () => {
+      expectTypeOf<NewRun["execution_profile_id"]>().toEqualTypeOf<number | null | undefined>();
     });
 
     it("ベスト回答フラグを立てた NewRun を作成できる", () => {

--- a/packages/core/src/schema/runs.ts
+++ b/packages/core/src/schema/runs.ts
@@ -1,4 +1,5 @@
 import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { execution_profiles } from "./execution-profiles";
 import { projects } from "./projects";
 import { prompt_versions } from "./prompt-versions";
 import { test_cases } from "./test-cases";
@@ -12,6 +13,8 @@ import { test_cases } from "./test-cases";
  */
 export const runs = sqliteTable("runs", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  // 互換期間中は nullable で追加し、後続 Issue で必須化する。
+  execution_profile_id: integer("execution_profile_id").references(() => execution_profiles.id),
   project_id: integer("project_id")
     .notNull()
     .references(() => projects.id),

--- a/scripts/create-migration-issues.ps1
+++ b/scripts/create-migration-issues.ps1
@@ -1,0 +1,794 @@
+$issues = @(
+  @{
+    Title = "新ドメインモデル用スキーマを追加する"
+    Body = @'
+## 目的
+
+新データモデルの土台となるテーブルを Drizzle schema と migration に追加する。
+
+## 対象
+
+- `packages/core/src/schema/`
+- `packages/core/drizzle/`
+- `packages/core/drizzle.config.ts`
+- 必要なら `packages/core/scripts/check-db-schema.mjs`
+
+## 実装内容
+
+- `prompt_families` テーブルを追加
+- `execution_profiles` テーブルを追加
+- `context_assets` テーブルを追加
+- `test_case_projects` 中間テーブルを追加
+- `prompt_version_projects` 中間テーブルを追加
+- `test_case_context_assets` 中間テーブルを追加
+- `prompt_family_context_assets` 中間テーブルを追加
+- `runs.execution_profile_id` を追加
+- 一意制約を追加
+  - `UNIQUE(test_case_id, project_id)`
+  - `UNIQUE(prompt_version_id, project_id)`
+  - `UNIQUE(test_case_id, context_asset_id)`
+  - `UNIQUE(prompt_family_id, context_asset_id)`
+
+## 完了条件
+
+- Drizzle schema が新 ER 図と整合している
+- migration ファイルが生成済み
+- schema 検証スクリプトが通る
+
+## テスト
+
+- schema の型テスト
+- `check-db-schema.mjs` の期待カラム更新
+
+## 依存
+
+- なし
+'@
+  },
+  @{
+    Title = "既存データを新スキーマへ移す移行方針とスクリプトを作成する"
+    Body = @'
+## 目的
+
+旧テーブル/旧ファイル構造のデータを、新テーブルへ安全に移す。
+
+## 対象
+
+- `packages/core/scripts/`
+- 必要なら `scripts/`
+- `README.md` または `README.local.md`
+
+## 実装内容
+
+- 既存 `projects` をそのままラベルとして流用する方針を明文化
+- 既存 `prompt_versions.project_id` から `prompt_version_projects` を生成
+- 既存 `test_cases.project_id` から `test_case_projects` を生成
+- 既存 `project_settings` から `execution_profiles` を生成
+- 既存 `runs` に `execution_profile_id` を補完するルールを実装
+- 既存 `data/context-files/<projectId>/...` を走査し、`context_assets` と関連テーブルへ変換するスクリプトを作成
+- 重複ファイルの扱いを決める
+  - 初期実装は project ごとに別 asset でも可
+
+## 完了条件
+
+- 空でない既存 DB に対して移行スクリプトが動く
+- 主要データが新テーブルへコピーされる
+- 再実行時の挙動が明確
+
+## テスト
+
+- サンプル DB を使った移行テスト
+- `context-files` 取り込みテスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+'@
+  },
+  @{
+    Title = "`execution_profiles` の schema/export と API ルーターを追加する"
+    Body = @'
+## 目的
+
+旧 `project_settings` を置き換える新 API を追加する。
+
+## 対象
+
+- `packages/core/src/schema/index.ts`
+- `packages/server/src/routes/execution-profiles.ts` 新規
+- `packages/server/src/routes/execution-profiles.test.ts` 新規
+- `packages/server/src/index.ts`
+
+## 実装内容
+
+- `GET /api/execution-profiles`
+- `POST /api/execution-profiles`
+- `GET /api/execution-profiles/:id`
+- `PATCH /api/execution-profiles/:id`
+- `DELETE /api/execution-profiles/:id`
+- `POST /api/execution-profiles/models`
+- モデル一覧取得ロジックを `project-settings` ルーターから切り出す
+
+## 完了条件
+
+- `execution_profiles` CRUD が API から利用できる
+- モデル一覧取得 API が新経路で使える
+
+## テスト
+
+- CRUD テスト
+- バリデーションテスト
+- モデル一覧取得テスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+'@
+  },
+  @{
+    Title = "`project_settings` を互換レイヤ化する"
+    Body = @'
+## 目的
+
+旧 UI を壊さずに、`project_settings` API を `execution_profiles` ベースへ寄せる。
+
+## 対象
+
+- `packages/server/src/routes/project-settings.ts`
+- `packages/server/src/routes/project-settings.test.ts`
+
+## 実装内容
+
+- `GET /api/projects/:projectId/settings` を、対応する既定 `execution_profile` を返す実装に寄せる
+- `PUT /api/projects/:projectId/settings` を、内部的には `execution_profiles` を更新/作成する挙動へ変更
+- 互換のためレスポンス形は当面維持
+- project ごとの既定 profile 選定ルールを明文化
+
+## 完了条件
+
+- 旧 settings UI から操作しても新テーブル側が更新される
+- 既存テストが通る
+
+## テスト
+
+- 互換レスポンステスト
+- 新旧整合テスト
+
+## 依存
+
+- 既存データを新スキーマへ移す移行方針とスクリプトを作成する
+- `execution_profiles` の schema/export と API ルーターを追加する
+'@
+  },
+  @{
+    Title = "`prompt_families` API を追加する"
+    Body = @'
+## 目的
+
+プロンプトの系列単位を扱う API を追加する。
+
+## 対象
+
+- `packages/core/src/schema/`
+- `packages/server/src/routes/prompt-families.ts` 新規
+- `packages/server/src/routes/prompt-families.test.ts` 新規
+- `packages/server/src/index.ts`
+
+## 実装内容
+
+- `GET /api/prompt-families`
+- `POST /api/prompt-families`
+- `GET /api/prompt-families/:id`
+- `PATCH /api/prompt-families/:id`
+- `DELETE /api/prompt-families/:id`
+- 検索・ページ内並び順に必要な最小限のクエリ対応
+
+## 完了条件
+
+- prompt family の CRUD が成立する
+
+## テスト
+
+- CRUD テスト
+- 404 / 400 テスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+'@
+  },
+  @{
+    Title = "`prompt_versions` を `prompt_family` 前提へ移行する"
+    Body = @'
+## 目的
+
+`prompt_versions` の主従を `project` から `prompt_family` に切り替える。
+
+## 対象
+
+- `packages/core/src/schema/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.test.ts`
+
+## 実装内容
+
+- `GET /api/prompt-versions`
+- `POST /api/prompt-versions`
+- `GET /api/prompt-versions/:id`
+- `PATCH /api/prompt-versions/:id`
+- `POST /api/prompt-versions/:id/branch`
+- `PATCH /api/prompt-versions/:id/selected`
+- `prompt_family_id` ベースで `version` を採番する
+- `PUT /api/prompt-versions/:id/projects` を追加する
+
+## 完了条件
+
+- 新 API で prompt version の一覧/作成/分岐/選択が可能
+- `project_id` 依存なしで動作する
+
+## テスト
+
+- family 単位の連番採番テスト
+- branch テスト
+- selected 切り替えテスト
+- ラベル付けテスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+- 既存データを新スキーマへ移す移行方針とスクリプトを作成する
+- `prompt_families` API を追加する
+'@
+  },
+  @{
+    Title = "旧 `prompt-versions` API を互換レイヤ化する"
+    Body = @'
+## 目的
+
+既存 UI の `/projects/:projectId/prompt-versions` を新モデル上で動かす。
+
+## 対象
+
+- `packages/server/src/routes/prompt-versions.ts`
+- `packages/server/src/routes/prompt-versions.test.ts`
+
+## 実装内容
+
+- 旧 `/api/projects/:projectId/prompt-versions` を維持しつつ、内部的には `prompt_version_projects` でフィルタする
+- 旧レスポンスに必要な `project_id` は互換のため補完する
+- family が複数 project にラベル付けされている場合の挙動を明示
+
+## 完了条件
+
+- 既存 UI が壊れない
+- 新旧 API の結果が矛盾しない
+
+## テスト
+
+- project フィルタ互換テスト
+- legacy path の CRUD テスト
+
+## 依存
+
+- `prompt_versions` を `prompt_family` 前提へ移行する
+'@
+  },
+  @{
+    Title = "`context_assets` API を追加する"
+    Body = @'
+## 目的
+
+旧 `context-files` を置き換える独立資産 API を追加する。
+
+## 対象
+
+- `packages/server/src/routes/context-assets.ts` 新規
+- `packages/server/src/routes/context-assets.test.ts` 新規
+- `packages/server/src/index.ts`
+
+## 実装内容
+
+- `GET /api/context-assets`
+- `POST /api/context-assets`
+- `GET /api/context-assets/:id`
+- `PATCH /api/context-assets/:id`
+- `DELETE /api/context-assets/:id`
+- `PUT /api/context-assets/:id/projects`
+- `linked_to=test_case:*` / `linked_to=prompt_family:*` フィルタ対応
+- `q`, `project_id`, `unclassified` フィルタ対応
+
+## 完了条件
+
+- DB 保存の context asset CRUD が成立する
+
+## テスト
+
+- CRUD テスト
+- フィルタテスト
+- ラベル付けテスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+'@
+  },
+  @{
+    Title = "旧 `context-files` API を互換レイヤ化する"
+    Body = @'
+## 目的
+
+既存 `ContextFilesPage` と `TestCasesPage` の素材取り込みを、新 `context_assets` で裏打ちする。
+
+## 対象
+
+- `packages/server/src/routes/context-files.ts`
+- `packages/server/src/routes/context-files.test.ts`
+
+## 実装内容
+
+- 旧 `GET /api/projects/:projectId/context-files` を、project ラベル付きの `context_assets` 一覧に変換して返す
+- 旧 `POST /api/projects/:projectId/context-files` を、内部的には `context_assets` 作成 + project ラベル付けに変換する
+- 旧 `GET/PUT /content` も `context_assets` ベースへ置換する
+- path ベース指定と asset ID ベース内部処理の対応を持つ
+
+## 完了条件
+
+- 旧 UI からのコンテキスト一覧/編集/取り込みが動く
+
+## テスト
+
+- 既存互換テスト更新
+- project フィルタ互換テスト
+
+## 依存
+
+- 既存データを新スキーマへ移す移行方針とスクリプトを作成する
+- `context_assets` API を追加する
+'@
+  },
+  @{
+    Title = "`test_cases` API を独立資産化する"
+    Body = @'
+## 目的
+
+テストケース API を project 親子モデルから独立資産モデルへ移す。
+
+## 対象
+
+- `packages/server/src/routes/test-cases.ts`
+- `packages/server/src/routes/test-cases.test.ts`
+
+## 実装内容
+
+- `GET /api/test-cases`
+- `POST /api/test-cases`
+- `GET /api/test-cases/:id`
+- `PATCH /api/test-cases/:id`
+- `DELETE /api/test-cases/:id`
+- `PUT /api/test-cases/:id/projects`
+- `PUT /api/test-cases/:id/context-assets`
+- `project_id` / `unclassified` / `q` フィルタ対応
+
+## 完了条件
+
+- project 非依存で test case CRUD が成立する
+- context asset 関連付けが可能
+
+## テスト
+
+- CRUD テスト
+- ラベル付けテスト
+- context asset 関連付けテスト
+
+## 依存
+
+- 新ドメインモデル用スキーマを追加する
+- `context_assets` API を追加する
+'@
+  },
+  @{
+    Title = "旧 `test-cases` API を互換レイヤ化する"
+    Body = @'
+## 目的
+
+既存 UI の `/projects/:projectId/test-cases` を新モデル上で動かす。
+
+## 対象
+
+- `packages/server/src/routes/test-cases.ts`
+- `packages/server/src/routes/test-cases.test.ts`
+
+## 実装内容
+
+- 旧 path を維持しつつ内部的には `test_case_projects` で project フィルタする
+- 互換レスポンス用の `project_id` を補完する
+- 新旧 API 間のバリデーション差分を吸収する
+
+## 完了条件
+
+- 既存 UI が壊れない
+
+## テスト
+
+- 旧 path 互換テスト
+- 新旧 API 同値テスト
+
+## 依存
+
+- `test_cases` API を独立資産化する
+'@
+  },
+  @{
+    Title = "`runs` API を `execution_profile` / prompt-label 基準に移行する"
+    Body = @'
+## 目的
+
+Run API を新モデルへ移し、`project` 絞り込みをプロンプト側ラベル基準に統一する。
+
+## 対象
+
+- `packages/server/src/routes/runs.ts`
+- `packages/server/src/routes/runs.test.ts`
+- `packages/server/src/routes/score-progression.ts`
+
+## 実装内容
+
+- `GET /api/runs`
+- `POST /api/runs`
+- `POST /api/runs/execute`
+- `GET /api/runs/:id`
+- `PATCH /api/runs/:id/best`
+- `PATCH /api/runs/:id/discard`
+- `project_id` フィルタを `prompt_version_projects` 基準で実装
+- Run 作成時に `execution_profile` から snapshot を保存
+- score progression の集計条件も同じ基準にそろえる
+
+## 完了条件
+
+- 新 API で runs の CRUD/execute が成立する
+- score progression が新フィルタ定義で動く
+
+## テスト
+
+- project フィルタの基準テスト
+- execution_profile snapshot テスト
+- best/discard テスト
+- progression 集計テスト
+
+## 依存
+
+- `execution_profiles` の schema/export と API ルーターを追加する
+- `prompt_versions` を `prompt_family` 前提へ移行する
+- `test_cases` API を独立資産化する
+'@
+  },
+  @{
+    Title = "旧 `runs` / `score-progression` API を互換レイヤ化する"
+    Body = @'
+## 目的
+
+既存 Runs / Score / Progression 画面を壊さずに新モデルへつなぐ。
+
+## 対象
+
+- `packages/server/src/routes/runs.ts`
+- `packages/server/src/routes/score-progression.ts`
+
+## 実装内容
+
+- `/api/projects/:projectId/runs` を新 `runs` API の project フィルタへ委譲
+- `/api/projects/:projectId/score-progression` を新集計へ委譲
+- legacy response shape の `project_id` を補完
+
+## 完了条件
+
+- 既存 UI から Run 一覧/実行/推移表示が継続利用できる
+
+## テスト
+
+- legacy path 互換テスト
+
+## 依存
+
+- `runs` API を `execution_profile` / prompt-label 基準に移行する
+'@
+  },
+  @{
+    Title = "UI API クライアントを新エンドポイントへ対応させる"
+    Body = @'
+## 目的
+
+新 API を呼ぶフロント API クライアントを追加する。
+
+## 対象
+
+- `packages/ui/src/lib/api.ts`
+
+## 実装内容
+
+- `getContextAssets` / `createContextAsset` / `updateContextAsset` / `deleteContextAsset`
+- `getPromptFamilies` / `createPromptFamily`
+- `getExecutionProfiles` / `createExecutionProfile` / `updateExecutionProfile`
+- 独立 `getTestCases` / `getPromptVersions` / `getRuns` を追加
+- 旧メソッドは互換利用のため一旦残す
+
+## 完了条件
+
+- UI から新 API を呼ぶための関数群がそろう
+
+## テスト
+
+- 必要なら API クライアント単体テスト
+
+## 依存
+
+- `execution_profiles` の schema/export と API ルーターを追加する
+- `prompt_versions` を `prompt_family` 前提へ移行する
+- `context_assets` API を追加する
+- `test_cases` API を独立資産化する
+- `runs` API を `execution_profile` / prompt-label 基準に移行する
+'@
+  },
+  @{
+    Title = "Project Settings 画面を Execution Profiles 画面へ置き換える"
+    Body = @'
+## 目的
+
+`ProjectSettingsPage` を廃止し、独立した `ExecutionProfilesPage` を導入する。
+
+## 対象
+
+- `packages/ui/src/pages/ProjectSettingsPage.tsx`
+- `packages/ui/src/pages/ProjectSettingsPage.module.css`
+- `packages/ui/src/pages/ExecutionProfilesPage.tsx` 新規
+- `packages/ui/src/pages/ExecutionProfilesPage.module.css` 新規
+- `packages/ui/src/App.tsx`
+- `packages/ui/src/components/Layout.tsx`
+
+## 実装内容
+
+- execution profiles 一覧/作成/編集 UI を作る
+- モデル一覧取得 UI を新 API に接続
+- 旧 project settings 画面導線を新画面へ差し替える
+
+## 完了条件
+
+- settings 依存なしで実行設定を管理できる
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- UI API クライアントを新エンドポイントへ対応させる
+'@
+  },
+  @{
+    Title = "Prompts 画面を Prompt Families + Prompt Versions モデルへ置き換える"
+    Body = @'
+## 目的
+
+`PromptsPage` を project 前提から family 前提へ移す。
+
+## 対象
+
+- `packages/ui/src/pages/PromptsPage.tsx`
+- `packages/ui/src/pages/PromptsPage.module.css`
+
+## 実装内容
+
+- prompt family の選択 UI を追加
+- family 単位の version 履歴表示に変更
+- project ラベルはフィルタ/タグ表示として扱う
+- version 作成・branch・selected 更新を新 API に接続
+
+## 完了条件
+
+- prompt family ベースで UI が成立する
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- UI API クライアントを新エンドポイントへ対応させる
+'@
+  },
+  @{
+    Title = "ContextFiles 画面を ContextAssets 画面へ置き換える"
+    Body = @'
+## 目的
+
+旧 `ContextFilesPage` を、独立資産を扱う `ContextAssetsPage` に置き換える。
+
+## 対象
+
+- `packages/ui/src/pages/ContextFilesPage.tsx`
+- `packages/ui/src/pages/ContextFilesPage.module.css`
+- `packages/ui/src/pages/ContextAssetsPage.tsx` 新規
+- `packages/ui/src/pages/ContextAssetsPage.module.css` 新規
+- `packages/ui/src/App.tsx`
+
+## 実装内容
+
+- context assets 一覧/作成/編集/削除 UI を作る
+- project ラベルによるフィルタを追加
+- `linked_to` による関連状況表示を追加
+- 旧 page からの導線を新 page へ差し替える
+
+## 完了条件
+
+- コンテキスト素材を独立画面で管理できる
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- UI API クライアントを新エンドポイントへ対応させる
+'@
+  },
+  @{
+    Title = "Test Cases 画面を独立資産 + context assets 関連付け対応へ移す"
+    Body = @'
+## 目的
+
+`TestCasesPage` から `projectId` 前提を外し、context asset 関連付けを扱えるようにする。
+
+## 対象
+
+- `packages/ui/src/pages/TestCasesPage.tsx`
+- `packages/ui/src/pages/TestCasesPage.module.css`
+
+## 実装内容
+
+- 画面 URL を `/test-cases` 基準へ変更
+- project はフィルタまたはタグ編集として扱う
+- コンテキスト取り込み UI を `context_assets` 一覧から取得する実装へ変更
+- 取り込み後は `context_content` 保存を維持
+- 必要なら関連 asset の一覧表示を追加
+
+## 完了条件
+
+- project 親子に依存せず test cases を管理できる
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- UI API クライアントを新エンドポイントへ対応させる
+- ContextFiles 画面を ContextAssets 画面へ置き換える
+'@
+  },
+  @{
+    Title = "Runs / Score / Progression 画面を新フィルタモデルへ移す"
+    Body = @'
+## 目的
+
+Run 関連 UI を project 親子から独立させ、プロンプト側ラベル基準に合わせる。
+
+## 対象
+
+- `packages/ui/src/pages/RunsPage.tsx`
+- `packages/ui/src/pages/ScorePage.tsx`
+- `packages/ui/src/pages/ScoreProgressionPage.tsx`
+- 関連 CSS
+
+## 実装内容
+
+- projectId 付き URL 前提を外す
+- prompt version / prompt family / execution profile / project label フィルタを追加
+- score progression の `project` フィルタを prompt 側ラベル基準で表示に反映する
+- Run 実行 UI で `execution_profile` を選択可能にする
+
+## 完了条件
+
+- Run 作成/一覧/採点/推移表示が新 API で動く
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- UI API クライアントを新エンドポイントへ対応させる
+- Project Settings 画面を Execution Profiles 画面へ置き換える
+- Prompts 画面を Prompt Families + Prompt Versions モデルへ置き換える
+- Test Cases 画面を独立資産 + context assets 関連付け対応へ移す
+'@
+  },
+  @{
+    Title = "Projects 画面を「ラベル管理画面」へ再設計する"
+    Body = @'
+## 目的
+
+`ProjectsPage` / `ProjectDetailPage` を、所有単位 UI からラベル管理 UI へ置き換える。
+
+## 対象
+
+- `packages/ui/src/pages/ProjectsPage.tsx`
+- `packages/ui/src/pages/ProjectDetailPage.tsx`
+- 関連 CSS
+- `packages/ui/src/components/Layout.tsx`
+
+## 実装内容
+
+- projects 一覧をラベル管理 UI に変更
+- ラベルの作成/編集/削除に特化する
+- project detail の配下ページ導線を廃止または再設計する
+- 全体ナビゲーションを資産中心に組み替える
+
+## 完了条件
+
+- project が「分類ラベル」として UI 上で一貫している
+
+## テスト
+
+- 必要ならコンポーネントテスト
+
+## 依存
+
+- Project Settings 画面を Execution Profiles 画面へ置き換える
+- Prompts 画面を Prompt Families + Prompt Versions モデルへ置き換える
+- ContextFiles 画面を ContextAssets 画面へ置き換える
+- Test Cases 画面を独立資産 + context assets 関連付け対応へ移す
+- Runs / Score / Progression 画面を新フィルタモデルへ移す
+'@
+  },
+  @{
+    Title = "旧 API / 旧 UI 導線の削除"
+    Body = @'
+## 目的
+
+互換レイヤと旧前提コードを取り除く。
+
+## 対象
+
+- `packages/server/src/routes/project-settings.ts`
+- `packages/server/src/routes/context-files.ts`
+- legacy `/projects/:projectId/...` ルーティング
+- 旧 UI ページ/導線
+
+## 実装内容
+
+- 互換ルート削除
+- 旧 API クライアント削除
+- 旧ページ/コンポーネント削除
+- 不要テスト削除
+- ドキュメント更新
+
+## 完了条件
+
+- 旧 project 親子前提コードが repo に残っていない
+- README / doc が現状と一致する
+
+## テスト
+
+- `pnpm run typecheck`
+- `pnpm run test`
+- `pnpm run check`
+
+## 依存
+
+- `project_settings` を互換レイヤ化する
+- 旧 `prompt-versions` API を互換レイヤ化する
+- 旧 `context-files` API を互換レイヤ化する
+- 旧 `test-cases` API を互換レイヤ化する
+- 旧 `runs` / `score-progression` API を互換レイヤ化する
+- Projects 画面を「ラベル管理画面」へ再設計する
+'@
+  }
+)
+
+$created = @()
+
+foreach ($issue in $issues) {
+  $result = gh issue create --title $issue.Title --body $issue.Body
+  $created += $result
+  Write-Output $result
+}


### PR DESCRIPTION
## 概要
- 新ドメインモデル向けの core schema を追加
- Drizzle migration と schema check を更新
- 新規テーブルと中間テーブルの型テストを追加

## 変更内容
- `prompt_families` / `execution_profiles` / `context_assets` を追加
- `test_case_projects` / `prompt_version_projects` / `test_case_context_assets` / `prompt_family_context_assets` を追加
- 互換移行用に `prompt_versions.prompt_family_id` と `runs.execution_profile_id` を追加
- `packages/core/drizzle/0009_brief_hiroim.sql` を追加
- `check-db-schema.mjs` と schema export を更新

## 検証
- `pnpm --filter @prompt-reviewer/core build`
- `pnpm typecheck`
- `pnpm test -- --run packages/core/src/schema`
- 一時 SQLite に対する `pnpm --filter @prompt-reviewer/core migrate`
- `pnpm --filter @prompt-reviewer/core exec node ./scripts/check-db-schema.mjs ../../data/issue107-schema-check-2.sqlite`

## 関連
- Closes #107
