### PR TITLE
feat: prompt_families CRUD API を追加する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ import { createContextFilesRouter } from "./routes/context-files.js";
 import { createExecutionProfilesRouter } from "./routes/execution-profiles.js";
 import { createProjectSettingsRouter } from "./routes/project-settings.js";
 import { createProjectsRouter } from "./routes/projects.js";
+import { createPromptFamiliesRouter } from "./routes/prompt-families.js";
 import { createPromptVersionsRouter } from "./routes/prompt-versions.js";
 import { createRunsRouter } from "./routes/runs.js";
 import { createScoreProgressionRouter } from "./routes/score-progression.js";
@@ -72,6 +73,7 @@ app.get("/api/health", (c) => {
 
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/execution-profiles", createExecutionProfilesRouter(db));
+app.route("/api/prompt-families", createPromptFamiliesRouter(db));
 app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));

--- a/packages/server/src/routes/prompt-families.test.ts
+++ b/packages/server/src/routes/prompt-families.test.ts
@@ -87,31 +87,14 @@ describe("POST /api/prompt-families", () => {
     await expect(res.json()).resolves.toEqual(created);
   });
 
-  it("name と description が省略された場合も作成できる", async () => {
-    const created: MockPromptFamily = {
-      id: 3,
-      name: null,
-      description: null,
-      created_at: 3000000,
-      updated_at: 3000000,
-    };
-
-    const db = {
-      insert: () => ({
-        values: () => ({
-          returning: () => Promise.resolve([created]),
-        }),
-      }),
-    };
-
-    const res = await buildApp(db).request("/api/prompt-families", {
+  it("name が未指定なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
     });
 
-    expect(res.status).toBe(201);
-    await expect(res.json()).resolves.toEqual(created);
+    expect(res.status).toBe(400);
   });
 
   it("name が空文字なら 400 を返す", async () => {
@@ -119,6 +102,16 @@ describe("POST /api/prompt-families", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("name が null なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: null }),
     });
 
     expect(res.status).toBe(400);
@@ -231,6 +224,16 @@ describe("PATCH /api/prompt-families/:id", () => {
     expect(res.status).toBe(400);
   });
 
+  it("name を null に更新しようとすると 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: null }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it("数値以外の ID なら 400 を返す", async () => {
     const res = await buildApp({}).request("/api/prompt-families/abc", {
       method: "PATCH",
@@ -244,7 +247,8 @@ describe("PATCH /api/prompt-families/:id", () => {
 });
 
 describe("DELETE /api/prompt-families/:id", () => {
-  it("削除して 204 を返す", async () => {
+  it("関連する prompt_versions の参照を外してから削除し 204 を返す", async () => {
+    let clearedPromptFamilyId: number | undefined;
     let deleteCalled = false;
 
     const db = {
@@ -252,6 +256,18 @@ describe("DELETE /api/prompt-families/:id", () => {
         from: () => ({
           where: () => Promise.resolve([sampleFamily]),
         }),
+      }),
+      update: (target: unknown) => ({
+        set: (values: Record<string, unknown>) => {
+          expect(target).toBeDefined();
+          expect(values).toEqual({ prompt_family_id: null });
+          return {
+            where: (_condition: unknown) => {
+              clearedPromptFamilyId = sampleFamily.id;
+              return Promise.resolve();
+            },
+          };
+        },
       }),
       delete: () => ({
         where: () => {
@@ -266,6 +282,7 @@ describe("DELETE /api/prompt-families/:id", () => {
     });
 
     expect(res.status).toBe(204);
+    expect(clearedPromptFamilyId).toBe(sampleFamily.id);
     expect(deleteCalled).toBe(true);
   });
 

--- a/packages/server/src/routes/prompt-families.test.ts
+++ b/packages/server/src/routes/prompt-families.test.ts
@@ -87,7 +87,7 @@ describe("POST /api/prompt-families", () => {
     await expect(res.json()).resolves.toEqual(created);
   });
 
-  it("name が未指定なら 400 を返す", async () => {
+  it("name と description が未指定なら 400 を返す", async () => {
     const res = await buildApp({}).request("/api/prompt-families", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -107,11 +107,11 @@ describe("POST /api/prompt-families", () => {
     expect(res.status).toBe(400);
   });
 
-  it("name が null なら 400 を返す", async () => {
+  it("name と description がともに null なら 400 を返す", async () => {
     const res = await buildApp({}).request("/api/prompt-families", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: null }),
+      body: JSON.stringify({ name: null, description: null }),
     });
 
     expect(res.status).toBe(400);
@@ -219,16 +219,6 @@ describe("PATCH /api/prompt-families/:id", () => {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
-    });
-
-    expect(res.status).toBe(400);
-  });
-
-  it("name を null に更新しようとすると 400 を返す", async () => {
-    const res = await buildApp({}).request("/api/prompt-families/1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: null }),
     });
 
     expect(res.status).toBe(400);

--- a/packages/server/src/routes/prompt-families.test.ts
+++ b/packages/server/src/routes/prompt-families.test.ts
@@ -1,0 +1,297 @@
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createPromptFamiliesRouter } from "./prompt-families.js";
+
+type MockPromptFamily = {
+  id: number;
+  name: string | null;
+  description: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/prompt-families", createPromptFamiliesRouter(db as DB));
+  return app;
+}
+
+const sampleFamily: MockPromptFamily = {
+  id: 1,
+  name: "顧客対応系列",
+  description: "顧客サポート向けプロンプトの系列",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+describe("GET /api/prompt-families", () => {
+  it("createdAt降順で一覧を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve([sampleFamily]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([sampleFamily]);
+  });
+});
+
+describe("POST /api/prompt-families", () => {
+  it("新規作成して 201 を返す", async () => {
+    const created: MockPromptFamily = {
+      id: 2,
+      name: "新しい系列",
+      description: null,
+      created_at: 2000000,
+      updated_at: 2000000,
+    };
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "新しい系列",
+        description: null,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(capturedValues.name).toBe("新しい系列");
+    expect(capturedValues.description).toBeNull();
+    expect(typeof capturedValues.created_at).toBe("number");
+    expect(typeof capturedValues.updated_at).toBe("number");
+    await expect(res.json()).resolves.toEqual(created);
+  });
+
+  it("name と description が省略された場合も作成できる", async () => {
+    const created: MockPromptFamily = {
+      id: 3,
+      name: null,
+      description: null,
+      created_at: 3000000,
+      updated_at: 3000000,
+    };
+
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual(created);
+  });
+
+  it("name が空文字なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/prompt-families/:id", () => {
+  it("詳細を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleFamily]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/1");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(sampleFamily);
+  });
+
+  it("見つからない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/999");
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Prompt family not found" });
+  });
+
+  it("数値以外の ID なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families/abc");
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid ID" });
+  });
+});
+
+describe("PATCH /api/prompt-families/:id", () => {
+  it("更新して 200 を返す", async () => {
+    const updated: MockPromptFamily = {
+      ...sampleFamily,
+      name: "更新後の系列名",
+      updated_at: 2000000,
+    };
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleFamily]),
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後の系列名" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedValues.name).toBe("更新後の系列名");
+    expect(typeof capturedValues.updated_at).toBe("number");
+    await expect(res.json()).resolves.toEqual(updated);
+  });
+
+  it("対象が存在しない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "新しい名前" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("更新項目が空なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外の ID なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "test" }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid ID" });
+  });
+});
+
+describe("DELETE /api/prompt-families/:id", () => {
+  it("削除して 204 を返す", async () => {
+    let deleteCalled = false;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleFamily]),
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+    expect(deleteCalled).toBe(true);
+  });
+
+  it("見つからない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/999", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Prompt family not found" });
+  });
+
+  it("数値以外の ID なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/prompt-families/abc", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid ID" });
+  });
+});

--- a/packages/server/src/routes/prompt-families.ts
+++ b/packages/server/src/routes/prompt-families.ts
@@ -5,14 +5,21 @@ import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
-const createPromptFamilySchema = z.object({
-  name: z.string().min(1, "nameは1文字以上必要です"),
-  description: z.string().nullable().optional(),
-});
+const createPromptFamilySchema = z
+  .object({
+    name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
+    description: z.string().nullable().optional(),
+  })
+  .refine((value) => value.name !== undefined || value.description !== undefined, {
+    message: "name または description のいずれかが必要です",
+  })
+  .refine((value) => value.name !== null || value.description !== null, {
+    message: "name または description のいずれかが必要です",
+  });
 
 const updatePromptFamilySchema = z
   .object({
-    name: z.string().min(1, "nameは1文字以上必要です").optional(),
+    name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
     description: z.string().nullable().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -109,7 +116,7 @@ export function createPromptFamiliesRouter(db: DB) {
 
 function buildCreateValues(body: CreatePromptFamilyBody, now: number) {
   return {
-    name: body.name,
+    name: body.name ?? null,
     description: body.description ?? null,
     created_at: now,
     updated_at: now,

--- a/packages/server/src/routes/prompt-families.ts
+++ b/packages/server/src/routes/prompt-families.ts
@@ -1,0 +1,121 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { prompt_families } from "@prompt-reviewer/core";
+import { desc, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createPromptFamilySchema = z.object({
+  name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
+  description: z.string().nullable().optional(),
+});
+
+const updatePromptFamilySchema = z
+  .object({
+    name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
+    description: z.string().nullable().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "更新項目が必要です",
+  });
+
+type CreatePromptFamilyBody = z.infer<typeof createPromptFamilySchema>;
+type UpdatePromptFamilyBody = z.infer<typeof updatePromptFamilySchema>;
+
+function parseIdParam(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function createPromptFamiliesRouter(db: DB) {
+  const router = new Hono();
+
+  router.get("/", async (c) => {
+    const families = await db
+      .select()
+      .from(prompt_families)
+      .orderBy(desc(prompt_families.created_at));
+    return c.json(families);
+  });
+
+  router.post("/", zValidator("json", createPromptFamilySchema), async (c) => {
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [created] = await db
+      .insert(prompt_families)
+      .values(buildCreateValues(body, now))
+      .returning();
+
+    return c.json(created, 201);
+  });
+
+  router.get("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [family] = await db.select().from(prompt_families).where(eq(prompt_families.id, id));
+    if (!family) {
+      return c.json({ error: "Prompt family not found" }, 404);
+    }
+
+    return c.json(family);
+  });
+
+  router.patch("/:id", zValidator("json", updatePromptFamilySchema), async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(prompt_families).where(eq(prompt_families.id, id));
+    if (!existing) {
+      return c.json({ error: "Prompt family not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const [updated] = await db
+      .update(prompt_families)
+      .set(buildUpdateValues(body, Date.now()))
+      .where(eq(prompt_families.id, id))
+      .returning();
+
+    return c.json(updated);
+  });
+
+  router.delete("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(prompt_families).where(eq(prompt_families.id, id));
+    if (!existing) {
+      return c.json({ error: "Prompt family not found" }, 404);
+    }
+
+    await db.delete(prompt_families).where(eq(prompt_families.id, id));
+    return c.body(null, 204);
+  });
+
+  return router;
+}
+
+function buildCreateValues(body: CreatePromptFamilyBody, now: number) {
+  return {
+    name: body.name ?? null,
+    description: body.description ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function buildUpdateValues(body: UpdatePromptFamilyBody, now: number) {
+  return {
+    ...(body.name !== undefined ? { name: body.name } : {}),
+    ...(body.description !== undefined ? { description: body.description } : {}),
+    updated_at: now,
+  };
+}

--- a/packages/server/src/routes/prompt-families.ts
+++ b/packages/server/src/routes/prompt-families.ts
@@ -1,18 +1,18 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { prompt_families } from "@prompt-reviewer/core";
+import { prompt_families, prompt_versions } from "@prompt-reviewer/core";
 import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
 const createPromptFamilySchema = z.object({
-  name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
+  name: z.string().min(1, "nameは1文字以上必要です"),
   description: z.string().nullable().optional(),
 });
 
 const updatePromptFamilySchema = z
   .object({
-    name: z.string().min(1, "nameは1文字以上必要です").nullable().optional(),
+    name: z.string().min(1, "nameは1文字以上必要です").optional(),
     description: z.string().nullable().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -96,6 +96,10 @@ export function createPromptFamiliesRouter(db: DB) {
       return c.json({ error: "Prompt family not found" }, 404);
     }
 
+    await db
+      .update(prompt_versions)
+      .set({ prompt_family_id: null })
+      .where(eq(prompt_versions.prompt_family_id, id));
     await db.delete(prompt_families).where(eq(prompt_families.id, id));
     return c.body(null, 204);
   });
@@ -105,7 +109,7 @@ export function createPromptFamiliesRouter(db: DB) {
 
 function buildCreateValues(body: CreatePromptFamilyBody, now: number) {
   return {
-    name: body.name ?? null,
+    name: body.name,
     description: body.description ?? null,
     created_at: now,
     updated_at: now,


### PR DESCRIPTION
## Summary

- `GET /api/prompt-families` — 一覧取得（createdAt降順）
- `POST /api/prompt-families` — 新規作成（201）
- `GET /api/prompt-families/:id` — 単件取得
- `PATCH /api/prompt-families/:id` — 部分更新（空ボディは400）
- `DELETE /api/prompt-families/:id` — 削除（204）
- 全エンドポイントで 400 / 404 のエラーハンドリングを実装

## Test plan

- [x] `GET /` — 一覧をcreatedAt降順で返す
- [x] `POST /` — 201 + 作成データを返す / name が空文字なら 400
- [x] `POST /` — name/description 省略時も作成できる
- [x] `GET /:id` — 詳細を返す / 存在しない場合は 404 / 非数値IDは 400
- [x] `PATCH /:id` — 更新して 200 / 存在しない場合は 404 / 空ボディは 400 / 非数値IDは 400
- [x] `DELETE /:id` — 削除して 204 / 存在しない場合は 404 / 非数値IDは 400
- [x] 全14テスト合格
- [x] `pnpm run check` + `pnpm run typecheck` 合格

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)