### PR TITLE
fix: CRLF改行コードによるbiome checkエラーを修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/biome.json
+++ b/biome.json
@@ -31,6 +31,6 @@
     }
   },
   "files": {
-    "ignore": ["**/node_modules", "**/dist", "**/.turbo", "**/target"]
+    "ignore": ["**/node_modules", "**/dist", "**/.turbo", "**/target", "worktrees/**"]
   }
 }

--- a/packages/core/drizzle/meta/0004_snapshot.json
+++ b/packages/core/drizzle/meta/0004_snapshot.json
@@ -65,13 +65,9 @@
         "project_settings_project_id_projects_id_fk": {
           "name": "project_settings_project_id_projects_id_fk",
           "tableFrom": "project_settings",
-          "columnsFrom": [
-            "project_id"
-          ],
+          "columnsFrom": ["project_id"],
           "tableTo": "projects",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         }
@@ -199,13 +195,9 @@
         "test_cases_project_id_projects_id_fk": {
           "name": "test_cases_project_id_projects_id_fk",
           "tableFrom": "test_cases",
-          "columnsFrom": [
-            "project_id"
-          ],
+          "columnsFrom": ["project_id"],
           "tableTo": "projects",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         }
@@ -279,26 +271,18 @@
         "prompt_versions_project_id_projects_id_fk": {
           "name": "prompt_versions_project_id_projects_id_fk",
           "tableFrom": "prompt_versions",
-          "columnsFrom": [
-            "project_id"
-          ],
+          "columnsFrom": ["project_id"],
           "tableTo": "projects",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         },
         "prompt_versions_parent_version_id_prompt_versions_id_fk": {
           "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
           "tableFrom": "prompt_versions",
-          "columnsFrom": [
-            "parent_version_id"
-          ],
+          "columnsFrom": ["parent_version_id"],
           "tableTo": "prompt_versions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         }
@@ -387,39 +371,27 @@
         "runs_project_id_projects_id_fk": {
           "name": "runs_project_id_projects_id_fk",
           "tableFrom": "runs",
-          "columnsFrom": [
-            "project_id"
-          ],
+          "columnsFrom": ["project_id"],
           "tableTo": "projects",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         },
         "runs_prompt_version_id_prompt_versions_id_fk": {
           "name": "runs_prompt_version_id_prompt_versions_id_fk",
           "tableFrom": "runs",
-          "columnsFrom": [
-            "prompt_version_id"
-          ],
+          "columnsFrom": ["prompt_version_id"],
           "tableTo": "prompt_versions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         },
         "runs_test_case_id_test_cases_id_fk": {
           "name": "runs_test_case_id_test_cases_id_fk",
           "tableFrom": "runs",
-          "columnsFrom": [
-            "test_case_id"
-          ],
+          "columnsFrom": ["test_case_id"],
           "tableTo": "test_cases",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         }
@@ -501,13 +473,9 @@
         "scores_run_id_runs_id_fk": {
           "name": "scores_run_id_runs_id_fk",
           "tableFrom": "scores",
-          "columnsFrom": [
-            "run_id"
-          ],
+          "columnsFrom": ["run_id"],
           "tableTo": "runs",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "no action"
         }

--- a/packages/core/scripts/check-db-schema.mjs
+++ b/packages/core/scripts/check-db-schema.mjs
@@ -1,5 +1,5 @@
-import Database from "better-sqlite3";
 import path from "node:path";
+import Database from "better-sqlite3";
 
 const configuredPath = process.argv[2] ?? process.env.DB_PATH ?? "../../dev.db";
 const resolvedPath = path.resolve(process.cwd(), configuredPath);
@@ -66,7 +66,10 @@ const expectedSchema = {
 };
 
 function getColumns(db, tableName) {
-  return db.prepare(`PRAGMA table_info(${tableName})`).all().map((column) => column.name);
+  return db
+    .prepare(`PRAGMA table_info(${tableName})`)
+    .all()
+    .map((column) => column.name);
 }
 
 function formatList(values) {

--- a/packages/core/src/db/schema-check.ts
+++ b/packages/core/src/db/schema-check.ts
@@ -1,5 +1,5 @@
-import Database from "better-sqlite3";
 import path from "node:path";
+import Database from "better-sqlite3";
 
 const expectedSchema = {
   prompt_versions: ["workflow_definition"],
@@ -43,7 +43,9 @@ export function assertRequiredSchema(dbPath: string): void {
   }
 
   const migrateCommand =
-    dbPath.includes("data/") || dbPath.includes("data\\") ? "pnpm migrate:local" : "pnpm migrate:dev";
+    dbPath.includes("data/") || dbPath.includes("data\\")
+      ? "pnpm migrate:local"
+      : "pnpm migrate:dev";
 
   throw new Error(
     `DB schema is outdated: missing ${missingColumns.join(", ")}. Run \`${migrateCommand}\` before starting the server.`,

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -294,16 +294,13 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
       body: JSON.stringify({
         content: "プロンプト本文",
         workflow_definition: {
-          steps: [
-            { id: "__base_prompt__", title: "抽出", prompt: "内容を抽出してください" },
-          ],
+          steps: [{ id: "__base_prompt__", title: "抽出", prompt: "内容を抽出してください" }],
         },
       }),
     });
 
     expect(res.status).toBe(400);
   });
-
 });
 
 describe("GET /api/projects/:projectId/prompt-versions/:id", () => {

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -81,9 +81,10 @@ function buildDefaultPromptName(version: number): string {
 export function createPromptVersionsRouter(db: DB) {
   const router = new Hono();
 
-  function serializePromptVersion(
-    version: typeof prompt_versions.$inferSelect,
-  ): Omit<typeof version, "workflow_definition"> & {
+  function serializePromptVersion(version: typeof prompt_versions.$inferSelect): Omit<
+    typeof version,
+    "workflow_definition"
+  > & {
     workflow_definition: z.infer<typeof workflowDefinitionSchema> | null;
   } {
     return {
@@ -127,7 +128,8 @@ export function createPromptVersionsRouter(db: DB) {
       .where(eq(prompt_versions.project_id, projectId));
 
     const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
-    const normalizedName = normalizeOptionalString(body.name) ?? buildDefaultPromptName(nextVersion);
+    const normalizedName =
+      normalizeOptionalString(body.name) ?? buildDefaultPromptName(nextVersion);
 
     const result = await db
       .insert(prompt_versions)
@@ -206,7 +208,7 @@ export function createPromptVersionsRouter(db: DB) {
       const normalizedName = normalizeOptionalString(body.name);
       updateData.name =
         existing.parent_version_id === null
-          ? normalizedName ?? buildDefaultPromptName(existing.version)
+          ? (normalizedName ?? buildDefaultPromptName(existing.version))
           : normalizedName;
     }
     if (body.memo !== undefined) updateData.memo = body.memo;

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -187,7 +187,6 @@ describe("GET /api/projects/:projectId/runs", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Invalid test_case_id");
   });
-
 });
 
 describe("POST /api/projects/:projectId/runs", () => {
@@ -775,8 +774,7 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
           {
             id: "extract_effective",
             title: "効果発言抽出",
-            prompt:
-              "文脈: {{context}}\n前段: {{step:__base_prompt__}}\n前回: {{previous_output}}",
+            prompt: "文脈: {{context}}\n前段: {{step:__base_prompt__}}\n前回: {{previous_output}}",
           },
         ],
       }),
@@ -810,10 +808,8 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
         {
           id: "extract_effective",
           title: "効果発言抽出",
-          prompt:
-            "文脈: {{context}}\n前段: {{step:__base_prompt__}}\n前回: {{previous_output}}",
-          renderedPrompt:
-            "文脈: 行動を促せている\n前段: 行動を促せている\n前回: 行動を促せている",
+          prompt: "文脈: {{context}}\n前段: {{step:__base_prompt__}}\n前回: {{previous_output}}",
+          renderedPrompt: "文脈: 行動を促せている\n前段: 行動を促せている\n前回: 行動を促せている",
           inputConversation: [{ role: "user", content: "長い相談ログ" }],
           output: "効果があった発言は A と B です。",
         },
@@ -890,8 +886,7 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
     });
     expect(capturedRequests[1]).toMatchObject({
       messages: [{ role: "user", content: "長い相談ログ" }],
-      systemPrompt:
-        "文脈: 行動を促せている\n前段: 行動を促せている\n前回: 行動を促せている",
+      systemPrompt: "文脈: 行動を促せている\n前段: 行動を促せている\n前回: 行動を促せている",
     });
     expect(streamText).toContain("event: step-start");
     expect(streamText).toContain("event: step-complete");
@@ -953,7 +948,8 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
       api_provider: settings.api_provider,
     };
 
-    const capturedInsertValues: Array<{ execution_trace: string | null; conversation: string }> = [];
+    const capturedInsertValues: Array<{ execution_trace: string | null; conversation: string }> =
+      [];
     let selectCallCount = 0;
     let streamCallCount = 0;
 

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -216,9 +216,10 @@ function buildExecutionRequest(params: {
   };
 }
 
-function serializeRun(
-  run: typeof runs.$inferSelect,
-): Omit<typeof run, "conversation" | "execution_trace"> & {
+function serializeRun(run: typeof runs.$inferSelect): Omit<
+  typeof run,
+  "conversation" | "execution_trace"
+> & {
   conversation: ConversationMessage[];
   execution_trace: ExecutionTraceStep[] | null;
 } {
@@ -286,9 +287,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       .from(runs)
       .where(and(...conditions));
 
-    return c.json(
-      result.map(serializeRun),
-    );
+    return c.json(result.map(serializeRun));
   });
 
   // POST /api/projects/:projectId/runs - 新規Run作成
@@ -407,7 +406,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
                   conversation: inputConversation,
                   previousOutput:
                     executionTrace.length > 0
-                      ? executionTrace[executionTrace.length - 1]?.output ?? null
+                      ? (executionTrace[executionTrace.length - 1]?.output ?? null)
                       : null,
                   stepOutputs,
                 });
@@ -463,7 +462,9 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
                   output: stepOutput,
                 });
 
-                controller.enqueue(encodeSse("step-complete", executionTrace[executionTrace.length - 1]));
+                controller.enqueue(
+                  encodeSse("step-complete", executionTrace[executionTrace.length - 1]),
+                );
               }
               assistantContent = executionTrace[executionTrace.length - 1]?.output ?? "";
             } else {
@@ -491,8 +492,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
                 prompt_version_id: body.prompt_version_id,
                 test_case_id: body.test_case_id,
                 conversation: JSON.stringify(conversation),
-                execution_trace:
-                  executionTrace.length > 0 ? JSON.stringify(executionTrace) : null,
+                execution_trace: executionTrace.length > 0 ? JSON.stringify(executionTrace) : null,
                 is_best: false,
                 is_discarded: false,
                 model: settings.model,
@@ -509,9 +509,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
               return;
             }
 
-            controller.enqueue(
-              encodeSse("run", serializeRun(created)),
-            );
+            controller.enqueue(encodeSse("run", serializeRun(created)));
           } catch (error) {
             controller.enqueue(encodeSse("error", normalizeExecuteError(error)));
           } finally {

--- a/packages/ui/src/components/RunCompareView.tsx
+++ b/packages/ui/src/components/RunCompareView.tsx
@@ -13,14 +13,20 @@ function CopyButton({ text }: { text: string }) {
   }
 
   return (
-    <button type="button" onClick={handleCopy} className={`${styles.btnCopy} ${copied ? styles.btnCopied : ""}`}>
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`${styles.btnCopy} ${copied ? styles.btnCopied : ""}`}
+    >
       {copied ? "コピー済み" : "コピー"}
     </button>
   );
 }
 
 function getLastAssistantMessage(run: Run): string {
-  return [...run.conversation].reverse().find((message) => message.role === "assistant")?.content ?? "";
+  return (
+    [...run.conversation].reverse().find((message) => message.role === "assistant")?.content ?? ""
+  );
 }
 
 export function diffLines(
@@ -175,7 +181,9 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                 <div ref={scrollRefA} className={styles.chatList} onScroll={handleScrollA}>
                   <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>
                     <span className={styles.bubbleRole}>Assistant</span>
-                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>{lastAssistantA}</div>
+                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>
+                      {lastAssistantA}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -188,7 +196,9 @@ export function RunCompareView({ runA, runB, versionLabelA, versionLabelB, onClo
                 <div ref={scrollRefB} className={styles.chatList} onScroll={handleScrollB}>
                   <div className={`${styles.bubbleWrapper} ${styles.bubbleWrapperAssistant}`}>
                     <span className={styles.bubbleRole}>Assistant</span>
-                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>{lastAssistantB}</div>
+                    <div className={`${styles.bubble} ${styles.bubbleAssistant}`}>
+                      {lastAssistantB}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -269,8 +269,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
       name?: string;
       memo?: string;
       workflow_definition?: { steps: PromptExecutionStepDefinition[] };
-    }) =>
-      createPromptVersion(projectId, data),
+    }) => createPromptVersion(projectId, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
       onSave();
@@ -334,7 +333,9 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
     <form onSubmit={handleSubmit} className={styles.editorForm}>
       <div>
         <label htmlFor="editor-name" className={styles.fieldLabel}>
-          {isNew || version?.parent_version_id === null ? "プロンプト名（任意）" : "バージョン名（任意）"}
+          {isNew || version?.parent_version_id === null
+            ? "プロンプト名（任意）"
+            : "バージョン名（任意）"}
         </label>
         <input
           id="editor-name"
@@ -378,10 +379,10 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
       <div className={styles.workflowSection}>
         <div className={styles.workflowHeader}>
           <div>
-            <label className={styles.fieldLabel}>追加ステップ（Step 2 以降）</label>
+            <p className={styles.fieldLabel}>追加ステップ（Step 2 以降）</p>
             <p className={styles.workflowHint}>
-              各ステップで `{"{{conversation}}"}`、`{"{{context}}"}`、`{"{{previous_output}}"}`、
-              `{"{{step:step_id}}"}` を利用できます。
+              各ステップで `{"{{conversation}}"}`、`{"{{context}}"}`、`{"{{previous_output}}"}`、 `
+              {"{{step:step_id}}"}` を利用できます。
             </p>
           </div>
           <button
@@ -432,9 +433,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
                     onChange={(e) =>
                       setWorkflowSteps((prev) =>
                         prev.map((current, currentIndex) =>
-                          currentIndex === index
-                            ? { ...current, title: e.target.value }
-                            : current,
+                          currentIndex === index ? { ...current, title: e.target.value } : current,
                         ),
                       )
                     }
@@ -447,9 +446,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
                   onChange={(e) =>
                     setWorkflowSteps((prev) =>
                       prev.map((current, currentIndex) =>
-                        currentIndex === index
-                          ? { ...current, prompt: e.target.value }
-                          : current,
+                        currentIndex === index ? { ...current, prompt: e.target.value } : current,
                       ),
                     )
                   }

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -10,12 +10,12 @@ import {
   type Run,
   type TestCase,
   createRun,
+  discardRun,
   executeRunStream,
   getProject,
   getPromptVersions,
   getRuns,
   getTestCases,
-  discardRun,
   setBestRun,
 } from "../lib/api";
 import styles from "./RunsPage.module.css";
@@ -34,7 +34,9 @@ function buildFullPrompt(version: PromptVersion, testCase: TestCase): string {
     .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
     .join("\n\n");
 
-  return turnsText ? `${systemPrompt}\n\n[Conversation]\n${turnsText}\n[/Conversation]` : systemPrompt;
+  return turnsText
+    ? `${systemPrompt}\n\n[Conversation]\n${turnsText}\n[/Conversation]`
+    : systemPrompt;
 }
 
 function buildWorkflowPreview(version: PromptVersion, testCase: TestCase): string {
@@ -43,16 +45,10 @@ function buildWorkflowPreview(version: PromptVersion, testCase: TestCase): strin
     .join("\n\n");
   const baseContext = testCase.context_content || "(なし)";
   const stepsText = [
-    "## Step 1: プロンプト本文\n" +
-      "id: __base_prompt__\n" +
-      "context: テストケースの context_content\n\n" +
-      version.content,
+    `## Step 1: プロンプト本文\nid: __base_prompt__\ncontext: テストケースの context_content\n\n${version.content}`,
     ...(version.workflow_definition?.steps ?? []).map(
       (step, index) =>
-        `## Step ${index + 2}: ${step.title}\n` +
-        `id: ${step.id}\n` +
-        "context: 直前ステップの出力\n\n" +
-        `${step.prompt}`,
+        `## Step ${index + 2}: ${step.title}\nid: ${step.id}\ncontext: 直前ステップの出力\n\n${step.prompt}`,
     ),
   ].join("\n\n");
 
@@ -113,7 +109,8 @@ function CopyPromptPanel({
       {hasWorkflow && (
         <div className={styles.workflowSummary}>
           <p className={styles.workflowSummaryText}>
-            この Run は段階実行です。プロンプト本文が Step 1、追加ステップが Step 2 以降として実行されます。
+            この Run は段階実行です。プロンプト本文が Step 1、追加ステップが Step 2
+            以降として実行されます。
           </p>
         </div>
       )}
@@ -475,7 +472,9 @@ export function RunsPage() {
         onStepDelta: (stepDelta) => {
           setExecutionTrace((prev) =>
             prev.map((step) =>
-              step.id === stepDelta.id ? { ...step, output: `${step.output}${stepDelta.text}` } : step,
+              step.id === stepDelta.id
+                ? { ...step, output: `${step.output}${stepDelta.text}` }
+                : step,
             ),
           );
           setLlmResponse((prev) => `${prev}${stepDelta.text}`);
@@ -658,24 +657,317 @@ export function RunsPage() {
         {/* ============ タブ: Run を作成 ============ */}
         {activeTab === "create" && (
           <div>
-          {/* Step 1: 選択フォーム */}
-          {step === "select" && (
-            <div className={styles.selectCard}>
-              <h3 className={styles.selectCardTitle}>Run を取得する</h3>
+            {/* Step 1: 選択フォーム */}
+            {step === "select" && (
+              <div className={styles.selectCard}>
+                <h3 className={styles.selectCardTitle}>Run を取得する</h3>
 
-              <div className={styles.fieldGroup}>
-                <label htmlFor="select-version" className={styles.fieldLabel}>
-                  プロンプトバージョン
+                <div className={styles.fieldGroup}>
+                  <label htmlFor="select-version" className={styles.fieldLabel}>
+                    プロンプトバージョン
+                  </label>
+                  <select
+                    id="select-version"
+                    value={selectedVersionId}
+                    onChange={(e) =>
+                      setSelectedVersionId(e.target.value === "" ? "" : Number(e.target.value))
+                    }
+                    className={styles.fieldSelect}
+                  >
+                    <option value="">-- 選択してください --</option>
+                    {promptVersions.map((v) => (
+                      <option key={v.id} value={v.id}>
+                        v{v.version}
+                        {v.name ? ` - ${v.name}` : ""}
+                      </option>
+                    ))}
+                  </select>
+                  {promptVersions.length === 0 && (
+                    <p className={styles.fieldHint}>
+                      プロンプトバージョンがありません。先にバージョンを作成してください。
+                    </p>
+                  )}
+                </div>
+
+                <div className={styles.fieldGroupLg}>
+                  <label htmlFor="select-test-case" className={styles.fieldLabel}>
+                    テストケース
+                  </label>
+                  <select
+                    id="select-test-case"
+                    value={selectedTestCaseId}
+                    onChange={(e) =>
+                      setSelectedTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
+                    }
+                    className={styles.fieldSelect}
+                  >
+                    <option value="">-- 選択してください --</option>
+                    {testCases.map((tc) => (
+                      <option key={tc.id} value={tc.id}>
+                        {tc.title}
+                      </option>
+                    ))}
+                  </select>
+                  {testCases.length === 0 && (
+                    <p className={styles.fieldHint}>
+                      テストケースがありません。先にテストケースを作成してください。
+                    </p>
+                  )}
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleStartRun}
+                  disabled={isStartDisabled}
+                  title={
+                    !hasApiKey ? "APIキーが未設定です（設定画面で入力してください）" : undefined
+                  }
+                  className={`${styles.btnStart} ${isStartDisabled ? styles.btnStartDisabled : ""}`}
+                >
+                  Run の取得
+                </button>
+                {!hasApiKey && (
+                  <p className={styles.fieldHint}>
+                    APIキーが未設定です。
+                    <Link to={`/projects/${projectId}/settings`} className={styles.settingsLink}>
+                      設定画面
+                    </Link>
+                    で入力してください。
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Step 2: Run 実行UI */}
+            {step === "input" && selectedVersion && selectedTestCase && (
+              <div>
+                <div className={styles.stepHeader}>
+                  <button
+                    type="button"
+                    onClick={() => setStep("select")}
+                    className={styles.btnSecondary}
+                  >
+                    ← 戻る
+                  </button>
+                  <span className={styles.stepLabel}>
+                    v{selectedVersion.version}
+                    {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
+                    {selectedTestCase.title}
+                  </span>
+                </div>
+
+                <CopyPromptPanel version={selectedVersion} testCase={selectedTestCase} />
+
+                <div className={styles.twoColumns}>
+                  {/* 左カラム: テストケース表示 */}
+                  <div className={styles.panel}>
+                    <h3 className={styles.panelTitle}>テストケース: {selectedTestCase.title}</h3>
+
+                    {/* 会話ターン表示 */}
+                    <div className={styles.chatList}>
+                      {selectedTestCase.turns.map((turn, index) => (
+                        <div
+                          key={`turn-${
+                            // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
+                            index
+                          }`}
+                          className={`${styles.bubbleWrapper} ${turn.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
+                        >
+                          <span className={styles.bubbleRole}>
+                            {turn.role === "user" ? "User" : "Assistant"}
+                          </span>
+                          <div
+                            className={`${styles.bubble} ${turn.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                          >
+                            {turn.content}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+
+                    {selectedTestCase.context_content && (
+                      <div className={styles.expectedBox}>
+                        <p className={styles.expectedLabel}>コンテキスト</p>
+                        <p className={styles.expectedText}>{selectedTestCase.context_content}</p>
+                      </div>
+                    )}
+
+                    {/* 期待される説明 */}
+                    {selectedTestCase.expected_description && (
+                      <div className={styles.expectedBox}>
+                        <p className={styles.expectedLabel}>期待される応答の説明</p>
+                        <p className={styles.expectedText}>
+                          {selectedTestCase.expected_description}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 右カラム: LLM実行・手動入力エリア */}
+                  <div className={`${styles.panel} ${styles.panelFlex}`}>
+                    <h3 className={styles.panelSubtitle}>LLM 応答</h3>
+                    <p className={styles.inputDescription}>
+                      {selectedVersion.workflow_definition?.steps.length
+                        ? "実行するとプロンプト本文を Step 1 として実行し、その後に追加ステップを順番に走らせます。"
+                        : "実行すると応答をストリーミング表示し、完了後に Run として保存します。"}
+                    </p>
+
+                    <div className={styles.inputActionsTop}>
+                      <button
+                        type="button"
+                        onClick={handleExecuteRun}
+                        disabled={isExecuteDisabled}
+                        className={`${styles.btnLlmRun} ${isExecuteDisabled ? styles.btnLlmRunDisabled : ""}`}
+                      >
+                        {executeRunMutation.isPending ? "実行中..." : "実行"}
+                      </button>
+                      {executeError && <p className={styles.errorMsgTop}>{executeError}</p>}
+                    </div>
+
+                    <textarea
+                      value={llmResponse}
+                      onChange={(e) => setLlmResponse(e.target.value)}
+                      placeholder="実行結果がここに表示されます。手動入力して保存することもできます。"
+                      className={styles.responseTextarea}
+                      readOnly={executeRunMutation.isPending}
+                    />
+
+                    {executionTrace.length > 0 && (
+                      <div className={styles.traceBlock}>
+                        <h4 className={styles.traceBlockTitle}>ステップ実行結果</h4>
+                        <ExecutionTraceView
+                          trace={executionTrace}
+                          streamingStepId={streamingStepId}
+                        />
+                      </div>
+                    )}
+
+                    <div className={styles.inputActions}>
+                      <button
+                        type="button"
+                        onClick={handleSaveRun}
+                        disabled={isSaveDisabled}
+                        className={`${styles.btnSave} ${isSaveDisabled ? styles.btnSaveDisabled : ""}`}
+                      >
+                        {createRunMutation.isPending ? "保存中..." : "Run を保存"}
+                      </button>
+                    </div>
+                    {createRunMutation.isError && (
+                      <p className={styles.errorMsg}>
+                        保存に失敗しました。もう一度お試しください。
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Step 3: 保存後の表示 */}
+            {step === "saved" && savedRun && selectedVersion && selectedTestCase && (
+              <div>
+                <div className={styles.successBanner}>Run を保存しました（ID: {savedRun.id}）</div>
+
+                <div className={styles.savedActions}>
+                  <button type="button" onClick={handleNewRun} className={styles.btnPrimary}>
+                    新しい Run を作成
+                  </button>
+                </div>
+
+                {/* 保存したRunの内容 */}
+                <div className={styles.savedPanel}>
+                  <h3 className={styles.panelTitle}>保存した Run の内容</h3>
+                  <p className={styles.savedMeta}>
+                    v{selectedVersion.version}
+                    {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
+                    {selectedTestCase.title} · {formatDate(savedRun.created_at)}
+                  </p>
+                  <div className={`${styles.chatList} ${styles.chatListStatic}`}>
+                    {savedRun.conversation.map((msg, index) => (
+                      <div
+                        key={`msg-${
+                          // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理するため index をキーとして使用
+                          index
+                        }`}
+                        className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
+                      >
+                        <span className={styles.bubbleRole}>
+                          {msg.role === "user" ? "User" : "Assistant"}
+                        </span>
+                        <div
+                          className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
+                        >
+                          {msg.content}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {savedRun.execution_trace?.length ? (
+                    <div className={styles.traceBlock}>
+                      <h4 className={styles.traceBlockTitle}>保存されたステップ結果</h4>
+                      <ExecutionTraceView trace={savedRun.execution_trace} />
+                    </div>
+                  ) : null}
+                </div>
+
+                {/* 同一バージョン×ケースの過去Run一覧 */}
+                <div className={styles.savedPanel}>
+                  <h3 className={styles.panelTitle}>過去の Run 一覧</h3>
+                  {relatedRuns.length === 0 ? (
+                    <p className={styles.emptyRuns}>まだ Run がありません。</p>
+                  ) : (
+                    <div className={styles.runList}>
+                      {relatedRuns.map((run) => (
+                        <RunCard
+                          key={run.id}
+                          run={run}
+                          projectId={projectId}
+                          versionLabel={getVersionLabel(run.prompt_version_id)}
+                          versionNumber={getVersionNumber(run.prompt_version_id)}
+                          testCaseLabel={getTestCaseLabel(run.test_case_id)}
+                          onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
+                          isBestPending={setBestMutation.isPending}
+                          onDiscard={() => handleDiscardRun(run)}
+                          isDiscardPending={discardMutation.isPending}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ============ タブ: Run 一覧 ============ */}
+        {activeTab === "list" && (
+          <div>
+            <RunCompareBar
+              compareRunA={compareRunA}
+              compareRunB={compareRunB}
+              getVersionLabel={getVersionLabel}
+              onOpenCompare={() => setIsCompareOpen(true)}
+              onClearFirst={() => setCompareRunA(null)}
+              onClearAll={() => {
+                setCompareRunA(null);
+                setCompareRunB(null);
+              }}
+            />
+
+            {/* フィルターバー */}
+            <div className={styles.filterBar}>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-version" className={styles.filterLabel}>
+                  バージョン
                 </label>
                 <select
-                  id="select-version"
-                  value={selectedVersionId}
+                  id="filter-version"
+                  value={filterVersionId}
                   onChange={(e) =>
-                    setSelectedVersionId(e.target.value === "" ? "" : Number(e.target.value))
+                    setFilterVersionId(e.target.value === "" ? "" : Number(e.target.value))
                   }
-                  className={styles.fieldSelect}
+                  className={styles.filterSelect}
                 >
-                  <option value="">-- 選択してください --</option>
+                  <option value="">すべて</option>
                   {promptVersions.map((v) => (
                     <option key={v.id} value={v.id}>
                       v{v.version}
@@ -683,367 +975,83 @@ export function RunsPage() {
                     </option>
                   ))}
                 </select>
-                {promptVersions.length === 0 && (
-                  <p className={styles.fieldHint}>
-                    プロンプトバージョンがありません。先にバージョンを作成してください。
-                  </p>
-                )}
               </div>
 
-              <div className={styles.fieldGroupLg}>
-                <label htmlFor="select-test-case" className={styles.fieldLabel}>
+              <div className={styles.filterField}>
+                <label htmlFor="filter-test-case" className={styles.filterLabel}>
                   テストケース
                 </label>
                 <select
-                  id="select-test-case"
-                  value={selectedTestCaseId}
+                  id="filter-test-case"
+                  value={filterTestCaseId}
                   onChange={(e) =>
-                    setSelectedTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
+                    setFilterTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
                   }
-                  className={styles.fieldSelect}
+                  className={styles.filterSelect}
                 >
-                  <option value="">-- 選択してください --</option>
+                  <option value="">すべて</option>
                   {testCases.map((tc) => (
                     <option key={tc.id} value={tc.id}>
                       {tc.title}
                     </option>
                   ))}
                 </select>
-                {testCases.length === 0 && (
-                  <p className={styles.fieldHint}>
-                    テストケースがありません。先にテストケースを作成してください。
-                  </p>
-                )}
               </div>
 
               <button
                 type="button"
-                onClick={handleStartRun}
-                disabled={isStartDisabled}
-                title={!hasApiKey ? "APIキーが未設定です（設定画面で入力してください）" : undefined}
-                className={`${styles.btnStart} ${isStartDisabled ? styles.btnStartDisabled : ""}`}
+                onClick={() => {
+                  setFilterVersionId("");
+                  setFilterTestCaseId("");
+                }}
+                className={styles.btnClearFilter}
               >
-                Run の取得
+                クリア
               </button>
-              {!hasApiKey && (
-                <p className={styles.fieldHint}>
-                  APIキーが未設定です。
-                  <Link to={`/projects/${projectId}/settings`} className={styles.settingsLink}>
-                    設定画面
-                  </Link>
-                  で入力してください。
-                </p>
-              )}
             </div>
-          )}
 
-          {/* Step 2: Run 実行UI */}
-          {step === "input" && selectedVersion && selectedTestCase && (
-            <div>
-              <div className={styles.stepHeader}>
-                <button
-                  type="button"
-                  onClick={() => setStep("select")}
-                  className={styles.btnSecondary}
-                >
-                  ← 戻る
-                </button>
-                <span className={styles.stepLabel}>
-                  v{selectedVersion.version}
-                  {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
-                  {selectedTestCase.title}
-                </span>
-              </div>
-
-              <CopyPromptPanel version={selectedVersion} testCase={selectedTestCase} />
-
-              <div className={styles.twoColumns}>
-                {/* 左カラム: テストケース表示 */}
-                <div className={styles.panel}>
-                  <h3 className={styles.panelTitle}>テストケース: {selectedTestCase.title}</h3>
-
-                  {/* 会話ターン表示 */}
-                  <div className={styles.chatList}>
-                    {selectedTestCase.turns.map((turn, index) => (
-                      <div
-                        key={`turn-${
-                          // biome-ignore lint/suspicious/noArrayIndexKey: ターン配列は順序で管理するため index をキーとして使用
-                          index
-                        }`}
-                        className={`${styles.bubbleWrapper} ${turn.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                      >
-                        <span className={styles.bubbleRole}>
-                          {turn.role === "user" ? "User" : "Assistant"}
-                        </span>
-                        <div
-                          className={`${styles.bubble} ${turn.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                        >
-                          {turn.content}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {selectedTestCase.context_content && (
-                    <div className={styles.expectedBox}>
-                      <p className={styles.expectedLabel}>コンテキスト</p>
-                      <p className={styles.expectedText}>{selectedTestCase.context_content}</p>
-                    </div>
-                  )}
-
-                  {/* 期待される説明 */}
-                  {selectedTestCase.expected_description && (
-                    <div className={styles.expectedBox}>
-                      <p className={styles.expectedLabel}>期待される応答の説明</p>
-                      <p className={styles.expectedText}>{selectedTestCase.expected_description}</p>
-                    </div>
-                  )}
-                </div>
-
-                {/* 右カラム: LLM実行・手動入力エリア */}
-                <div className={`${styles.panel} ${styles.panelFlex}`}>
-                  <h3 className={styles.panelSubtitle}>LLM 応答</h3>
-                  <p className={styles.inputDescription}>
-                    {selectedVersion.workflow_definition?.steps.length
-                      ? "実行するとプロンプト本文を Step 1 として実行し、その後に追加ステップを順番に走らせます。"
-                      : "実行すると応答をストリーミング表示し、完了後に Run として保存します。"}
-                  </p>
-
-                  <div className={styles.inputActionsTop}>
-                    <button
-                      type="button"
-                      onClick={handleExecuteRun}
-                      disabled={isExecuteDisabled}
-                      className={`${styles.btnLlmRun} ${isExecuteDisabled ? styles.btnLlmRunDisabled : ""}`}
-                    >
-                      {executeRunMutation.isPending ? "実行中..." : "実行"}
-                    </button>
-                    {executeError && <p className={styles.errorMsgTop}>{executeError}</p>}
-                  </div>
-
-                  <textarea
-                    value={llmResponse}
-                    onChange={(e) => setLlmResponse(e.target.value)}
-                    placeholder="実行結果がここに表示されます。手動入力して保存することもできます。"
-                    className={styles.responseTextarea}
-                    readOnly={executeRunMutation.isPending}
+            {/* Run 一覧 */}
+            {isRunsLoading ? (
+              <p className={styles.loadingMsg}>読み込み中...</p>
+            ) : allRuns.length === 0 ? (
+              <p className={styles.emptyRuns}>
+                {filterVersionId !== "" || filterTestCaseId !== ""
+                  ? "条件に一致する Run がありません。"
+                  : "まだ Run がありません。「Run を作成」タブから実行してください。"}
+              </p>
+            ) : (
+              <div className={styles.runList}>
+                {allRuns.map((run) => (
+                  <RunCard
+                    key={run.id}
+                    run={run}
+                    projectId={projectId}
+                    versionLabel={getVersionLabel(run.prompt_version_id)}
+                    versionNumber={getVersionNumber(run.prompt_version_id)}
+                    testCaseLabel={getTestCaseLabel(run.test_case_id)}
+                    onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
+                    isBestPending={setBestMutation.isPending}
+                    onDiscard={() => handleDiscardRun(run)}
+                    isDiscardPending={discardMutation.isPending}
+                    onCompare={() => handleCompareRun(run)}
+                    isCompareSelected={compareRunA?.id === run.id || compareRunB?.id === run.id}
                   />
-
-                  {executionTrace.length > 0 && (
-                    <div className={styles.traceBlock}>
-                      <h4 className={styles.traceBlockTitle}>ステップ実行結果</h4>
-                      <ExecutionTraceView trace={executionTrace} streamingStepId={streamingStepId} />
-                    </div>
-                  )}
-
-                  <div className={styles.inputActions}>
-                    <button
-                      type="button"
-                      onClick={handleSaveRun}
-                      disabled={isSaveDisabled}
-                      className={`${styles.btnSave} ${isSaveDisabled ? styles.btnSaveDisabled : ""}`}
-                    >
-                      {createRunMutation.isPending ? "保存中..." : "Run を保存"}
-                    </button>
-                  </div>
-                  {createRunMutation.isError && (
-                    <p className={styles.errorMsg}>保存に失敗しました。もう一度お試しください。</p>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Step 3: 保存後の表示 */}
-          {step === "saved" && savedRun && selectedVersion && selectedTestCase && (
-            <div>
-              <div className={styles.successBanner}>Run を保存しました（ID: {savedRun.id}）</div>
-
-              <div className={styles.savedActions}>
-                <button type="button" onClick={handleNewRun} className={styles.btnPrimary}>
-                  新しい Run を作成
-                </button>
-              </div>
-
-              {/* 保存したRunの内容 */}
-              <div className={styles.savedPanel}>
-                <h3 className={styles.panelTitle}>保存した Run の内容</h3>
-                <p className={styles.savedMeta}>
-                  v{selectedVersion.version}
-                  {selectedVersion.name ? ` - ${selectedVersion.name}` : ""} ×{" "}
-                  {selectedTestCase.title} · {formatDate(savedRun.created_at)}
-                </p>
-                <div className={`${styles.chatList} ${styles.chatListStatic}`}>
-                  {savedRun.conversation.map((msg, index) => (
-                    <div
-                      key={`msg-${
-                        // biome-ignore lint/suspicious/noArrayIndexKey: 会話配列は順序で管理するため index をキーとして使用
-                        index
-                      }`}
-                      className={`${styles.bubbleWrapper} ${msg.role === "user" ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant}`}
-                    >
-                      <span className={styles.bubbleRole}>
-                        {msg.role === "user" ? "User" : "Assistant"}
-                      </span>
-                      <div
-                        className={`${styles.bubble} ${msg.role === "user" ? styles.bubbleUser : styles.bubbleAssistant}`}
-                      >
-                        {msg.content}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-                {savedRun.execution_trace?.length ? (
-                  <div className={styles.traceBlock}>
-                    <h4 className={styles.traceBlockTitle}>保存されたステップ結果</h4>
-                    <ExecutionTraceView trace={savedRun.execution_trace} />
-                  </div>
-                ) : null}
-              </div>
-
-              {/* 同一バージョン×ケースの過去Run一覧 */}
-              <div className={styles.savedPanel}>
-                <h3 className={styles.panelTitle}>過去の Run 一覧</h3>
-                {relatedRuns.length === 0 ? (
-                  <p className={styles.emptyRuns}>まだ Run がありません。</p>
-                ) : (
-                  <div className={styles.runList}>
-                    {relatedRuns.map((run) => (
-                      <RunCard
-                        key={run.id}
-                        run={run}
-                        projectId={projectId}
-                        versionLabel={getVersionLabel(run.prompt_version_id)}
-                        versionNumber={getVersionNumber(run.prompt_version_id)}
-                        testCaseLabel={getTestCaseLabel(run.test_case_id)}
-                        onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
-                        isBestPending={setBestMutation.isPending}
-                        onDiscard={() => handleDiscardRun(run)}
-                        isDiscardPending={discardMutation.isPending}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-          </div>
-        )}
-
-        {/* ============ タブ: Run 一覧 ============ */}
-        {activeTab === "list" && (
-          <div>
-          <RunCompareBar
-            compareRunA={compareRunA}
-            compareRunB={compareRunB}
-            getVersionLabel={getVersionLabel}
-            onOpenCompare={() => setIsCompareOpen(true)}
-            onClearFirst={() => setCompareRunA(null)}
-            onClearAll={() => {
-              setCompareRunA(null);
-              setCompareRunB(null);
-            }}
-          />
-
-          {/* フィルターバー */}
-          <div className={styles.filterBar}>
-            <div className={styles.filterField}>
-              <label htmlFor="filter-version" className={styles.filterLabel}>
-                バージョン
-              </label>
-              <select
-                id="filter-version"
-                value={filterVersionId}
-                onChange={(e) =>
-                  setFilterVersionId(e.target.value === "" ? "" : Number(e.target.value))
-                }
-                className={styles.filterSelect}
-              >
-                <option value="">すべて</option>
-                {promptVersions.map((v) => (
-                  <option key={v.id} value={v.id}>
-                    v{v.version}
-                    {v.name ? ` - ${v.name}` : ""}
-                  </option>
                 ))}
-              </select>
-            </div>
+              </div>
+            )}
 
-            <div className={styles.filterField}>
-              <label htmlFor="filter-test-case" className={styles.filterLabel}>
-                テストケース
-              </label>
-              <select
-                id="filter-test-case"
-                value={filterTestCaseId}
-                onChange={(e) =>
-                  setFilterTestCaseId(e.target.value === "" ? "" : Number(e.target.value))
-                }
-                className={styles.filterSelect}
-              >
-                <option value="">すべて</option>
-                {testCases.map((tc) => (
-                  <option key={tc.id} value={tc.id}>
-                    {tc.title}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <button
-              type="button"
-              onClick={() => {
-                setFilterVersionId("");
-                setFilterTestCaseId("");
+            <RunCompareBar
+              compareRunA={compareRunA}
+              compareRunB={compareRunB}
+              getVersionLabel={getVersionLabel}
+              onOpenCompare={() => setIsCompareOpen(true)}
+              onClearFirst={() => setCompareRunA(null)}
+              onClearAll={() => {
+                setCompareRunA(null);
+                setCompareRunB(null);
               }}
-              className={styles.btnClearFilter}
-            >
-              クリア
-            </button>
-          </div>
-
-          {/* Run 一覧 */}
-          {isRunsLoading ? (
-            <p className={styles.loadingMsg}>読み込み中...</p>
-          ) : allRuns.length === 0 ? (
-            <p className={styles.emptyRuns}>
-              {filterVersionId !== "" || filterTestCaseId !== ""
-                ? "条件に一致する Run がありません。"
-                : "まだ Run がありません。「Run を作成」タブから実行してください。"}
-            </p>
-          ) : (
-            <div className={styles.runList}>
-              {allRuns.map((run) => (
-                <RunCard
-                  key={run.id}
-                  run={run}
-                  projectId={projectId}
-                  versionLabel={getVersionLabel(run.prompt_version_id)}
-                  versionNumber={getVersionNumber(run.prompt_version_id)}
-                  testCaseLabel={getTestCaseLabel(run.test_case_id)}
-                  onSetBest={(unset) => setBestMutation.mutate({ id: run.id, unset })}
-                  isBestPending={setBestMutation.isPending}
-                  onDiscard={() => handleDiscardRun(run)}
-                  isDiscardPending={discardMutation.isPending}
-                  onCompare={() => handleCompareRun(run)}
-                  isCompareSelected={compareRunA?.id === run.id || compareRunB?.id === run.id}
-                />
-              ))}
-            </div>
-          )}
-
-          <RunCompareBar
-            compareRunA={compareRunA}
-            compareRunB={compareRunB}
-            getVersionLabel={getVersionLabel}
-            onOpenCompare={() => setIsCompareOpen(true)}
-            onClearFirst={() => setCompareRunA(null)}
-            onClearAll={() => {
-              setCompareRunA(null);
-              setCompareRunB(null);
-            }}
-            className={styles.compareBarBottom}
-          />
+              className={styles.compareBarBottom}
+            />
           </div>
         )}
       </div>

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -2,12 +2,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import {
-  getContextFile,
-  getContextFiles,
   type TestCase,
   type Turn,
   createTestCase,
   deleteTestCase,
+  getContextFile,
+  getContextFiles,
   getTestCases,
   updateTestCase,
 } from "../lib/api";
@@ -161,9 +161,7 @@ type TestCaseModalProps = {
 };
 
 function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: TestCaseModalProps) {
-  const [formData, setFormData] = useState<TestCaseFormData>(() =>
-    getInitialFormData(testCase),
-  );
+  const [formData, setFormData] = useState<TestCaseFormData>(() => getInitialFormData(testCase));
   const [selectedContextFilePath, setSelectedContextFilePath] = useState("");
   const [importNotice, setImportNotice] = useState<string | null>(null);
   const isEdit = !!testCase;
@@ -254,7 +252,9 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
                     setImportNotice(null);
                     setSelectedContextFilePath(e.target.value);
                   }}
-                  disabled={(contextFilesQuery.data?.length ?? 0) === 0 || importContextMutation.isPending}
+                  disabled={
+                    (contextFilesQuery.data?.length ?? 0) === 0 || importContextMutation.isPending
+                  }
                   className={styles.contextFileSelect}
                 >
                   {(contextFilesQuery.data?.length ?? 0) === 0 ? (
@@ -283,10 +283,14 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
                 コンテキスト管理で取り込んだファイルをここへコピーします。取り込み後に編集して保存できます。
               </p>
               {contextFilesQuery.isError && (
-                <p className={styles.contextImportError}>コンテキストファイル一覧の取得に失敗しました。</p>
+                <p className={styles.contextImportError}>
+                  コンテキストファイル一覧の取得に失敗しました。
+                </p>
               )}
               {importContextMutation.isError && (
-                <p className={styles.contextImportError}>選択したコンテキストファイルの取り込みに失敗しました。</p>
+                <p className={styles.contextImportError}>
+                  選択したコンテキストファイルの取り込みに失敗しました。
+                </p>
               )}
               {importNotice && <p className={styles.contextImportNotice}>{importNotice}</p>}
             </div>
@@ -406,18 +410,10 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
       <div className={styles.cardHeader}>
         <h3 className={styles.cardTitle}>{testCase.title}</h3>
         <div className={styles.cardActions}>
-          <button
-            type="button"
-            onClick={() => onEdit(testCase)}
-            className={styles.btnCardEdit}
-          >
+          <button type="button" onClick={() => onEdit(testCase)} className={styles.btnCardEdit}>
             編集
           </button>
-          <button
-            type="button"
-            onClick={() => onDelete(testCase)}
-            className={styles.btnCardDelete}
-          >
+          <button type="button" onClick={() => onDelete(testCase)} className={styles.btnCardDelete}>
             削除
           </button>
         </div>
@@ -515,11 +511,7 @@ export function TestCasesPage() {
     <div className={styles.root}>
       <div className={styles.pageHeader}>
         <h2 className={styles.pageTitle}>テストケース管理</h2>
-        <button
-          type="button"
-          onClick={() => setIsCreateOpen(true)}
-          className={styles.btnPrimary}
-        >
+        <button type="button" onClick={() => setIsCreateOpen(true)} className={styles.btnPrimary}>
           + 新規作成
         </button>
       </div>
@@ -528,9 +520,7 @@ export function TestCasesPage() {
         プロジェクトのテストケース一覧です。会話ターン、コンテキスト、期待記述をまとめて管理します。
       </p>
 
-      {isLoading && (
-        <p className={`${styles.statusText} ${styles.loading}`}>読み込み中...</p>
-      )}
+      {isLoading && <p className={`${styles.statusText} ${styles.loading}`}>読み込み中...</p>}
 
       {isError && (
         <p className={`${styles.statusText} ${styles.error}`}>


### PR DESCRIPTION
## Summary

- `.gitattributes` を追加し、Windowsチェックアウト時もLFで統一（`* text=auto eol=lf`）
- `biome.json` の `files.ignore` に `worktrees/**` を追加（worktree内ファイルをスキャン対象外に）
- 既存ファイルのCRLF→LF変換
- 発見された既存のformat/lintエラーも合わせて修正

## Test plan

- [x] `pnpm run check` がエラーなく通過することを確認
- [x] `pnpm run typecheck` がエラーなく通過することを確認

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)