### PR TITLE
Issue #108 既存データ移行スクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ pnpm migrate:local
 > pnpm --filter @prompt-reviewer/core seed
 > ```
 
+### 既存データの新スキーマ移行
+
+Issue #108 対応として、旧 `project_settings` / `prompt_versions.project_id` / `test_cases.project_id` と
+`data/context-files/<projectId>/...` を新ドメインモデルへ移すスクリプトを追加しています。
+
+```bash
+pnpm --filter @prompt-reviewer/core migrate:domain-model -- ../../dev.db ../../data/context-files
+```
+
+- 第1引数は移行対象 DB のパスです。省略時は `../../dev.db` を使います
+- 第2引数は旧 `context-files` ディレクトリです。省略時は `../../data/context-files` を使います
+- 既存 `projects` はそのまま分類ラベルとして流用します
+- `prompt_versions` は project ごとに 1 つの `prompt_family` へ束ねます
+- `project_settings` は project ごとの既定 `execution_profile` に変換します
+- 既存 Run の設定スナップショットが `project_settings` と一致しない場合は、Run の実値から追加の `execution_profile` を作って `execution_profile_id` を補完します
+- `context-files` は project ごとの `path` をキーとして `context_assets` へ upsert します。同じ project / path で再実行した場合は重複作成せず内容を更新します
+
 ### 開発サーバーの起動
 
 ```bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "build:watch": "tsc --watch --preserveWatchOutput",
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",
+    "migrate:domain-model": "node ./scripts/migrate-domain-model.mjs",
     "seed": "tsx src/seed.ts"
   },
   "dependencies": {

--- a/packages/core/scripts/migrate-domain-model.mjs
+++ b/packages/core/scripts/migrate-domain-model.mjs
@@ -1,0 +1,516 @@
+import { createHash } from "node:crypto";
+import { access, readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+
+const DEFAULT_DB_PATH = "../../dev.db";
+const DEFAULT_CONTEXT_FILES_DIR = "../../data/context-files";
+
+const textMimeTypes = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".md": "text/markdown",
+  ".py": "text/x-python",
+  ".sql": "application/sql",
+  ".ts": "text/typescript",
+  ".tsx": "text/tsx",
+  ".txt": "text/plain",
+  ".xml": "application/xml",
+  ".yaml": "application/yaml",
+  ".yml": "application/yaml",
+};
+
+function resolveTargetPath(targetPath, fallbackPath) {
+  return path.resolve(process.cwd(), targetPath ?? fallbackPath);
+}
+
+function toTimestamp(value) {
+  return Math.round(value);
+}
+
+function inferMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return textMimeTypes[ext] ?? "text/plain";
+}
+
+function buildContentHash(content) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function buildProjectFamilyMarker(projectId) {
+  return `[migration] prompt_family project_id=${projectId}`;
+}
+
+function buildProjectSettingsProfileMarker(projectId) {
+  return `[migration] execution_profile project_settings project_id=${projectId}`;
+}
+
+function buildRunSnapshotProfileMarker(projectId, model, temperature, apiProvider) {
+  return (
+    `[migration] execution_profile run_snapshot project_id=${projectId}` +
+    ` model=${model} temperature=${temperature} api_provider=${apiProvider}`
+  );
+}
+
+function buildPromptFamilyName(projectName, projectId) {
+  return projectName ? `${projectName} migrated family` : `Project ${projectId} migrated family`;
+}
+
+function buildExecutionProfileName(projectName, projectId, model) {
+  if (projectName) {
+    return `${projectName} migrated profile (${model})`;
+  }
+
+  return `Project ${projectId} migrated profile (${model})`;
+}
+
+function loadProjects(sqlite) {
+  const rows = sqlite.prepare("SELECT id, name FROM projects").all();
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+async function collectContextFiles(contextFilesDir) {
+  try {
+    await access(contextFilesDir);
+  } catch {
+    return [];
+  }
+
+  const projectEntries = await readdir(contextFilesDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const projectId = Number(entry.name);
+    if (!Number.isInteger(projectId)) {
+      continue;
+    }
+
+    const projectRoot = path.join(contextFilesDir, entry.name);
+    const nestedFiles = await collectProjectFiles(projectRoot, projectId, projectRoot);
+    files.push(...nestedFiles);
+  }
+
+  return files.sort((a, b) => {
+    if (a.projectId !== b.projectId) {
+      return a.projectId - b.projectId;
+    }
+
+    return a.relativePath.localeCompare(b.relativePath, "ja");
+  });
+}
+
+async function collectProjectFiles(projectRoot, projectId, currentDir) {
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      const nestedFiles = await collectProjectFiles(projectRoot, projectId, fullPath);
+      files.push(...nestedFiles);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const [content, fileStat] = await Promise.all([readFile(fullPath, "utf8"), stat(fullPath)]);
+    const relativePath = path.relative(projectRoot, fullPath).replace(/\\/g, "/");
+    const timestamp = toTimestamp(fileStat.mtimeMs);
+
+    files.push({
+      projectId,
+      name: path.basename(fullPath),
+      relativePath,
+      mimeType: inferMimeType(fullPath),
+      content,
+      contentHash: buildContentHash(content),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+  }
+
+  return files;
+}
+
+function ensurePromptFamilies(sqlite, projects, stats) {
+  const promptVersionsByProject = sqlite
+    .prepare(
+      `
+        SELECT project_id, MIN(created_at) AS created_at
+        FROM prompt_versions
+        GROUP BY project_id
+      `,
+    )
+    .all();
+
+  const findFamilyByMarker = sqlite.prepare(
+    "SELECT id FROM prompt_families WHERE description = ? LIMIT 1",
+  );
+  const updateFamily = sqlite.prepare(
+    "UPDATE prompt_families SET name = ?, updated_at = ? WHERE id = ?",
+  );
+  const insertFamily = sqlite.prepare(
+    `
+      INSERT INTO prompt_families (name, description, created_at, updated_at)
+      VALUES (?, ?, ?, ?)
+    `,
+  );
+  const assignFamily = sqlite.prepare(
+    `
+      UPDATE prompt_versions
+      SET prompt_family_id = ?
+      WHERE project_id = ? AND prompt_family_id IS NULL
+    `,
+  );
+
+  for (const row of promptVersionsByProject) {
+    const projectId = row.project_id;
+    const project = projects.get(projectId);
+    const marker = buildProjectFamilyMarker(projectId);
+    const familyName = buildPromptFamilyName(project?.name ?? null, projectId);
+    const existing = findFamilyByMarker.get(marker);
+
+    let familyId;
+    if (existing) {
+      familyId = existing.id;
+      updateFamily.run(familyName, row.created_at, familyId);
+    } else {
+      familyId = Number(
+        insertFamily.run(familyName, marker, row.created_at, row.created_at).lastInsertRowid,
+      );
+      stats.createdPromptFamilies += 1;
+    }
+
+    stats.linkedPromptVersionsToFamilies += assignFamily.run(familyId, projectId).changes;
+  }
+}
+
+function ensureProjectLabelLinks(sqlite, stats) {
+  stats.createdPromptVersionLabels += sqlite
+    .prepare(
+      `
+        INSERT OR IGNORE INTO prompt_version_projects (prompt_version_id, project_id, created_at)
+        SELECT id, project_id, created_at
+        FROM prompt_versions
+      `,
+    )
+    .run().changes;
+
+  stats.createdTestCaseLabels += sqlite
+    .prepare(
+      `
+        INSERT OR IGNORE INTO test_case_projects (test_case_id, project_id, created_at)
+        SELECT id, project_id, created_at
+        FROM test_cases
+      `,
+    )
+    .run().changes;
+}
+
+function ensureExecutionProfiles(sqlite, projects, stats) {
+  const projectSettingsRows = sqlite
+    .prepare(
+      `
+        SELECT id, project_id, model, temperature, api_provider, created_at, updated_at
+        FROM project_settings
+        ORDER BY project_id ASC, id ASC
+      `,
+    )
+    .all();
+
+  const findProfileByMarker = sqlite.prepare(
+    "SELECT id FROM execution_profiles WHERE description = ? LIMIT 1",
+  );
+  const updateProfile = sqlite.prepare(
+    `
+      UPDATE execution_profiles
+      SET name = ?, model = ?, temperature = ?, api_provider = ?, updated_at = ?
+      WHERE id = ?
+    `,
+  );
+  const insertProfile = sqlite.prepare(
+    `
+      INSERT INTO execution_profiles (
+        name, description, model, temperature, api_provider, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+  );
+
+  const profileByProjectId = new Map();
+  const settingsByProjectId = new Map();
+
+  for (const row of projectSettingsRows) {
+    const project = projects.get(row.project_id);
+    const marker = buildProjectSettingsProfileMarker(row.project_id);
+    const profileName = buildExecutionProfileName(project?.name ?? null, row.project_id, row.model);
+    const existing = findProfileByMarker.get(marker);
+
+    let profileId;
+    if (existing) {
+      profileId = existing.id;
+      updateProfile.run(
+        profileName,
+        row.model,
+        row.temperature,
+        row.api_provider,
+        row.updated_at,
+        profileId,
+      );
+    } else {
+      profileId = Number(
+        insertProfile.run(
+          profileName,
+          marker,
+          row.model,
+          row.temperature,
+          row.api_provider,
+          row.created_at,
+          row.updated_at,
+        ).lastInsertRowid,
+      );
+      stats.createdExecutionProfiles += 1;
+    }
+
+    profileByProjectId.set(row.project_id, profileId);
+    settingsByProjectId.set(row.project_id, row);
+  }
+
+  const distinctRunSnapshots = sqlite
+    .prepare(
+      `
+        SELECT project_id, model, temperature, api_provider, MIN(created_at) AS created_at
+        FROM runs
+        WHERE execution_profile_id IS NULL
+        GROUP BY project_id, model, temperature, api_provider
+      `,
+    )
+    .all();
+
+  const updateRuns = sqlite.prepare(
+    `
+      UPDATE runs
+      SET execution_profile_id = ?
+      WHERE execution_profile_id IS NULL
+        AND project_id = ?
+        AND model = ?
+        AND temperature = ?
+        AND api_provider = ?
+    `,
+  );
+
+  for (const row of distinctRunSnapshots) {
+    const settings = settingsByProjectId.get(row.project_id);
+    const matchesProjectSettings =
+      settings !== undefined &&
+      settings.model === row.model &&
+      settings.temperature === row.temperature &&
+      settings.api_provider === row.api_provider;
+
+    let profileId = matchesProjectSettings ? profileByProjectId.get(row.project_id) : undefined;
+
+    if (profileId === undefined) {
+      const project = projects.get(row.project_id);
+      const marker = buildRunSnapshotProfileMarker(
+        row.project_id,
+        row.model,
+        row.temperature,
+        row.api_provider,
+      );
+      const profileName = buildExecutionProfileName(
+        project?.name ?? null,
+        row.project_id,
+        row.model,
+      );
+      const existing = findProfileByMarker.get(marker);
+
+      if (existing) {
+        profileId = existing.id;
+        updateProfile.run(
+          profileName,
+          row.model,
+          row.temperature,
+          row.api_provider,
+          row.created_at,
+          profileId,
+        );
+      } else {
+        profileId = Number(
+          insertProfile.run(
+            profileName,
+            marker,
+            row.model,
+            row.temperature,
+            row.api_provider,
+            row.created_at,
+            row.created_at,
+          ).lastInsertRowid,
+        );
+        stats.createdExecutionProfiles += 1;
+      }
+    }
+
+    stats.assignedRunExecutionProfiles += updateRuns.run(
+      profileId,
+      row.project_id,
+      row.model,
+      row.temperature,
+      row.api_provider,
+    ).changes;
+  }
+}
+
+function upsertContextAssets(sqlite, files, stats) {
+  const findAssetByProjectAndPath = sqlite.prepare(
+    `
+      SELECT ca.id, ca.content_hash
+      FROM context_assets AS ca
+      INNER JOIN context_asset_projects AS cap
+        ON cap.context_asset_id = ca.id
+      WHERE cap.project_id = ? AND ca.path = ?
+      ORDER BY ca.id ASC
+      LIMIT 1
+    `,
+  );
+  const insertAsset = sqlite.prepare(
+    `
+      INSERT INTO context_assets (
+        name, path, content, mime_type, content_hash, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+  );
+  const updateAsset = sqlite.prepare(
+    `
+      UPDATE context_assets
+      SET name = ?, content = ?, mime_type = ?, content_hash = ?, updated_at = ?
+      WHERE id = ?
+    `,
+  );
+  const linkAsset = sqlite.prepare(
+    `
+      INSERT OR IGNORE INTO context_asset_projects (context_asset_id, project_id, created_at)
+      VALUES (?, ?, ?)
+    `,
+  );
+
+  for (const file of files) {
+    const existing = findAssetByProjectAndPath.get(file.projectId, file.relativePath);
+
+    if (existing) {
+      if (existing.content_hash !== file.contentHash) {
+        stats.updatedContextAssets += updateAsset.run(
+          file.name,
+          file.content,
+          file.mimeType,
+          file.contentHash,
+          file.updatedAt,
+          existing.id,
+        ).changes;
+      }
+
+      linkAsset.run(existing.id, file.projectId, file.createdAt);
+      continue;
+    }
+
+    const assetId = Number(
+      insertAsset.run(
+        file.name,
+        file.relativePath,
+        file.content,
+        file.mimeType,
+        file.contentHash,
+        file.createdAt,
+        file.updatedAt,
+      ).lastInsertRowid,
+    );
+
+    linkAsset.run(assetId, file.projectId, file.createdAt);
+    stats.createdContextAssets += 1;
+    stats.createdContextAssetLabels += 1;
+  }
+}
+
+export async function migrateDomainModelData(options = {}) {
+  const dbPath = resolveTargetPath(options.dbPath, DEFAULT_DB_PATH);
+  const contextFilesDir = resolveTargetPath(options.contextFilesDir, DEFAULT_CONTEXT_FILES_DIR);
+  const logger = options.logger ?? console;
+  const contextFiles = await collectContextFiles(contextFilesDir);
+  const sqlite = new Database(dbPath);
+
+  const stats = {
+    createdPromptFamilies: 0,
+    linkedPromptVersionsToFamilies: 0,
+    createdPromptVersionLabels: 0,
+    createdTestCaseLabels: 0,
+    createdExecutionProfiles: 0,
+    assignedRunExecutionProfiles: 0,
+    createdContextAssets: 0,
+    updatedContextAssets: 0,
+    createdContextAssetLabels: 0,
+  };
+
+  try {
+    sqlite.pragma("foreign_keys = ON");
+
+    const transaction = sqlite.transaction(() => {
+      const projects = loadProjects(sqlite);
+      ensurePromptFamilies(sqlite, projects, stats);
+      ensureProjectLabelLinks(sqlite, stats);
+      ensureExecutionProfiles(sqlite, projects, stats);
+      upsertContextAssets(sqlite, contextFiles, stats);
+    });
+
+    transaction();
+  } finally {
+    sqlite.close();
+  }
+
+  logger.log(`Migrated domain-model data for ${dbPath}`);
+  logger.log(`Context files source: ${contextFilesDir}`);
+  logger.log(
+    [
+      `prompt_families created=${stats.createdPromptFamilies}`,
+      `prompt_versions linked=${stats.linkedPromptVersionsToFamilies}`,
+      `prompt_version_projects inserted=${stats.createdPromptVersionLabels}`,
+      `test_case_projects inserted=${stats.createdTestCaseLabels}`,
+      `execution_profiles created=${stats.createdExecutionProfiles}`,
+      `runs assigned=${stats.assignedRunExecutionProfiles}`,
+      `context_assets created=${stats.createdContextAssets}`,
+      `context_assets updated=${stats.updatedContextAssets}`,
+      `context_asset_projects inserted=${stats.createdContextAssetLabels}`,
+    ].join(", "),
+  );
+
+  return {
+    dbPath,
+    contextFilesDir,
+    stats,
+  };
+}
+
+async function main() {
+  const dbPathArg = process.argv[2];
+  const contextFilesDirArg = process.argv[3];
+  await migrateDomainModelData({
+    dbPath: dbPathArg,
+    contextFilesDir: contextFilesDirArg,
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error("Failed to migrate domain-model data:");
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/core/src/migrations/domain-model-migration.test.ts
+++ b/packages/core/src/migrations/domain-model-migration.test.ts
@@ -1,0 +1,441 @@
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+const cleanupTargets: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupTargets.splice(0).map((target) => rm(target, { recursive: true, force: true })),
+  );
+});
+
+function createSchema(db: Database.Database) {
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE projects (
+      id integer PRIMARY KEY,
+      name text NOT NULL,
+      description text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE project_settings (
+      id integer PRIMARY KEY,
+      project_id integer NOT NULL REFERENCES projects(id),
+      model text NOT NULL,
+      temperature real NOT NULL,
+      api_provider text NOT NULL,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE prompt_families (
+      id integer PRIMARY KEY AUTOINCREMENT,
+      name text,
+      description text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE execution_profiles (
+      id integer PRIMARY KEY AUTOINCREMENT,
+      name text NOT NULL,
+      description text,
+      model text NOT NULL,
+      temperature real NOT NULL,
+      api_provider text NOT NULL,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE context_assets (
+      id integer PRIMARY KEY AUTOINCREMENT,
+      name text NOT NULL,
+      path text NOT NULL,
+      content text NOT NULL,
+      mime_type text NOT NULL,
+      content_hash text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE test_cases (
+      id integer PRIMARY KEY,
+      project_id integer NOT NULL REFERENCES projects(id),
+      title text NOT NULL,
+      turns text NOT NULL,
+      context_content text NOT NULL,
+      expected_description text,
+      display_order integer NOT NULL,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    );
+
+    CREATE TABLE prompt_versions (
+      id integer PRIMARY KEY,
+      prompt_family_id integer REFERENCES prompt_families(id),
+      project_id integer NOT NULL REFERENCES projects(id),
+      version integer NOT NULL,
+      name text,
+      memo text,
+      content text NOT NULL,
+      workflow_definition text,
+      parent_version_id integer REFERENCES prompt_versions(id),
+      created_at integer NOT NULL,
+      is_selected integer NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE runs (
+      id integer PRIMARY KEY,
+      execution_profile_id integer REFERENCES execution_profiles(id),
+      project_id integer NOT NULL REFERENCES projects(id),
+      prompt_version_id integer NOT NULL REFERENCES prompt_versions(id),
+      test_case_id integer NOT NULL REFERENCES test_cases(id),
+      conversation text NOT NULL,
+      execution_trace text,
+      is_best integer NOT NULL DEFAULT 0,
+      is_discarded integer NOT NULL DEFAULT 0,
+      created_at integer NOT NULL,
+      model text NOT NULL,
+      temperature real NOT NULL,
+      api_provider text NOT NULL
+    );
+
+    CREATE TABLE prompt_version_projects (
+      prompt_version_id integer NOT NULL REFERENCES prompt_versions(id),
+      project_id integer NOT NULL REFERENCES projects(id),
+      created_at integer NOT NULL,
+      PRIMARY KEY (prompt_version_id, project_id)
+    );
+
+    CREATE TABLE test_case_projects (
+      test_case_id integer NOT NULL REFERENCES test_cases(id),
+      project_id integer NOT NULL REFERENCES projects(id),
+      created_at integer NOT NULL,
+      PRIMARY KEY (test_case_id, project_id)
+    );
+
+    CREATE TABLE context_asset_projects (
+      context_asset_id integer NOT NULL REFERENCES context_assets(id),
+      project_id integer NOT NULL REFERENCES projects(id),
+      created_at integer NOT NULL,
+      PRIMARY KEY (context_asset_id, project_id)
+    );
+  `);
+}
+
+async function createTempFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "prompt-reviewer-domain-model-"));
+  cleanupTargets.push(root);
+
+  const dbPath = path.join(root, "migration.sqlite");
+  const contextFilesDir = path.join(root, "context-files");
+  await mkdir(contextFilesDir, { recursive: true });
+
+  return { root, dbPath, contextFilesDir };
+}
+
+async function loadMigrationScript() {
+  return (await import("../../scripts/migrate-domain-model.mjs")) as unknown as {
+    migrateDomainModelData: (options?: {
+      dbPath?: string;
+      contextFilesDir?: string;
+      logger?: Pick<Console, "log">;
+    }) => Promise<{
+      dbPath: string;
+      contextFilesDir: string;
+      stats: {
+        createdPromptFamilies: number;
+        linkedPromptVersionsToFamilies: number;
+        createdPromptVersionLabels: number;
+        createdTestCaseLabels: number;
+        createdExecutionProfiles: number;
+        assignedRunExecutionProfiles: number;
+        createdContextAssets: number;
+        updatedContextAssets: number;
+        createdContextAssetLabels: number;
+      };
+    }>;
+  };
+}
+
+describe("migrateDomainModelData", () => {
+  it("旧データを新スキーマへ移し替える", async () => {
+    const { migrateDomainModelData } = await loadMigrationScript();
+    const { dbPath, contextFilesDir } = await createTempFixture();
+    const db = new Database(dbPath);
+    createSchema(db);
+
+    db.prepare(
+      `
+        INSERT INTO projects (id, name, description, created_at, updated_at)
+        VALUES
+          (1, 'Support', NULL, 1000, 1000),
+          (2, 'Sales', NULL, 2000, 2000)
+      `,
+    ).run();
+
+    db.prepare(
+      `
+        INSERT INTO project_settings (
+          id, project_id, model, temperature, api_provider, created_at, updated_at
+        )
+        VALUES
+          (1, 1, 'claude-opus-4-5', 0.7, 'anthropic', 1100, 1200)
+      `,
+    ).run();
+
+    db.prepare(
+      `
+        INSERT INTO test_cases (
+          id, project_id, title, turns, context_content, expected_description, display_order, created_at, updated_at
+        )
+        VALUES
+          (10, 1, 'delivery', '[]', '', NULL, 1, 1300, 1400),
+          (20, 2, 'refund', '[]', '', NULL, 1, 2300, 2400)
+      `,
+    ).run();
+
+    db.prepare(
+      `
+        INSERT INTO prompt_versions (
+          id, prompt_family_id, project_id, version, name, memo, content, workflow_definition, parent_version_id, created_at, is_selected
+        )
+        VALUES
+          (100, NULL, 1, 1, 'v1', NULL, 'system 1', NULL, NULL, 1500, 1),
+          (101, NULL, 1, 2, 'v2', NULL, 'system 2', NULL, 100, 1600, 0),
+          (200, NULL, 2, 1, 'sales v1', NULL, 'sales', NULL, NULL, 2500, 1)
+      `,
+    ).run();
+
+    db.prepare(
+      `
+        INSERT INTO runs (
+          id, execution_profile_id, project_id, prompt_version_id, test_case_id, conversation, execution_trace,
+          is_best, is_discarded, created_at, model, temperature, api_provider
+        )
+        VALUES
+          (1000, NULL, 1, 100, 10, '[]', NULL, 1, 0, 1700, 'claude-opus-4-5', 0.7, 'anthropic'),
+          (1001, NULL, 1, 101, 10, '[]', NULL, 0, 0, 1800, 'gpt-5.2', 0.1, 'openai'),
+          (2000, NULL, 2, 200, 20, '[]', NULL, 1, 0, 2600, 'claude-sonnet-4-5', 0.3, 'anthropic')
+      `,
+    ).run();
+    db.close();
+
+    const project1Dir = path.join(contextFilesDir, "1", "docs");
+    const project2Dir = path.join(contextFilesDir, "2");
+    await mkdir(project1Dir, { recursive: true });
+    await mkdir(project2Dir, { recursive: true });
+    await writeFile(path.join(project1Dir, "policy.md"), "# policy", "utf8");
+    await writeFile(path.join(project2Dir, "faq.txt"), "faq", "utf8");
+
+    const result = await migrateDomainModelData({
+      dbPath,
+      contextFilesDir,
+      logger: { log() {} },
+    });
+
+    expect(result.stats.createdPromptFamilies).toBe(2);
+    expect(result.stats.createdExecutionProfiles).toBe(3);
+    expect(result.stats.assignedRunExecutionProfiles).toBe(3);
+    expect(result.stats.createdContextAssets).toBe(2);
+
+    const migrated = new Database(dbPath, { readonly: true });
+    const promptFamilies = migrated
+      .prepare("SELECT id, name, description FROM prompt_families ORDER BY id ASC")
+      .all() as Array<{ id: number; name: string; description: string }>;
+    expect(promptFamilies).toHaveLength(2);
+    expect(promptFamilies[0]?.name).toContain("Support");
+
+    const promptVersionLinks = migrated
+      .prepare(
+        "SELECT prompt_version_id, project_id FROM prompt_version_projects ORDER BY prompt_version_id ASC",
+      )
+      .all();
+    expect(promptVersionLinks).toEqual([
+      { prompt_version_id: 100, project_id: 1 },
+      { prompt_version_id: 101, project_id: 1 },
+      { prompt_version_id: 200, project_id: 2 },
+    ]);
+
+    const testCaseLinks = migrated
+      .prepare("SELECT test_case_id, project_id FROM test_case_projects ORDER BY test_case_id ASC")
+      .all();
+    expect(testCaseLinks).toEqual([
+      { test_case_id: 10, project_id: 1 },
+      { test_case_id: 20, project_id: 2 },
+    ]);
+
+    const promptVersions = migrated
+      .prepare("SELECT id, prompt_family_id FROM prompt_versions ORDER BY id ASC")
+      .all() as Array<{ id: number; prompt_family_id: number }>;
+    expect(promptVersions[0]?.prompt_family_id).toBeTruthy();
+    expect(promptVersions[0]?.prompt_family_id).toBe(promptVersions[1]?.prompt_family_id);
+    expect(promptVersions[2]?.prompt_family_id).not.toBe(promptVersions[0]?.prompt_family_id);
+
+    const executionProfiles = migrated
+      .prepare(
+        "SELECT id, model, temperature, api_provider, description FROM execution_profiles ORDER BY id ASC",
+      )
+      .all() as Array<{
+      id: number;
+      model: string;
+      temperature: number;
+      api_provider: string;
+      description: string;
+    }>;
+    expect(executionProfiles).toHaveLength(3);
+    expect(
+      executionProfiles.some((row) => row.description.includes("project_settings project_id=1")),
+    ).toBe(true);
+    expect(
+      executionProfiles.some(
+        (row) => row.description.includes("run_snapshot project_id=1") && row.model === "gpt-5.2",
+      ),
+    ).toBe(true);
+    const project1DefaultProfileId = executionProfiles.find((row) =>
+      row.description.includes("project_settings project_id=1"),
+    )?.id;
+    const project1SnapshotProfileId = executionProfiles.find(
+      (row) => row.description.includes("run_snapshot project_id=1") && row.model === "gpt-5.2",
+    )?.id;
+
+    const runs = migrated
+      .prepare("SELECT id, execution_profile_id FROM runs ORDER BY id ASC")
+      .all() as Array<{ id: number; execution_profile_id: number }>;
+    expect(runs.every((row) => row.execution_profile_id !== null)).toBe(true);
+    expect(runs[0]?.execution_profile_id).toBe(project1DefaultProfileId);
+    expect(runs[1]?.execution_profile_id).toBe(project1SnapshotProfileId);
+
+    const contextAssets = migrated
+      .prepare("SELECT id, name, path, mime_type, content FROM context_assets ORDER BY id ASC")
+      .all() as Array<{
+      id: number;
+      name: string;
+      path: string;
+      mime_type: string;
+      content: string;
+    }>;
+    expect(contextAssets).toEqual([
+      {
+        id: contextAssets[0]?.id,
+        name: "policy.md",
+        path: "docs/policy.md",
+        mime_type: "text/markdown",
+        content: "# policy",
+      },
+      {
+        id: contextAssets[1]?.id,
+        name: "faq.txt",
+        path: "faq.txt",
+        mime_type: "text/plain",
+        content: "faq",
+      },
+    ]);
+
+    const contextAssetProjects = migrated
+      .prepare(
+        "SELECT context_asset_id, project_id FROM context_asset_projects ORDER BY project_id ASC, context_asset_id ASC",
+      )
+      .all();
+    expect(contextAssetProjects).toEqual([
+      { context_asset_id: contextAssets[0]?.id, project_id: 1 },
+      { context_asset_id: contextAssets[1]?.id, project_id: 2 },
+    ]);
+
+    migrated.close();
+  });
+
+  it("再実行時は project ごとの path をキーに context asset を更新し、重複作成しない", async () => {
+    const { migrateDomainModelData } = await loadMigrationScript();
+    const { dbPath, contextFilesDir } = await createTempFixture();
+    const db = new Database(dbPath);
+    createSchema(db);
+    db.prepare(
+      `
+        INSERT INTO projects (id, name, description, created_at, updated_at)
+        VALUES (1, 'Support', NULL, 1000, 1000)
+      `,
+    ).run();
+    db.prepare(
+      `
+        INSERT INTO project_settings (
+          id, project_id, model, temperature, api_provider, created_at, updated_at
+        )
+        VALUES (1, 1, 'claude-opus-4-5', 0.7, 'anthropic', 1100, 1200)
+      `,
+    ).run();
+    db.prepare(
+      `
+        INSERT INTO test_cases (
+          id, project_id, title, turns, context_content, expected_description, display_order, created_at, updated_at
+        )
+        VALUES (10, 1, 'delivery', '[]', '', NULL, 1, 1300, 1400)
+      `,
+    ).run();
+    db.prepare(
+      `
+        INSERT INTO prompt_versions (
+          id, prompt_family_id, project_id, version, name, memo, content, workflow_definition, parent_version_id, created_at, is_selected
+        )
+        VALUES (100, NULL, 1, 1, 'v1', NULL, 'system 1', NULL, NULL, 1500, 1)
+      `,
+    ).run();
+    db.prepare(
+      `
+        INSERT INTO runs (
+          id, execution_profile_id, project_id, prompt_version_id, test_case_id, conversation, execution_trace,
+          is_best, is_discarded, created_at, model, temperature, api_provider
+        )
+        VALUES (1000, NULL, 1, 100, 10, '[]', NULL, 1, 0, 1700, 'claude-opus-4-5', 0.7, 'anthropic')
+      `,
+    ).run();
+    db.close();
+
+    const docsDir = path.join(contextFilesDir, "1");
+    await mkdir(docsDir, { recursive: true });
+    const targetFile = path.join(docsDir, "policy.md");
+    await writeFile(targetFile, "before", "utf8");
+    await utimes(targetFile, new Date(1000), new Date(1000));
+
+    await migrateDomainModelData({
+      dbPath,
+      contextFilesDir,
+      logger: { log() {} },
+    });
+
+    await writeFile(targetFile, "after", "utf8");
+    await utimes(targetFile, new Date(2000), new Date(2000));
+
+    const secondRun = await migrateDomainModelData({
+      dbPath,
+      contextFilesDir,
+      logger: { log() {} },
+    });
+
+    expect(secondRun.stats.createdContextAssets).toBe(0);
+    expect(secondRun.stats.updatedContextAssets).toBe(1);
+
+    const migrated = new Database(dbPath, { readonly: true });
+    const assets = migrated
+      .prepare("SELECT id, content, updated_at FROM context_assets")
+      .all() as Array<{ id: number; content: string; updated_at: number }>;
+    expect(assets).toHaveLength(1);
+    expect(assets[0]?.content).toBe("after");
+    expect(assets[0]?.updated_at).toBe(2000);
+
+    const links = migrated
+      .prepare("SELECT context_asset_id, project_id FROM context_asset_projects")
+      .all();
+    expect(links).toEqual([{ context_asset_id: assets[0]?.id, project_id: 1 }]);
+    migrated.close();
+
+    const saved = await readFile(targetFile, "utf8");
+    expect(saved).toBe("after");
+  });
+});

--- a/packages/core/src/types/mjs-modules.d.ts
+++ b/packages/core/src/types/mjs-modules.d.ts
@@ -1,0 +1,4 @@
+declare module "*.mjs" {
+  const value: unknown;
+  export default value;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,6 +9,6 @@
     "lib": ["ES2022"],
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["vitest.config.ts", "packages/*/src/**/*.ts"],
+  "include": ["vitest.config.ts", "packages/*/src/**/*.ts", "packages/*/src/**/*.d.ts"],
   "exclude": ["**/node_modules", "**/dist", "packages/ui/**"]
 }


### PR DESCRIPTION
## 概要
- 既存 DB と context-files を新ドメインモデルへ移す移行スクリプトを追加
- 既存データ移行の挙動を検証するテストを追加
- README に移行手順を追記

## 変更内容
- `packages/core/scripts/migrate-domain-model.mjs` を追加
- `projects` をラベルとして流用し、`prompt_families` / `prompt_version_projects` / `test_case_projects` / `execution_profiles` / `runs.execution_profile_id` / `context_assets` を補完する処理を実装
- `context-files` は project ごとの `path` をキーに upsert し、再実行時の重複作成を避けるようにした
- `packages/core/src/migrations/domain-model-migration.test.ts` を追加し、旧データからの移行と再実行時更新をテスト
- `packages/core/package.json` に `migrate:domain-model` を追加
- `.d.ts` を拾えるように TypeScript 設定を更新
- README に実行例と移行ルールを追記

## 検証
- `pnpm exec tsc --noEmit`
- `pnpm run test -- --run packages/core/src/migrations/domain-model-migration.test.ts`

## 関連
- Refs #108
