### PR TITLE
feat: prompt_versions を prompt_family 前提へ移行する

### DIFF
--- a/packages/core/src/schema/prompt-versions.test.ts
+++ b/packages/core/src/schema/prompt-versions.test.ts
@@ -10,21 +10,20 @@ import type { NewPromptVersion, PromptVersion } from "./prompt-versions.js";
 
 describe("prompt_versions スキーマ型定義", () => {
   describe("PromptVersion 型", () => {
-    it("PromptVersion 型は必須フィールドを持つ", () => {
-      type RequiredFields = {
-        id: number;
-        prompt_family_id: number | null;
-        project_id: number;
-        version: number;
-        content: string;
-        created_at: number;
-      };
-      expectTypeOf<
-        Pick<
-          PromptVersion,
-          "id" | "prompt_family_id" | "project_id" | "version" | "content" | "created_at"
-        >
-      >().toMatchTypeOf<RequiredFields>();
+    it("PromptVersion の prompt_family_id は必須（number 型）", () => {
+      expectTypeOf<PromptVersion["prompt_family_id"]>().toEqualTypeOf<number>();
+    });
+
+    it("PromptVersion の project_id は nullable（後方互換）", () => {
+      expectTypeOf<PromptVersion["project_id"]>().toEqualTypeOf<number | null>();
+    });
+
+    it("PromptVersion の version は number 型（family 内連番）", () => {
+      expectTypeOf<PromptVersion["version"]>().toEqualTypeOf<number>();
+    });
+
+    it("PromptVersion の content は string 型", () => {
+      expectTypeOf<PromptVersion["content"]>().toEqualTypeOf<string>();
     });
 
     it("PromptVersion の name はオプショナル（null許容）", () => {
@@ -39,28 +38,28 @@ describe("prompt_versions スキーマ型定義", () => {
       expectTypeOf<PromptVersion["parent_version_id"]>().toEqualTypeOf<number | null>();
     });
 
-    it("PromptVersion の version は number 型（プロジェクト内連番）", () => {
-      expectTypeOf<PromptVersion["version"]>().toEqualTypeOf<number>();
-    });
-
-    it("PromptVersion の content は string 型", () => {
-      expectTypeOf<PromptVersion["content"]>().toEqualTypeOf<string>();
-    });
-
-    it("PromptVersion の project_id は number 型", () => {
-      expectTypeOf<PromptVersion["project_id"]>().toEqualTypeOf<number>();
+    it("PromptVersion の is_selected は boolean 型", () => {
+      expectTypeOf<PromptVersion["is_selected"]>().toEqualTypeOf<boolean>();
     });
   });
 
   describe("NewPromptVersion 型", () => {
-    it("NewPromptVersion は id なしで作成できる（AutoIncrement）", () => {
+    it("NewPromptVersion は prompt_family_id を必須として作成できる", () => {
       const newPromptVersion: NewPromptVersion = {
-        project_id: 1,
+        prompt_family_id: 1,
         version: 1,
         content: "あなたは親切なアシスタントです。",
         created_at: Date.now(),
       };
       expectTypeOf(newPromptVersion).toMatchTypeOf<NewPromptVersion>();
+    });
+
+    it("NewPromptVersion の prompt_family_id は number 型（必須）", () => {
+      expectTypeOf<NewPromptVersion["prompt_family_id"]>().toEqualTypeOf<number>();
+    });
+
+    it("NewPromptVersion の project_id はオプショナル（後方互換）", () => {
+      expectTypeOf<NewPromptVersion["project_id"]>().toEqualTypeOf<number | null | undefined>();
     });
 
     it("NewPromptVersion の name はオプショナル", () => {
@@ -79,7 +78,7 @@ describe("prompt_versions スキーマ型定義", () => {
 
     it("分岐バージョンは parent_version_id を指定して作成できる", () => {
       const branchedVersion: NewPromptVersion = {
-        project_id: 1,
+        prompt_family_id: 1,
         version: 2,
         content: "あなたは丁寧なアシスタントです。",
         parent_version_id: 1,
@@ -90,7 +89,7 @@ describe("prompt_versions スキーマ型定義", () => {
 
     it("名前付きバージョンは name を指定して作成できる", () => {
       const namedVersion: NewPromptVersion = {
-        project_id: 1,
+        prompt_family_id: 1,
         version: 3,
         name: "丁寧口調バージョン",
         memo: "語尾を丁寧語に変更した改善版",
@@ -100,11 +99,4 @@ describe("prompt_versions スキーマ型定義", () => {
       expectTypeOf(namedVersion).toMatchTypeOf<NewPromptVersion>();
     });
   });
-});
-it("PromptVersion の prompt_family_id は移行期間中 number | null 型", () => {
-  expectTypeOf<PromptVersion["prompt_family_id"]>().toEqualTypeOf<number | null>();
-});
-
-it("NewPromptVersion の prompt_family_id は移行期間中オプショナル", () => {
-  expectTypeOf<NewPromptVersion["prompt_family_id"]>().toEqualTypeOf<number | null | undefined>();
 });

--- a/packages/core/src/schema/prompt-versions.ts
+++ b/packages/core/src/schema/prompt-versions.ts
@@ -2,17 +2,12 @@ import { type AnySQLiteColumn, integer, sqliteTable, text } from "drizzle-orm/sq
 import { projects } from "./projects";
 import { prompt_families } from "./prompt-families";
 
-/**
- * プロンプトバージョンテーブル
- * システムプロンプトのバージョン履歴を管理する（分岐・メモ付き）
- */
 export const prompt_versions = sqliteTable("prompt_versions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
-  // 互換期間中は project_id と併存し、後続 Issue で prompt_family_id を必須化する。
-  prompt_family_id: integer("prompt_family_id").references(() => prompt_families.id),
-  project_id: integer("project_id")
+  prompt_family_id: integer("prompt_family_id")
     .notNull()
-    .references(() => projects.id),
+    .references(() => prompt_families.id),
+  project_id: integer("project_id").references(() => projects.id),
   version: integer("version").notNull(),
   name: text("name"),
   memo: text("memo"),
@@ -25,7 +20,6 @@ export const prompt_versions = sqliteTable("prompt_versions", {
   is_selected: integer("is_selected", { mode: "boolean" }).notNull().default(false),
 });
 
-// Drizzle推論型のエクスポート
 export type PromptVersion = typeof prompt_versions.$inferSelect;
 export type NewPromptVersion = typeof prompt_versions.$inferInsert;
 

--- a/packages/core/src/seed.ts
+++ b/packages/core/src/seed.ts
@@ -34,6 +34,7 @@ async function seed() {
   sqlite.exec("DELETE FROM scores");
   sqlite.exec("DELETE FROM runs");
   sqlite.exec("DELETE FROM prompt_versions");
+  sqlite.exec("DELETE FROM prompt_families");
   sqlite.exec("DELETE FROM test_cases");
   sqlite.exec("DELETE FROM project_settings");
   sqlite.exec("DELETE FROM projects");
@@ -126,11 +127,27 @@ async function seed() {
   );
   console.log(`テストケース2作成: id=${testCase2.id}`);
 
-  // 4. プロンプトバージョン作成
+  // 4. プロンプトファミリー作成
+  const promptFamily = getFirstOrThrow(
+    await db
+      .insert(schema.prompt_families)
+      .values({
+        name: "カスタマーサポートBot",
+        description: "ECサイト向けカスタマーサポートのプロンプト系列",
+        created_at: now,
+        updated_at: now,
+      })
+      .returning(),
+    "promptFamily",
+  );
+  console.log(`プロンプトファミリー作成: id=${promptFamily.id}`);
+
+  // 5. プロンプトバージョン作成
   const promptV1 = getFirstOrThrow(
     await db
       .insert(schema.prompt_versions)
       .values({
+        prompt_family_id: promptFamily.id,
         project_id: project.id,
         version: 1,
         name: "初期バージョン",
@@ -148,6 +165,7 @@ async function seed() {
     await db
       .insert(schema.prompt_versions)
       .values({
+        prompt_family_id: promptFamily.id,
         project_id: project.id,
         version: 2,
         name: "共感強化バージョン",
@@ -167,7 +185,7 @@ async function seed() {
   );
   console.log(`プロンプトバージョン2作成: id=${promptV2.id}`);
 
-  // 5. 実行結果（runs）作成
+  // 6. 実行結果（runs）作成
   const conversation1 = JSON.stringify([
     { role: "user", content: "注文した商品がまだ届いていません。注文番号は#12345です。" },
     {
@@ -224,7 +242,7 @@ async function seed() {
   );
   console.log(`実行結果2作成: id=${run2.id} (ベスト回答)`);
 
-  // 6. スコア（scores）作成
+  // 7. スコア（scores）作成
   const score1 = getFirstOrThrow(
     await db
       .insert(schema.scores)
@@ -268,6 +286,7 @@ async function seed() {
   - プロジェクト: 1件
   - プロジェクト設定: 1件
   - テストケース: 2件
+  - プロンプトファミリー: 1件
   - プロンプトバージョン: 2件 (v1 -> v2 の分岐)
   - 実行結果: 2件 (run2 がベスト回答)
   - スコア: 2件 (3点, 5点)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -76,7 +76,7 @@ app.route("/api/execution-profiles", createExecutionProfilesRouter(db));
 app.route("/api/prompt-families", createPromptFamiliesRouter(db));
 app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
-app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
+app.route("/api/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));

--- a/packages/server/src/routes/prompt-families.test.ts
+++ b/packages/server/src/routes/prompt-families.test.ts
@@ -237,9 +237,8 @@ describe("PATCH /api/prompt-families/:id", () => {
 });
 
 describe("DELETE /api/prompt-families/:id", () => {
-  it("関連する prompt_versions の参照を外してから削除し 204 を返す", async () => {
-    let clearedPromptFamilyId: number | undefined;
-    let deleteCalled = false;
+  it("関連する prompt_versions を削除してから family を削除し 204 を返す", async () => {
+    let deleteCallCount = 0;
 
     const db = {
       select: () => ({
@@ -247,21 +246,9 @@ describe("DELETE /api/prompt-families/:id", () => {
           where: () => Promise.resolve([sampleFamily]),
         }),
       }),
-      update: (target: unknown) => ({
-        set: (values: Record<string, unknown>) => {
-          expect(target).toBeDefined();
-          expect(values).toEqual({ prompt_family_id: null });
-          return {
-            where: (_condition: unknown) => {
-              clearedPromptFamilyId = sampleFamily.id;
-              return Promise.resolve();
-            },
-          };
-        },
-      }),
       delete: () => ({
         where: () => {
-          deleteCalled = true;
+          deleteCallCount++;
           return Promise.resolve();
         },
       }),
@@ -272,8 +259,7 @@ describe("DELETE /api/prompt-families/:id", () => {
     });
 
     expect(res.status).toBe(204);
-    expect(clearedPromptFamilyId).toBe(sampleFamily.id);
-    expect(deleteCalled).toBe(true);
+    expect(deleteCallCount).toBe(2);
   });
 
   it("見つからない場合は 404 を返す", async () => {

--- a/packages/server/src/routes/prompt-families.test.ts
+++ b/packages/server/src/routes/prompt-families.test.ts
@@ -237,13 +237,23 @@ describe("PATCH /api/prompt-families/:id", () => {
 });
 
 describe("DELETE /api/prompt-families/:id", () => {
-  it("関連する prompt_versions を削除してから family を削除し 204 を返す", async () => {
+  it("関連する run がなければ prompt_versions を削除してから family を削除し 204 を返す", async () => {
     let deleteCallCount = 0;
+    let selectCallCount = 0;
 
     const db = {
       select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([sampleFamily]),
+        from: (_table?: unknown) => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleFamily]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([{ id: 10 }]);
+            }
+            return Promise.resolve([]);
+          },
         }),
       }),
       delete: () => ({
@@ -260,6 +270,42 @@ describe("DELETE /api/prompt-families/:id", () => {
 
     expect(res.status).toBe(204);
     expect(deleteCallCount).toBe(2);
+  });
+
+  it("関連する run がある場合は 409 を返す", async () => {
+    let deleteCalled = false;
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: (_table?: unknown) => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleFamily]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([{ id: 10 }]);
+            }
+            return Promise.resolve([{ id: 99 }]);
+          },
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/prompt-families/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "Prompt family is referenced by runs" });
+    expect(deleteCalled).toBe(false);
   });
 
   it("見つからない場合は 404 を返す", async () => {

--- a/packages/server/src/routes/prompt-families.ts
+++ b/packages/server/src/routes/prompt-families.ts
@@ -103,10 +103,7 @@ export function createPromptFamiliesRouter(db: DB) {
       return c.json({ error: "Prompt family not found" }, 404);
     }
 
-    await db
-      .update(prompt_versions)
-      .set({ prompt_family_id: null })
-      .where(eq(prompt_versions.prompt_family_id, id));
+    await db.delete(prompt_versions).where(eq(prompt_versions.prompt_family_id, id));
     await db.delete(prompt_families).where(eq(prompt_families.id, id));
     return c.body(null, 204);
   });

--- a/packages/server/src/routes/prompt-families.ts
+++ b/packages/server/src/routes/prompt-families.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { prompt_families, prompt_versions } from "@prompt-reviewer/core";
+import { prompt_families, prompt_versions, runs } from "@prompt-reviewer/core";
 import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -101,6 +101,22 @@ export function createPromptFamiliesRouter(db: DB) {
     const [existing] = await db.select().from(prompt_families).where(eq(prompt_families.id, id));
     if (!existing) {
       return c.json({ error: "Prompt family not found" }, 404);
+    }
+
+    const versions = await db
+      .select({ id: prompt_versions.id })
+      .from(prompt_versions)
+      .where(eq(prompt_versions.prompt_family_id, id));
+
+    for (const version of versions) {
+      const [referencingRun] = await db
+        .select({ id: runs.id })
+        .from(runs)
+        .where(eq(runs.prompt_version_id, version.id));
+
+      if (referencingRun) {
+        return c.json({ error: "Prompt family is referenced by runs" }, 409);
+      }
     }
 
     await db.delete(prompt_versions).where(eq(prompt_versions.prompt_family_id, id));

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -747,11 +747,18 @@ describe("PATCH /api/prompt-versions/:id/selected", () => {
 describe("PUT /api/prompt-versions/:id/projects", () => {
   it("project_id を設定して200で返す", async () => {
     const updated = { ...sampleVersion, project_id: 5 };
+    let selectCallCount = 0;
 
     const db = {
       select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([sampleVersion]),
+        from: (_table?: unknown) => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleVersion]);
+            }
+            return Promise.resolve([{ id: 5 }]);
+          },
         }),
       }),
       update: () => ({
@@ -776,6 +783,46 @@ describe("PUT /api/prompt-versions/:id/projects", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion;
     expect(body.project_id).toBe(5);
+  });
+
+  it("存在しない project_id を指定すると 404 を返す", async () => {
+    let updateCalled = false;
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: (_table?: unknown) => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleVersion]);
+            }
+            return Promise.resolve([]);
+          },
+        }),
+      }),
+      update: () => ({
+        set: () => {
+          updateCalled = true;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: 999 }),
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Project not found" });
+    expect(updateCalled).toBe(false);
   });
 
   it("project_id を null にして紐付けを解除できる", async () => {

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -6,7 +6,6 @@
  * モックを使用してルートハンドラの動作を検証する。
  */
 
-// better-sqlite3 のネイティブモジュールをモックしてDB初期化をブロック
 vi.mock("better-sqlite3", () => {
   return {
     default: vi.fn().mockReturnValue({}),
@@ -22,7 +21,8 @@ import { createPromptVersionsRouter } from "./prompt-versions.js";
 
 type MockPromptVersion = {
   id: number;
-  project_id: number;
+  prompt_family_id: number;
+  project_id: number | null;
   version: number;
   name: string | null;
   memo: string | null;
@@ -30,13 +30,14 @@ type MockPromptVersion = {
   workflow_definition: { steps: Array<{ id: string; title: string; prompt: string }> } | null;
   parent_version_id: number | null;
   created_at: number;
+  is_selected: boolean;
 };
 
 // ---- ヘルパー ----
 
 function buildApp(db: unknown) {
   const app = new Hono();
-  app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db as DB));
+  app.route("/api/prompt-versions", createPromptVersionsRouter(db as DB));
   return app;
 }
 
@@ -44,7 +45,8 @@ function buildApp(db: unknown) {
 
 const sampleVersion: MockPromptVersion = {
   id: 1,
-  project_id: 1,
+  prompt_family_id: 10,
+  project_id: null,
   version: 1,
   name: "初期バージョン",
   memo: null,
@@ -52,12 +54,13 @@ const sampleVersion: MockPromptVersion = {
   workflow_definition: null,
   parent_version_id: null,
   created_at: 1000000,
+  is_selected: false,
 };
 
-// ---- テスト ----
+// ---- GET /api/prompt-versions ----
 
-describe("GET /api/projects/:projectId/prompt-versions", () => {
-  it("バージョン一覧を200で返す", async () => {
+describe("GET /api/prompt-versions", () => {
+  it("prompt_family_id でフィルタしたバージョン一覧を200で返す", async () => {
     const versions = [sampleVersion, { ...sampleVersion, id: 2, version: 2, name: "v2" }];
 
     const db = {
@@ -69,13 +72,24 @@ describe("GET /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions");
+    const res = await app.request("/api/prompt-versions?prompt_family_id=10");
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion[];
     expect(body).toHaveLength(2);
     expect(body.at(0)?.version).toBe(1);
     expect(body.at(1)?.version).toBe(2);
+  });
+
+  it("prompt_family_id が未指定のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("prompt_family_id is required");
   });
 
   it("バージョンが0件のとき空配列を返す", async () => {
@@ -88,7 +102,7 @@ describe("GET /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions");
+    const res = await app.request("/api/prompt-versions?prompt_family_id=10");
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion[];
@@ -96,7 +110,9 @@ describe("GET /api/projects/:projectId/prompt-versions", () => {
   });
 });
 
-describe("POST /api/projects/:projectId/prompt-versions", () => {
+// ---- POST /api/prompt-versions ----
+
+describe("POST /api/prompt-versions", () => {
   it("バリデーション通過時に201でバージョンを返す", async () => {
     const created = { ...sampleVersion };
 
@@ -114,10 +130,14 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "あなたは親切なアシスタントです。", name: "初期バージョン" }),
+      body: JSON.stringify({
+        prompt_family_id: 10,
+        content: "あなたは親切なアシスタントです。",
+        name: "初期バージョン",
+      }),
     });
 
     expect(res.status).toBe(201);
@@ -126,7 +146,7 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     expect(body.name).toBe("初期バージョン");
   });
 
-  it("version番号が既存の最大値+1で採番される", async () => {
+  it("family内の version が max+1 で採番される", async () => {
     const created = { ...sampleVersion, id: 3, version: 3 };
 
     const db = {
@@ -136,10 +156,10 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
         }),
       }),
       insert: () => ({
-        values: (values: { version: number }) => ({
+        values: (values: { version: number; prompt_family_id: number }) => ({
           returning: () => {
-            // 採番された version が 3 になっているか検証
             expect(values.version).toBe(3);
+            expect(values.prompt_family_id).toBe(10);
             return Promise.resolve([created]);
           },
         }),
@@ -147,10 +167,10 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "新しいプロンプト", name: "新しいプロンプト" }),
+      body: JSON.stringify({ prompt_family_id: 10, content: "新しいプロンプト", name: "v3" }),
     });
 
     expect(res.status).toBe(201);
@@ -158,7 +178,7 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     expect(body.version).toBe(3);
   });
 
-  it("プロジェクト内にバージョンが0件の場合、version=1 で採番される", async () => {
+  it("family内にバージョンが0件の場合、version=1 で採番される", async () => {
     const created = { ...sampleVersion, version: 1 };
 
     const db = {
@@ -178,10 +198,10 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "初めてのプロンプト", name: "初めてのプロンプト" }),
+      body: JSON.stringify({ prompt_family_id: 10, content: "初めてのプロンプト" }),
     });
 
     expect(res.status).toBe(201);
@@ -208,10 +228,10 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "初めてのプロンプト" }),
+      body: JSON.stringify({ prompt_family_id: 10, content: "初めてのプロンプト" }),
     });
 
     expect(res.status).toBe(201);
@@ -219,27 +239,27 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     expect(body.name).toBe("プロンプト 2");
   });
 
-  it("content が空文字列のとき400を返す", async () => {
+  it("prompt_family_id が未指定のとき400を返す", async () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "" }),
+      body: JSON.stringify({ content: "プロンプト" }),
     });
 
     expect(res.status).toBe(400);
   });
 
-  it("content が未指定のとき400を返す", async () => {
+  it("content が空文字列のとき400を返す", async () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "名前だけ" }),
+      body: JSON.stringify({ prompt_family_id: 10, content: "" }),
     });
 
     expect(res.status).toBe(400);
@@ -249,10 +269,11 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        prompt_family_id: 10,
         content: "プロンプト本文",
         workflow_definition: {
           steps: [{ id: "step.1", title: "抽出", prompt: "内容を抽出してください" }],
@@ -267,10 +288,11 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        prompt_family_id: 10,
         content: "プロンプト本文",
         workflow_definition: {
           steps: [
@@ -288,10 +310,11 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions", {
+    const res = await app.request("/api/prompt-versions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        prompt_family_id: 10,
         content: "プロンプト本文",
         workflow_definition: {
           steps: [{ id: "__base_prompt__", title: "抽出", prompt: "内容を抽出してください" }],
@@ -303,7 +326,9 @@ describe("POST /api/projects/:projectId/prompt-versions", () => {
   });
 });
 
-describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
+// ---- GET /api/prompt-versions/:id ----
+
+describe("GET /api/prompt-versions/:id", () => {
   it("存在するIDに対して200でバージョンを返す", async () => {
     const db = {
       select: () => ({
@@ -314,12 +339,13 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1");
+    const res = await app.request("/api/prompt-versions/1");
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion;
     expect(body.id).toBe(1);
     expect(body.content).toBe("あなたは親切なアシスタントです。");
+    expect(body.prompt_family_id).toBe(10);
   });
 
   it("存在しないIDに対して404を返す", async () => {
@@ -332,7 +358,7 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/999");
+    const res = await app.request("/api/prompt-versions/999");
 
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
@@ -343,7 +369,89 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/abc");
+    const res = await app.request("/api/prompt-versions/abc");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- PATCH /api/prompt-versions/:id ----
+
+describe("PATCH /api/prompt-versions/:id", () => {
+  it("存在するIDに対して200で更新されたバージョンを返す", async () => {
+    const updated = { ...sampleVersion, content: "更新されたプロンプト", name: "v1-updated" };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新されたプロンプト", name: "v1-updated" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.content).toBe("更新されたプロンプト");
+    expect(body.name).toBe("v1-updated");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("content が空文字列のとき400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "更新" }),
+    });
 
     expect(res.status).toBe(400);
   });
@@ -370,7 +478,7 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1", {
+    const res = await app.request("/api/prompt-versions/1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "" }),
@@ -380,92 +488,12 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     const body = (await res.json()) as MockPromptVersion;
     expect(body.name).toBe("プロンプト 1");
   });
-});
-
-describe("PATCH /api/projects/:projectId/prompt-versions/:id", () => {
-  it("存在するIDに対して200で更新されたバージョンを返す", async () => {
-    const updated = { ...sampleVersion, content: "更新されたプロンプト", name: "v1-updated" };
-
-    const db = {
-      select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([sampleVersion]),
-        }),
-      }),
-      update: () => ({
-        set: () => ({
-          where: () => ({
-            returning: () => Promise.resolve([updated]),
-          }),
-        }),
-      }),
-    };
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "更新されたプロンプト", name: "v1-updated" }),
-    });
-
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as MockPromptVersion;
-    expect(body.content).toBe("更新されたプロンプト");
-    expect(body.name).toBe("v1-updated");
-  });
-
-  it("存在しないIDに対して404を返す", async () => {
-    const db = {
-      select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([]),
-        }),
-      }),
-    };
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/999", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "更新" }),
-    });
-
-    expect(res.status).toBe(404);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("PromptVersion not found");
-  });
-
-  it("content が空文字列のとき400を返す", async () => {
-    const db = {};
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "" }),
-    });
-
-    expect(res.status).toBe(400);
-  });
-
-  it("数値以外のIDに対して400を返す", async () => {
-    const db = {};
-
-    const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/abc", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "更新" }),
-    });
-
-    expect(res.status).toBe(400);
-  });
 
   it("PATCH で workflow_definition の step.id が重複すると400を返す", async () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1", {
+    const res = await app.request("/api/prompt-versions/1", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -482,8 +510,10 @@ describe("PATCH /api/projects/:projectId/prompt-versions/:id", () => {
   });
 });
 
-describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
-  it("分岐作成時に parent_version_id が正しく設定される", async () => {
+// ---- POST /api/prompt-versions/:id/branch ----
+
+describe("POST /api/prompt-versions/:id/branch", () => {
+  it("分岐作成時に parent_version_id と prompt_family_id が正しく引き継がれる", async () => {
     const branched: MockPromptVersion = {
       ...sampleVersion,
       id: 2,
@@ -499,10 +529,14 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
         }),
       }),
       insert: () => ({
-        values: (values: { parent_version_id: number; version: number }) => ({
+        values: (values: {
+          parent_version_id: number;
+          version: number;
+          prompt_family_id: number;
+        }) => ({
           returning: () => {
-            // parent_version_id が親の id (1) に設定されていることを確認
             expect(values.parent_version_id).toBe(1);
+            expect(values.prompt_family_id).toBe(10);
             return Promise.resolve([branched]);
           },
         }),
@@ -510,7 +544,7 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+    const res = await app.request("/api/prompt-versions/1/branch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "分岐バージョン" }),
@@ -540,7 +574,6 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
       insert: () => ({
         values: (values: { content: string }) => ({
           returning: () => {
-            // 親の content が引き継がれていることを確認
             expect(values.content).toBe(sampleVersion.content);
             return Promise.resolve([branched]);
           },
@@ -549,7 +582,7 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+    const res = await app.request("/api/prompt-versions/1/branch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -560,7 +593,7 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     expect(body.content).toBe(sampleVersion.content);
   });
 
-  it("分岐作成時に version 番号が自動採番される", async () => {
+  it("分岐作成時に family 単位で version 番号が自動採番される", async () => {
     const branched: MockPromptVersion = {
       ...sampleVersion,
       id: 2,
@@ -568,7 +601,6 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
       parent_version_id: 1,
     };
 
-    // select が2回呼ばれる: 1回目は親バージョン取得, 2回目は maxVersion 取得
     let selectCallCount = 0;
     const db = {
       select: () => ({
@@ -576,10 +608,8 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
           where: () => {
             selectCallCount++;
             if (selectCallCount === 1) {
-              // 親バージョン取得
               return Promise.resolve([sampleVersion]);
             }
-            // maxVersion 取得
             return Promise.resolve([{ maxVersion: 1 }]);
           },
         }),
@@ -595,7 +625,7 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/1/branch", {
+    const res = await app.request("/api/prompt-versions/1/branch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -616,7 +646,7 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     };
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/999/branch", {
+    const res = await app.request("/api/prompt-versions/999/branch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -631,10 +661,185 @@ describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
     const db = {};
 
     const app = buildApp(db);
-    const res = await app.request("/api/projects/1/prompt-versions/abc/branch", {
+    const res = await app.request("/api/prompt-versions/abc/branch", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- PATCH /api/prompt-versions/:id/selected ----
+
+describe("PATCH /api/prompt-versions/:id/selected", () => {
+  it("family内で選択状態を切り替えて200で返す", async () => {
+    const updated = { ...sampleVersion, is_selected: true };
+
+    let updateCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { is_selected: boolean }) => ({
+          where: () => {
+            updateCallCount++;
+            if (updateCallCount === 1) {
+              expect(values.is_selected).toBe(false);
+              return Promise.resolve([]);
+            }
+            expect(values.is_selected).toBe(true);
+            return {
+              returning: () => Promise.resolve([updated]),
+            };
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1/selected", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.is_selected).toBe(true);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/999/selected", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/abc/selected", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- PUT /api/prompt-versions/:id/projects ----
+
+describe("PUT /api/prompt-versions/:id/projects", () => {
+  it("project_id を設定して200で返す", async () => {
+    const updated = { ...sampleVersion, project_id: 5 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleVersion]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { project_id: number | null }) => ({
+          where: () => ({
+            returning: () => {
+              expect(values.project_id).toBe(5);
+              return Promise.resolve([updated]);
+            },
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: 5 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.project_id).toBe(5);
+  });
+
+  it("project_id を null にして紐付けを解除できる", async () => {
+    const updated = { ...sampleVersion, project_id: null };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([{ ...sampleVersion, project_id: 5 }]),
+        }),
+      }),
+      update: () => ({
+        set: (values: { project_id: number | null }) => ({
+          where: () => ({
+            returning: () => {
+              expect(values.project_id).toBeNull();
+              return Promise.resolve([updated]);
+            },
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.project_id).toBeNull();
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/999/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: 1 }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("PromptVersion not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const db = {};
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/abc/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: 1 }),
     });
 
     expect(res.status).toBe(400);

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -47,6 +47,7 @@ const workflowDefinitionSchema = z
   });
 
 const createPromptVersionSchema = z.object({
+  prompt_family_id: z.number().int().positive("prompt_family_idは正の整数が必要です"),
   content: z.string().min(1, "contentは1文字以上必要です"),
   name: z.string().optional(),
   memo: z.string().optional(),
@@ -63,6 +64,10 @@ const updatePromptVersionSchema = z.object({
 const branchPromptVersionSchema = z.object({
   name: z.string().optional(),
   memo: z.string().optional(),
+});
+
+const updateProjectLinkSchema = z.object({
+  project_id: z.number().int().positive("project_idは正の整数が必要です").nullable(),
 });
 
 function normalizeOptionalString(value: string | null | undefined): string | null {
@@ -95,37 +100,35 @@ export function createPromptVersionsRouter(db: DB) {
     };
   }
 
-  // GET /api/projects/:projectId/prompt-versions - バージョン一覧取得
+  // GET /api/prompt-versions?prompt_family_id=N - family単位でバージョン一覧取得
   router.get("/", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
+    const familyIdParam = c.req.query("prompt_family_id");
+    if (!familyIdParam) {
+      return c.json({ error: "prompt_family_id is required" }, 400);
+    }
 
-    if (Number.isNaN(projectId)) {
-      return c.json({ error: "Invalid projectId" }, 400);
+    const familyId = Number(familyIdParam);
+    if (Number.isNaN(familyId)) {
+      return c.json({ error: "Invalid prompt_family_id" }, 400);
     }
 
     const result = await db
       .select()
       .from(prompt_versions)
-      .where(eq(prompt_versions.project_id, projectId));
+      .where(eq(prompt_versions.prompt_family_id, familyId));
 
     return c.json(result.map(serializePromptVersion));
   });
 
-  // POST /api/projects/:projectId/prompt-versions - 新規バージョン作成
+  // POST /api/prompt-versions - prompt_family_id ベースで新規バージョン作成
   router.post("/", zValidator("json", createPromptVersionSchema), async (c) => {
-    const projectId = Number(c.req.param("projectId"));
-
-    if (Number.isNaN(projectId)) {
-      return c.json({ error: "Invalid projectId" }, 400);
-    }
-
     const body = c.req.valid("json");
+    const { prompt_family_id } = body;
 
-    // version 番号を自動採番（プロジェクト内の最大 version + 1）
     const [maxResult] = await db
       .select({ maxVersion: max(prompt_versions.version) })
       .from(prompt_versions)
-      .where(eq(prompt_versions.project_id, projectId));
+      .where(eq(prompt_versions.prompt_family_id, prompt_family_id));
 
     const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
     const normalizedName =
@@ -134,7 +137,7 @@ export function createPromptVersionsRouter(db: DB) {
     const result = await db
       .insert(prompt_versions)
       .values({
-        project_id: projectId,
+        prompt_family_id,
         version: nextVersion,
         content: body.content,
         name: normalizedName,
@@ -155,19 +158,15 @@ export function createPromptVersionsRouter(db: DB) {
     return c.json(serializePromptVersion(created), 201);
   });
 
-  // GET /api/projects/:projectId/prompt-versions/:id - 特定バージョン取得
+  // GET /api/prompt-versions/:id - 単件取得
   router.get("/:id", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [version] = await db
-      .select()
-      .from(prompt_versions)
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+    const [version] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
 
     if (!version) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -176,19 +175,15 @@ export function createPromptVersionsRouter(db: DB) {
     return c.json(serializePromptVersion(version));
   });
 
-  // PATCH /api/projects/:projectId/prompt-versions/:id - バージョン更新
+  // PATCH /api/prompt-versions/:id - 部分更新
   router.patch("/:id", zValidator("json", updatePromptVersionSchema), async (c) => {
-    const projectId = Number(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [existing] = await db
-      .select()
-      .from(prompt_versions)
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+    const [existing] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
 
     if (!existing) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -221,7 +216,7 @@ export function createPromptVersionsRouter(db: DB) {
     const updateResult = await db
       .update(prompt_versions)
       .set(updateData)
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)))
+      .where(eq(prompt_versions.id, id))
       .returning();
 
     const updated = updateResult[0];
@@ -232,19 +227,15 @@ export function createPromptVersionsRouter(db: DB) {
     return c.json(serializePromptVersion(updated));
   });
 
-  // POST /api/projects/:projectId/prompt-versions/:id/branch - 分岐バージョン作成
+  // POST /api/prompt-versions/:id/branch - 分岐バージョン作成
   router.post("/:id/branch", zValidator("json", branchPromptVersionSchema), async (c) => {
-    const projectId = Number(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [parent] = await db
-      .select()
-      .from(prompt_versions)
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+    const [parent] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
 
     if (!parent) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -252,18 +243,17 @@ export function createPromptVersionsRouter(db: DB) {
 
     const body = c.req.valid("json");
 
-    // version 番号を自動採番（プロジェクト内の最大 version + 1）
     const [maxResult] = await db
       .select({ maxVersion: max(prompt_versions.version) })
       .from(prompt_versions)
-      .where(eq(prompt_versions.project_id, projectId));
+      .where(eq(prompt_versions.prompt_family_id, parent.prompt_family_id));
 
     const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
 
     const result = await db
       .insert(prompt_versions)
       .values({
-        project_id: projectId,
+        prompt_family_id: parent.prompt_family_id,
         version: nextVersion,
         content: parent.content,
         name: body.name ?? null,
@@ -282,36 +272,59 @@ export function createPromptVersionsRouter(db: DB) {
     return c.json(serializePromptVersion(created), 201);
   });
 
-  // PATCH /api/projects/:projectId/prompt-versions/:id/selected - Selected フラグ設定
-  // プロジェクト内の既存フラグを解除してから対象バージョンに設定（1プロジェクト1件制約）
+  // PATCH /api/prompt-versions/:id/selected - family内で選択切り替え（1family1件制約）
   router.patch("/:id/selected", async (c) => {
-    const projectId = Number(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
-    if (Number.isNaN(projectId) || Number.isNaN(id)) {
+    if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [existing] = await db
-      .select()
-      .from(prompt_versions)
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
+    const [existing] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
 
     if (!existing) {
       return c.json({ error: "PromptVersion not found" }, 404);
     }
 
-    // プロジェクト内の既存 selected フラグを解除
     await db
       .update(prompt_versions)
       .set({ is_selected: false })
-      .where(eq(prompt_versions.project_id, projectId));
+      .where(eq(prompt_versions.prompt_family_id, existing.prompt_family_id));
 
-    // 対象バージョンに selected フラグを設定
     const updateResult = await db
       .update(prompt_versions)
       .set({ is_selected: true })
-      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)))
+      .where(eq(prompt_versions.id, id))
+      .returning();
+
+    const updated = updateResult[0];
+    if (!updated) {
+      return c.json({ error: "Failed to update PromptVersion" }, 500);
+    }
+
+    return c.json(serializePromptVersion(updated));
+  });
+
+  // PUT /api/prompt-versions/:id/projects - プロジェクト紐付け更新
+  router.put("/:id/projects", zValidator("json", updateProjectLinkSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+
+    if (!existing) {
+      return c.json({ error: "PromptVersion not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+
+    const updateResult = await db
+      .update(prompt_versions)
+      .set({ project_id: body.project_id })
+      .where(eq(prompt_versions.id, id))
       .returning();
 
     const updated = updateResult[0];

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -1,7 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { prompt_versions } from "@prompt-reviewer/core";
-import { and, eq, max } from "drizzle-orm";
+import { projects, prompt_versions } from "@prompt-reviewer/core";
+import { eq, max } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
@@ -320,6 +320,12 @@ export function createPromptVersionsRouter(db: DB) {
     }
 
     const body = c.req.valid("json");
+    if (body.project_id !== null) {
+      const [project] = await db.select().from(projects).where(eq(projects.id, body.project_id));
+      if (!project) {
+        return c.json({ error: "Project not found" }, 404);
+      }
+    }
 
     const updateResult = await db
       .update(prompt_versions)

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -62,7 +62,7 @@ type RunsRouterOptions = {
 
 type StoredPromptVersion = {
   id: number;
-  project_id: number;
+  project_id: number | null;
   content: string;
   workflow_definition: string | null;
 };


### PR DESCRIPTION
## 概要

Issue #112 の対応。`prompt_versions` の主従を `project` から `prompt_family` に切り替え。

## 変更内容

### スキーマ変更（`packages/core/src/schema/prompt-versions.ts`）
- `prompt_family_id` を `notNull()` に変更（互換期間を終了）
- `project_id` を nullable に変更（後方互換として残存）

### 新 API（`packages/server/src/routes/prompt-versions.ts`）

| メソッド | エンドポイント | 説明 |
|---|---|---|
| GET | `/api/prompt-versions?prompt_family_id=N` | family単位でバージョン一覧取得 |
| POST | `/api/prompt-versions` | prompt_family_id ベースでバージョン作成 |
| GET | `/api/prompt-versions/:id` | 単件取得 |
| PATCH | `/api/prompt-versions/:id` | 部分更新 |
| POST | `/api/prompt-versions/:id/branch` | 分岐（family内でversion採番） |
| PATCH | `/api/prompt-versions/:id/selected` | family内で選択切り替え |
| PUT | `/api/prompt-versions/:id/projects` | プロジェクト紐付け更新 |

### ルート登録変更（`packages/server/src/index.ts`）
- 旧: `/api/projects/:projectId/prompt-versions` → 削除
- 新: `/api/prompt-versions` → 追加

### 関連ファイル修正
- `prompt-families.ts`: DELETE時に関連 prompt_versions を cascade delete
- `runs.ts`: `StoredPromptVersion.project_id` を `number | null` に修正
- `seed.ts`: prompt_family を先に作成し、prompt_versions に prompt_family_id を付与

## テスト

- family単位の連番採番（version=1から始まり、max+1で採番）
- branch時のprompt_family_idとparent_version_id引き継ぎ
- selected切り替え（family内でupdateが2回呼ばれることを検証）
- PUT /projects によるプロジェクト紐付け更新・解除

## 動作確認

- 全271件テスト通過
- biome check クリア
- typecheck クリア

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)