### PR TITLE
Issue #109 Execution Profiles API を追加

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ import { assertRequiredSchema, db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createContextFilesRouter } from "./routes/context-files.js";
+import { createExecutionProfilesRouter } from "./routes/execution-profiles.js";
 import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
@@ -70,6 +71,7 @@ app.get("/api/health", (c) => {
 });
 
 app.route("/api/projects", createProjectsRouter(db));
+app.route("/api/execution-profiles", createExecutionProfilesRouter(db));
 app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));

--- a/packages/server/src/routes/execution-profile-models.ts
+++ b/packages/server/src/routes/execution-profile-models.ts
@@ -1,0 +1,74 @@
+import {
+  AnthropicLLMClient,
+  LLMAuthenticationError,
+  LLMConfigurationError,
+} from "@prompt-reviewer/core";
+import { z } from "zod";
+
+export const listExecutionProfileModelsSchema = z.object({
+  api_provider: z.enum(["anthropic", "openai"], {
+    error: 'api_providerは "anthropic" または "openai" である必要があります',
+  }),
+  api_key: z.string().min(1, "api_keyは1文字以上必要です"),
+});
+
+export type ListExecutionProfileModelsBody = z.infer<typeof listExecutionProfileModelsSchema>;
+
+export type ExecutionProfileModelListClient = {
+  listModels(): Promise<unknown[]>;
+};
+
+export type ExecutionProfileModelClientFactory = (
+  body: ListExecutionProfileModelsBody,
+) => ExecutionProfileModelListClient | null;
+
+export function defaultExecutionProfileModelClientFactory(
+  body: ListExecutionProfileModelsBody,
+): ExecutionProfileModelListClient | null {
+  if (body.api_provider === "anthropic") {
+    return new AnthropicLLMClient({ apiKey: body.api_key });
+  }
+
+  return null;
+}
+
+export async function fetchExecutionProfileModels(
+  body: ListExecutionProfileModelsBody,
+  modelClientFactory: ExecutionProfileModelClientFactory,
+): Promise<{ status: number; body: { error?: string; models?: unknown[] } }> {
+  const client = modelClientFactory(body);
+
+  if (!client) {
+    return {
+      status: 501,
+      body: { error: "Provider model listing is not implemented" },
+    };
+  }
+
+  try {
+    const models = await client.listModels();
+    return {
+      status: 200,
+      body: { models },
+    };
+  } catch (error) {
+    if (error instanceof LLMConfigurationError) {
+      return {
+        status: 400,
+        body: { error: error.message },
+      };
+    }
+
+    if (error instanceof LLMAuthenticationError) {
+      return {
+        status: 401,
+        body: { error: error.message },
+      };
+    }
+
+    return {
+      status: 502,
+      body: { error: "Failed to fetch models" },
+    };
+  }
+}

--- a/packages/server/src/routes/execution-profiles.test.ts
+++ b/packages/server/src/routes/execution-profiles.test.ts
@@ -239,13 +239,24 @@ describe("PATCH /api/execution-profiles/:id", () => {
 });
 
 describe("DELETE /api/execution-profiles/:id", () => {
-  it("削除して 204 を返す", async () => {
+  it("参照中の Run を切り離してから削除し 204 を返す", async () => {
     let deleteCalled = false;
+    let updateRunsCalled = false;
+    let clearedExecutionProfileId: number | null | undefined;
     const db = {
       select: () => ({
         from: () => ({
           where: () => Promise.resolve([sampleProfile]),
         }),
+      }),
+      update: () => ({
+        set: (values: { execution_profile_id: number | null }) => {
+          updateRunsCalled = true;
+          clearedExecutionProfileId = values.execution_profile_id;
+          return {
+            where: () => Promise.resolve(),
+          };
+        },
       }),
       delete: () => ({
         where: () => {
@@ -260,6 +271,8 @@ describe("DELETE /api/execution-profiles/:id", () => {
     });
 
     expect(res.status).toBe(204);
+    expect(updateRunsCalled).toBe(true);
+    expect(clearedExecutionProfileId).toBeNull();
     expect(deleteCalled).toBe(true);
   });
 

--- a/packages/server/src/routes/execution-profiles.test.ts
+++ b/packages/server/src/routes/execution-profiles.test.ts
@@ -1,0 +1,349 @@
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { LLMAuthenticationError } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createExecutionProfilesRouter } from "./execution-profiles.js";
+
+type MockExecutionProfile = {
+  id: number;
+  name: string;
+  description: string | null;
+  model: string;
+  temperature: number;
+  api_provider: "anthropic" | "openai";
+  created_at: number;
+  updated_at: number;
+};
+
+type ModelListClient = {
+  listModels(): Promise<unknown[]>;
+};
+
+function buildApp(
+  db: unknown,
+  options?: {
+    modelClientFactory?: (body: {
+      api_provider: "anthropic" | "openai";
+      api_key: string;
+    }) => ModelListClient | null;
+  },
+) {
+  const app = new Hono();
+  app.route("/api/execution-profiles", createExecutionProfilesRouter(db as DB, options));
+  return app;
+}
+
+const sampleProfile: MockExecutionProfile = {
+  id: 1,
+  name: "Claude Sonnet 低温度",
+  description: "比較用の低温度設定",
+  model: "claude-sonnet-4-5",
+  temperature: 0.2,
+  api_provider: "anthropic",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+describe("GET /api/execution-profiles", () => {
+  it("一覧を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve([sampleProfile]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([sampleProfile]);
+  });
+});
+
+describe("POST /api/execution-profiles", () => {
+  it("新規作成して 201 を返す", async () => {
+    const created: MockExecutionProfile = {
+      ...sampleProfile,
+      id: 2,
+      name: "GPT-4o high temp",
+      description: null,
+      model: "gpt-4o",
+      temperature: 1.2,
+      api_provider: "openai",
+    };
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "GPT-4o high temp",
+        description: null,
+        model: "gpt-4o",
+        temperature: 1.2,
+        api_provider: "openai",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(capturedValues.name).toBe("GPT-4o high temp");
+    expect(capturedValues.description).toBeNull();
+    expect(typeof capturedValues.created_at).toBe("number");
+    expect(typeof capturedValues.updated_at).toBe("number");
+    await expect(res.json()).resolves.toEqual(created);
+  });
+
+  it("temperature が範囲外なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/execution-profiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "bad",
+        model: "claude",
+        temperature: 2.5,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/execution-profiles/:id", () => {
+  it("詳細を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleProfile]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles/1");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(sampleProfile);
+  });
+
+  it("見つからない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles/999");
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Execution profile not found" });
+  });
+});
+
+describe("PATCH /api/execution-profiles/:id", () => {
+  it("更新して 200 を返す", async () => {
+    const updated: MockExecutionProfile = {
+      ...sampleProfile,
+      name: "Claude Sonnet 高温度",
+      temperature: 0.9,
+      updated_at: 2000000,
+    };
+    let selectCount = 0;
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCount += 1;
+            return Promise.resolve(selectCount === 1 ? [sampleProfile] : []);
+          },
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Claude Sonnet 高温度",
+        temperature: 0.9,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedValues.name).toBe("Claude Sonnet 高温度");
+    expect(capturedValues.temperature).toBe(0.9);
+    expect(typeof capturedValues.updated_at).toBe("number");
+    await expect(res.json()).resolves.toEqual(updated);
+  });
+
+  it("対象が存在しない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        temperature: 0.9,
+      }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("更新項目が空なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/execution-profiles/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/execution-profiles/:id", () => {
+  it("削除して 204 を返す", async () => {
+    let deleteCalled = false;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleProfile]),
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/execution-profiles/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+    expect(deleteCalled).toBe(true);
+  });
+
+  it("数値以外の ID なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/execution-profiles/abc", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid ID" });
+  });
+});
+
+describe("POST /api/execution-profiles/models", () => {
+  it("モデル一覧を返す", async () => {
+    const listModels = vi.fn().mockResolvedValue([
+      {
+        id: "claude-sonnet-4-5-20250929",
+        displayName: "Claude Sonnet 4.5",
+      },
+    ]);
+    const modelClientFactory = vi.fn().mockReturnValue({ listModels });
+
+    const res = await buildApp({}, { modelClientFactory }).request(
+      "/api/execution-profiles/models",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_provider: "anthropic",
+          api_key: "sk-ant-test",
+        }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(modelClientFactory).toHaveBeenCalledWith({
+      api_provider: "anthropic",
+      api_key: "sk-ant-test",
+    });
+    await expect(res.json()).resolves.toEqual({
+      models: [
+        {
+          id: "claude-sonnet-4-5-20250929",
+          displayName: "Claude Sonnet 4.5",
+        },
+      ],
+    });
+  });
+
+  it("未対応プロバイダーなら 501 を返す", async () => {
+    const res = await buildApp({}, { modelClientFactory: () => null }).request(
+      "/api/execution-profiles/models",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_provider: "openai",
+          api_key: "sk-test",
+        }),
+      },
+    );
+
+    expect(res.status).toBe(501);
+  });
+
+  it("認証エラーなら 401 を返す", async () => {
+    const res = await buildApp(
+      {},
+      {
+        modelClientFactory: () => ({
+          listModels: vi.fn().mockRejectedValue(new LLMAuthenticationError("invalid api key")),
+        }),
+      },
+    ).request("/api/execution-profiles/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_provider: "anthropic",
+        api_key: "bad-key",
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "invalid api key" });
+  });
+});

--- a/packages/server/src/routes/execution-profiles.ts
+++ b/packages/server/src/routes/execution-profiles.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { execution_profiles } from "@prompt-reviewer/core";
+import { execution_profiles, runs } from "@prompt-reviewer/core";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -136,6 +136,10 @@ export function createExecutionProfilesRouter(
       return c.json({ error: "Execution profile not found" }, 404);
     }
 
+    await db
+      .update(runs)
+      .set({ execution_profile_id: null })
+      .where(eq(runs.execution_profile_id, id));
     await db.delete(execution_profiles).where(eq(execution_profiles.id, id));
     return c.body(null, 204);
   });

--- a/packages/server/src/routes/execution-profiles.ts
+++ b/packages/server/src/routes/execution-profiles.ts
@@ -1,0 +1,173 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { execution_profiles } from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  type ExecutionProfileModelClientFactory,
+  defaultExecutionProfileModelClientFactory,
+  fetchExecutionProfileModels,
+  listExecutionProfileModelsSchema,
+} from "./execution-profile-models.js";
+
+const createExecutionProfileSchema = z.object({
+  name: z.string().min(1, "nameは1文字以上必要です"),
+  description: z.string().nullable().optional(),
+  model: z.string().min(1, "modelは1文字以上必要です"),
+  temperature: z
+    .number()
+    .min(0, "temperatureは0以上が必要です")
+    .max(2, "temperatureは2以下が必要です"),
+  api_provider: z.enum(["anthropic", "openai"], {
+    error: 'api_providerは "anthropic" または "openai" である必要があります',
+  }),
+});
+
+const updateExecutionProfileSchema = z
+  .object({
+    name: z.string().min(1, "nameは1文字以上必要です").optional(),
+    description: z.string().nullable().optional(),
+    model: z.string().min(1, "modelは1文字以上必要です").optional(),
+    temperature: z
+      .number()
+      .min(0, "temperatureは0以上が必要です")
+      .max(2, "temperatureは2以下が必要です")
+      .optional(),
+    api_provider: z
+      .enum(["anthropic", "openai"], {
+        error: 'api_providerは "anthropic" または "openai" である必要があります',
+      })
+      .optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "更新項目が必要です",
+  });
+
+type CreateExecutionProfileBody = z.infer<typeof createExecutionProfileSchema>;
+type UpdateExecutionProfileBody = z.infer<typeof updateExecutionProfileSchema>;
+
+type ExecutionProfilesRouterOptions = {
+  modelClientFactory?: ExecutionProfileModelClientFactory;
+};
+
+function parseIdParam(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function createExecutionProfilesRouter(
+  db: DB,
+  options: ExecutionProfilesRouterOptions = {},
+) {
+  const router = new Hono();
+  const modelClientFactory =
+    options.modelClientFactory ?? defaultExecutionProfileModelClientFactory;
+
+  router.get("/", async (c) => {
+    const profiles = await db.select().from(execution_profiles).orderBy(execution_profiles.id);
+    return c.json(profiles);
+  });
+
+  router.post("/", zValidator("json", createExecutionProfileSchema), async (c) => {
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [created] = await db
+      .insert(execution_profiles)
+      .values(buildCreateValues(body, now))
+      .returning();
+
+    return c.json(created, 201);
+  });
+
+  router.get("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [profile] = await db
+      .select()
+      .from(execution_profiles)
+      .where(eq(execution_profiles.id, id));
+    if (!profile) {
+      return c.json({ error: "Execution profile not found" }, 404);
+    }
+
+    return c.json(profile);
+  });
+
+  router.patch("/:id", zValidator("json", updateExecutionProfileSchema), async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(execution_profiles)
+      .where(eq(execution_profiles.id, id));
+    if (!existing) {
+      return c.json({ error: "Execution profile not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const [updated] = await db
+      .update(execution_profiles)
+      .set(buildUpdateValues(body, Date.now()))
+      .where(eq(execution_profiles.id, id))
+      .returning();
+
+    return c.json(updated);
+  });
+
+  router.delete("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(execution_profiles)
+      .where(eq(execution_profiles.id, id));
+    if (!existing) {
+      return c.json({ error: "Execution profile not found" }, 404);
+    }
+
+    await db.delete(execution_profiles).where(eq(execution_profiles.id, id));
+    return c.body(null, 204);
+  });
+
+  router.post("/models", zValidator("json", listExecutionProfileModelsSchema), async (c) => {
+    const body = c.req.valid("json");
+    const result = await fetchExecutionProfileModels(body, modelClientFactory);
+    return c.json(result.body, result.status as 200 | 400 | 401 | 501 | 502);
+  });
+
+  return router;
+}
+
+function buildCreateValues(body: CreateExecutionProfileBody, now: number) {
+  return {
+    name: body.name,
+    description: body.description ?? null,
+    model: body.model,
+    temperature: body.temperature,
+    api_provider: body.api_provider,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function buildUpdateValues(body: UpdateExecutionProfileBody, now: number) {
+  return {
+    ...(body.name !== undefined ? { name: body.name } : {}),
+    ...(body.description !== undefined ? { description: body.description } : {}),
+    ...(body.model !== undefined ? { model: body.model } : {}),
+    ...(body.temperature !== undefined ? { temperature: body.temperature } : {}),
+    ...(body.api_provider !== undefined ? { api_provider: body.api_provider } : {}),
+    updated_at: now,
+  };
+}

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -1,14 +1,15 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import {
-  AnthropicLLMClient,
-  LLMAuthenticationError,
-  LLMConfigurationError,
-  project_settings,
-} from "@prompt-reviewer/core";
+import { project_settings } from "@prompt-reviewer/core";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  type ExecutionProfileModelClientFactory,
+  defaultExecutionProfileModelClientFactory,
+  fetchExecutionProfileModels,
+  listExecutionProfileModelsSchema,
+} from "./execution-profile-models.js";
 
 const upsertSettingsSchema = z.object({
   model: z.string().min(1, "modelは1文字以上必要です"),
@@ -21,31 +22,11 @@ const upsertSettingsSchema = z.object({
   }),
 });
 
-const listModelsSchema = z.object({
-  api_provider: z.enum(["anthropic", "openai"], {
-    error: 'api_providerは "anthropic" または "openai" である必要があります',
-  }),
-  api_key: z.string().min(1, "api_keyは1文字以上必要です"),
-});
-
 type UpsertBody = z.infer<typeof upsertSettingsSchema>;
-type ListModelsBody = z.infer<typeof listModelsSchema>;
-
-type ModelListClient = {
-  listModels(): Promise<unknown[]>;
-};
 
 type ProjectSettingsRouterOptions = {
-  modelClientFactory?: (body: ListModelsBody) => ModelListClient | null;
+  modelClientFactory?: ExecutionProfileModelClientFactory;
 };
-
-function defaultModelClientFactory(body: ListModelsBody): ModelListClient | null {
-  if (body.api_provider === "anthropic") {
-    return new AnthropicLLMClient({ apiKey: body.api_key });
-  }
-
-  return null;
-}
 
 /** 文字列または undefined を整数に変換する。無効・undefined の場合は null を返す */
 function parseIntParam(value: string | undefined): number | null {
@@ -93,7 +74,8 @@ async function createSettings(db: DB, projectId: number, body: UpsertBody, now: 
  */
 export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRouterOptions = {}) {
   const router = new Hono();
-  const modelClientFactory = options.modelClientFactory ?? defaultModelClientFactory;
+  const modelClientFactory =
+    options.modelClientFactory ?? defaultExecutionProfileModelClientFactory;
 
   // GET /api/projects/:projectId/settings - 設定取得
   router.get("/", async (c) => {
@@ -143,28 +125,10 @@ export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRout
     return c.json(created, 201);
   });
 
-  router.post("/models", zValidator("json", listModelsSchema), async (c) => {
+  router.post("/models", zValidator("json", listExecutionProfileModelsSchema), async (c) => {
     const body = c.req.valid("json");
-    const client = modelClientFactory(body);
-
-    if (!client) {
-      return c.json({ error: "Provider model listing is not implemented" }, 501);
-    }
-
-    try {
-      const models = await client.listModels();
-      return c.json({ models });
-    } catch (error) {
-      if (error instanceof LLMConfigurationError) {
-        return c.json({ error: error.message }, 400);
-      }
-
-      if (error instanceof LLMAuthenticationError) {
-        return c.json({ error: error.message }, 401);
-      }
-
-      return c.json({ error: "Failed to fetch models" }, 502);
-    }
+    const result = await fetchExecutionProfileModels(body, modelClientFactory);
+    return c.json(result.body, result.status as 200 | 400 | 401 | 501 | 502);
   });
 
   return router;


### PR DESCRIPTION
## 概要
- execution_profiles の CRUD / モデル一覧 API を追加
- project-settings のモデル一覧取得ロジックを共通化
- 新ルーターのテストを追加

## 変更内容
- `packages/server/src/routes/execution-profiles.ts` を追加
- `GET /api/execution-profiles`
- `POST /api/execution-profiles`
- `GET /api/execution-profiles/:id`
- `PATCH /api/execution-profiles/:id`
- `DELETE /api/execution-profiles/:id`
- `POST /api/execution-profiles/models`
- モデル一覧取得処理を `execution-profile-models.ts` に切り出し、既存 `project-settings` ルーターでも再利用
- `packages/server/src/index.ts` に新ルートを追加
- `packages/server/src/routes/execution-profiles.test.ts` を追加

## 検証
- `pnpm exec tsc --noEmit`
- `pnpm run test -- --run packages/server/src/routes/execution-profiles.test.ts packages/server/src/routes/project-settings.test.ts`

## 関連
- Closes #109
