### PR TITLE
fix: 旧 prompt-versions API を互換レイヤ化する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -77,6 +77,7 @@ app.route("/api/prompt-families", createPromptFamiliesRouter(db));
 app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
 app.route("/api/projects/:projectId/test-cases", createTestCasesRouter(db));
 app.route("/api/prompt-versions", createPromptVersionsRouter(db));
+app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -41,6 +41,12 @@ function buildApp(db: unknown) {
   return app;
 }
 
+function buildLegacyApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db as DB));
+  return app;
+}
+
 // ---- テストデータ ----
 
 const sampleVersion: MockPromptVersion = {
@@ -107,6 +113,35 @@ describe("GET /api/prompt-versions", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion[];
     expect(body).toHaveLength(0);
+  });
+});
+
+// ---- GET /api/projects/:projectId/prompt-versions ----
+
+describe("GET /api/projects/:projectId/prompt-versions", () => {
+  it("project にリンクされた version 一覧を返し、project_id を補完する", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            return Promise.resolve([sampleVersion]);
+          },
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(1);
+    expect(body[0]?.project_id).toBe(7);
   });
 });
 
@@ -326,6 +361,93 @@ describe("POST /api/prompt-versions", () => {
   });
 });
 
+// ---- POST /api/projects/:projectId/prompt-versions ----
+
+describe("POST /api/projects/:projectId/prompt-versions", () => {
+  it("legacy path で family 未作成なら新規 family を作って version を作成する", async () => {
+    const created = { ...sampleVersion, prompt_family_id: 30, project_id: 7 };
+    let selectCallCount = 0;
+    let insertCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([]);
+            }
+            return Promise.resolve([{ maxVersion: null }]);
+          },
+        }),
+      }),
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          insertCallCount++;
+          if (insertCallCount === 1) {
+            expect(values.name).toBeNull();
+            return {
+              returning: () => Promise.resolve([{ id: 30 }]),
+            };
+          }
+          if (insertCallCount === 2) {
+            expect(values.prompt_family_id).toBe(30);
+            expect(values.project_id).toBe(7);
+            return {
+              returning: () => Promise.resolve([created]),
+            };
+          }
+          expect(values.prompt_version_id).toBe(1);
+          expect(values.project_id).toBe(7);
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "互換 API で作成" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.prompt_family_id).toBe(30);
+    expect(body.project_id).toBe(7);
+  });
+
+  it("legacy path で複数 family にまたがる project は 409 を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }, { prompt_version_id: 2 }]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([sampleVersion]);
+            }
+            return Promise.resolve([{ ...sampleVersion, id: 2, prompt_family_id: 11 }]);
+          },
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "互換 API で作成" }),
+    });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: "Legacy project is linked to multiple prompt families",
+    });
+  });
+});
+
 // ---- GET /api/prompt-versions/:id ----
 
 describe("GET /api/prompt-versions/:id", () => {
@@ -372,6 +494,34 @@ describe("GET /api/prompt-versions/:id", () => {
     const res = await app.request("/api/prompt-versions/abc");
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ---- GET /api/projects/:projectId/prompt-versions/:id ----
+
+describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
+  it("legacy path で project にリンクされた version 詳細を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            return Promise.resolve([sampleVersion]);
+          },
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions/1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.id).toBe(1);
+    expect(body.project_id).toBe(7);
   });
 });
 
@@ -507,6 +657,47 @@ describe("PATCH /api/prompt-versions/:id", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ---- PATCH /api/projects/:projectId/prompt-versions/:id ----
+
+describe("PATCH /api/projects/:projectId/prompt-versions/:id", () => {
+  it("legacy path で project にリンクされた version を更新できる", async () => {
+    const updated = { ...sampleVersion, content: "互換更新後", project_id: null };
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            return Promise.resolve([sampleVersion]);
+          },
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "互換更新後" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.content).toBe("互換更新後");
+    expect(body.project_id).toBe(7);
   });
 });
 
@@ -671,6 +862,65 @@ describe("POST /api/prompt-versions/:id/branch", () => {
   });
 });
 
+// ---- POST /api/projects/:projectId/prompt-versions/:id/branch ----
+
+describe("POST /api/projects/:projectId/prompt-versions/:id/branch", () => {
+  it("legacy path で branch 作成時に project_id を維持し project link を張る", async () => {
+    const branched: MockPromptVersion = {
+      ...sampleVersion,
+      id: 2,
+      version: 2,
+      project_id: 7,
+      parent_version_id: 1,
+    };
+    let selectCallCount = 0;
+    let insertCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([sampleVersion]);
+            }
+            return Promise.resolve([{ maxVersion: 1 }]);
+          },
+        }),
+      }),
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          insertCallCount++;
+          if (insertCallCount === 1) {
+            expect(values.parent_version_id).toBe(1);
+            expect(values.project_id).toBe(7);
+            return {
+              returning: () => Promise.resolve([branched]),
+            };
+          }
+          expect(values.prompt_version_id).toBe(2);
+          expect(values.project_id).toBe(7);
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions/1/branch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "branch" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.parent_version_id).toBe(1);
+    expect(body.project_id).toBe(7);
+  });
+});
+
 // ---- PATCH /api/prompt-versions/:id/selected ----
 
 describe("PATCH /api/prompt-versions/:id/selected", () => {
@@ -739,6 +989,53 @@ describe("PATCH /api/prompt-versions/:id/selected", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ---- PATCH /api/projects/:projectId/prompt-versions/:id/selected ----
+
+describe("PATCH /api/projects/:projectId/prompt-versions/:id/selected", () => {
+  it("legacy path でも selected 切り替え結果の project_id を補完する", async () => {
+    const updated = { ...sampleVersion, is_selected: true, project_id: null };
+    let selectCallCount = 0;
+    let updateCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            return Promise.resolve([sampleVersion]);
+          },
+        }),
+      }),
+      update: () => ({
+        set: (values: { is_selected: boolean }) => ({
+          where: () => {
+            updateCallCount++;
+            if (updateCallCount === 1) {
+              expect(values.is_selected).toBe(false);
+              return Promise.resolve([]);
+            }
+            return {
+              returning: () => Promise.resolve([updated]),
+            };
+          },
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions/1/selected", {
+      method: "PATCH",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.is_selected).toBe(true);
+    expect(body.project_id).toBe(7);
   });
 });
 

--- a/packages/server/src/routes/prompt-versions.test.ts
+++ b/packages/server/src/routes/prompt-versions.test.ts
@@ -121,6 +121,7 @@ describe("GET /api/prompt-versions", () => {
 describe("GET /api/projects/:projectId/prompt-versions", () => {
   it("project にリンクされた version 一覧を返し、project_id を補完する", async () => {
     let selectCallCount = 0;
+    const directVersion = { ...sampleVersion, id: 2, version: 2, project_id: 7, name: "direct" };
     const db = {
       select: () => ({
         from: () => ({
@@ -128,6 +129,9 @@ describe("GET /api/projects/:projectId/prompt-versions", () => {
             selectCallCount++;
             if (selectCallCount === 1) {
               return Promise.resolve([{ prompt_version_id: 1 }]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([directVersion]);
             }
             return Promise.resolve([sampleVersion]);
           },
@@ -139,9 +143,11 @@ describe("GET /api/projects/:projectId/prompt-versions", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion[];
-    expect(body).toHaveLength(1);
+    expect(body).toHaveLength(2);
     expect(body[0]?.id).toBe(1);
     expect(body[0]?.project_id).toBe(7);
+    expect(body[1]?.id).toBe(2);
+    expect(body[1]?.project_id).toBe(7);
   });
 });
 
@@ -521,6 +527,31 @@ describe("GET /api/projects/:projectId/prompt-versions/:id", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion;
     expect(body.id).toBe(1);
+    expect(body.project_id).toBe(7);
+  });
+
+  it("link table に無くても prompt_versions.project_id が一致すれば返す", async () => {
+    let selectCallCount = 0;
+    const directVersion = { ...sampleVersion, id: 2, project_id: 7 };
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([]);
+            }
+            return Promise.resolve([directVersion]);
+          },
+        }),
+      }),
+    };
+
+    const res = await buildLegacyApp(db).request("/api/projects/7/prompt-versions/2");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockPromptVersion;
+    expect(body.id).toBe(2);
     expect(body.project_id).toBe(7);
   });
 });
@@ -1042,9 +1073,10 @@ describe("PATCH /api/projects/:projectId/prompt-versions/:id/selected", () => {
 // ---- PUT /api/prompt-versions/:id/projects ----
 
 describe("PUT /api/prompt-versions/:id/projects", () => {
-  it("project_id を設定して200で返す", async () => {
+  it("project_id を設定して link table にも反映し 200で返す", async () => {
     const updated = { ...sampleVersion, project_id: 5 };
     let selectCallCount = 0;
+    let insertCallCount = 0;
 
     const db = {
       select: () => ({
@@ -1054,9 +1086,21 @@ describe("PUT /api/prompt-versions/:id/projects", () => {
             if (selectCallCount === 1) {
               return Promise.resolve([sampleVersion]);
             }
-            return Promise.resolve([{ id: 5 }]);
+            if (selectCallCount === 2) {
+              return Promise.resolve([{ id: 5 }]);
+            }
+            return Promise.resolve([]);
           },
         }),
+      }),
+      insert: () => ({
+        values: (values: { prompt_version_id: number; project_id: number; created_at: number }) => {
+          insertCallCount++;
+          expect(values.prompt_version_id).toBe(1);
+          expect(values.project_id).toBe(5);
+          expect(typeof values.created_at).toBe("number");
+          return Promise.resolve();
+        },
       }),
       update: () => ({
         set: (values: { project_id: number | null }) => ({
@@ -1080,6 +1124,53 @@ describe("PUT /api/prompt-versions/:id/projects", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion;
     expect(body.project_id).toBe(5);
+    expect(insertCallCount).toBe(1);
+  });
+
+  it("同じ project link が既にある場合は重複 insert しない", async () => {
+    const updated = { ...sampleVersion, project_id: 5 };
+    let selectCallCount = 0;
+    let insertCalled = false;
+
+    const db = {
+      select: () => ({
+        from: (_table?: unknown) => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleVersion]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([{ id: 5 }]);
+            }
+            return Promise.resolve([{ prompt_version_id: 1 }]);
+          },
+        }),
+      }),
+      insert: () => ({
+        values: () => {
+          insertCalled = true;
+          return Promise.resolve();
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/prompt-versions/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_id: 5 }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertCalled).toBe(false);
   });
 
   it("存在しない project_id を指定すると 404 を返す", async () => {
@@ -1122,14 +1213,21 @@ describe("PUT /api/prompt-versions/:id/projects", () => {
     expect(updateCalled).toBe(false);
   });
 
-  it("project_id を null にして紐付けを解除できる", async () => {
+  it("project_id を null にして link table の紐付けも解除できる", async () => {
     const updated = { ...sampleVersion, project_id: null };
+    let deleteCalled = false;
 
     const db = {
       select: () => ({
         from: () => ({
           where: () => Promise.resolve([{ ...sampleVersion, project_id: 5 }]),
         }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
       }),
       update: () => ({
         set: (values: { project_id: number | null }) => ({
@@ -1153,6 +1251,7 @@ describe("PUT /api/prompt-versions/:id/projects", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as MockPromptVersion;
     expect(body.project_id).toBeNull();
+    expect(deleteCalled).toBe(true);
   });
 
   it("存在しないIDに対して404を返す", async () => {

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -131,19 +131,27 @@ export function createPromptVersionsRouter(db: DB) {
       .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
       .from(prompt_version_projects)
       .where(eq(prompt_version_projects.project_id, projectId));
+    const directVersions = await db
+      .select()
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId));
 
-    const versions: Array<typeof prompt_versions.$inferSelect> = [];
+    const versions = new Map<number, typeof prompt_versions.$inferSelect>();
     for (const link of links) {
       const [version] = await db
         .select()
         .from(prompt_versions)
         .where(eq(prompt_versions.id, link.prompt_version_id));
       if (version) {
-        versions.push(version);
+        versions.set(version.id, version);
       }
     }
 
-    return versions.sort((a, b) => a.version - b.version || a.id - b.id);
+    for (const version of directVersions) {
+      versions.set(version.id, version);
+    }
+
+    return [...versions.values()].sort((a, b) => a.version - b.version || a.id - b.id);
   }
 
   async function getLegacyProjectVersion(projectId: number, id: number) {
@@ -157,11 +165,15 @@ export function createPromptVersionsRouter(db: DB) {
         ),
       );
 
-    if (!link) {
-      return null;
+    if (link) {
+      const [version] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+      return version ?? null;
     }
 
-    const [version] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+    const [version] = await db
+      .select()
+      .from(prompt_versions)
+      .where(and(eq(prompt_versions.id, id), eq(prompt_versions.project_id, projectId)));
     return version ?? null;
   }
 
@@ -519,6 +531,26 @@ export function createPromptVersionsRouter(db: DB) {
       const [project] = await db.select().from(projects).where(eq(projects.id, body.project_id));
       if (!project) {
         return c.json({ error: "Project not found" }, 404);
+      }
+    }
+
+    if (body.project_id === null) {
+      await db
+        .delete(prompt_version_projects)
+        .where(eq(prompt_version_projects.prompt_version_id, id));
+    } else {
+      const [existingLink] = await db
+        .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+        .from(prompt_version_projects)
+        .where(
+          and(
+            eq(prompt_version_projects.prompt_version_id, id),
+            eq(prompt_version_projects.project_id, body.project_id),
+          ),
+        );
+
+      if (!existingLink) {
+        await linkPromptVersionToProject(id, body.project_id);
       }
     }
 

--- a/packages/server/src/routes/prompt-versions.ts
+++ b/packages/server/src/routes/prompt-versions.ts
@@ -1,7 +1,12 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { projects, prompt_versions } from "@prompt-reviewer/core";
-import { eq, max } from "drizzle-orm";
+import {
+  projects,
+  prompt_families,
+  prompt_version_projects,
+  prompt_versions,
+} from "@prompt-reviewer/core";
+import { and, eq, max } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
@@ -54,6 +59,10 @@ const createPromptVersionSchema = z.object({
   workflow_definition: workflowDefinitionSchema.optional(),
 });
 
+const legacyCreatePromptVersionSchema = createPromptVersionSchema.omit({
+  prompt_family_id: true,
+});
+
 const updatePromptVersionSchema = z.object({
   content: z.string().min(1, "contentは1文字以上必要です").optional(),
   name: z.string().nullable().optional(),
@@ -100,8 +109,83 @@ export function createPromptVersionsRouter(db: DB) {
     };
   }
 
+  function parseLegacyProjectId(value: string | undefined): number | null | undefined {
+    if (value === undefined || value === "") {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isInteger(parsed) ? parsed : null;
+  }
+
+  function serializePromptVersionForProject(
+    version: typeof prompt_versions.$inferSelect,
+    projectId: number | undefined,
+  ) {
+    const serialized = serializePromptVersion(version);
+    return projectId === undefined ? serialized : { ...serialized, project_id: projectId };
+  }
+
+  async function listLegacyProjectVersions(projectId: number) {
+    const links = await db
+      .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+      .from(prompt_version_projects)
+      .where(eq(prompt_version_projects.project_id, projectId));
+
+    const versions: Array<typeof prompt_versions.$inferSelect> = [];
+    for (const link of links) {
+      const [version] = await db
+        .select()
+        .from(prompt_versions)
+        .where(eq(prompt_versions.id, link.prompt_version_id));
+      if (version) {
+        versions.push(version);
+      }
+    }
+
+    return versions.sort((a, b) => a.version - b.version || a.id - b.id);
+  }
+
+  async function getLegacyProjectVersion(projectId: number, id: number) {
+    const [link] = await db
+      .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+      .from(prompt_version_projects)
+      .where(
+        and(
+          eq(prompt_version_projects.project_id, projectId),
+          eq(prompt_version_projects.prompt_version_id, id),
+        ),
+      );
+
+    if (!link) {
+      return null;
+    }
+
+    const [version] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+    return version ?? null;
+  }
+
+  async function linkPromptVersionToProject(promptVersionId: number, projectId: number) {
+    await db.insert(prompt_version_projects).values({
+      prompt_version_id: promptVersionId,
+      project_id: projectId,
+      created_at: Date.now(),
+    });
+  }
+
   // GET /api/prompt-versions?prompt_family_id=N - family単位でバージョン一覧取得
   router.get("/", async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+    if (legacyProjectId !== undefined) {
+      const versions = await listLegacyProjectVersions(legacyProjectId);
+      return c.json(
+        versions.map((version) => serializePromptVersionForProject(version, legacyProjectId)),
+      );
+    }
+
     const familyIdParam = c.req.query("prompt_family_id");
     if (!familyIdParam) {
       return c.json({ error: "prompt_family_id is required" }, 400);
@@ -121,8 +205,82 @@ export function createPromptVersionsRouter(db: DB) {
   });
 
   // POST /api/prompt-versions - prompt_family_id ベースで新規バージョン作成
-  router.post("/", zValidator("json", createPromptVersionSchema), async (c) => {
-    const body = c.req.valid("json");
+  router.post("/", async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
+    const json = await c.req.json();
+    const parsedBody =
+      legacyProjectId !== undefined
+        ? legacyCreatePromptVersionSchema.safeParse(json)
+        : createPromptVersionSchema.safeParse(json);
+    if (!parsedBody.success) {
+      return c.json({ error: parsedBody.error.issues[0]?.message ?? "Invalid request body" }, 400);
+    }
+
+    if (legacyProjectId !== undefined) {
+      const legacyVersions = await listLegacyProjectVersions(legacyProjectId);
+      const familyIds = [...new Set(legacyVersions.map((version) => version.prompt_family_id))];
+      if (familyIds.length > 1) {
+        return c.json({ error: "Legacy project is linked to multiple prompt families" }, 409);
+      }
+
+      const familyId =
+        familyIds[0] ??
+        (
+          await db
+            .insert(prompt_families)
+            .values({
+              name: null,
+              description: null,
+              created_at: Date.now(),
+              updated_at: Date.now(),
+            })
+            .returning()
+        )[0]?.id;
+
+      if (!familyId) {
+        return c.json({ error: "Failed to create Prompt family" }, 500);
+      }
+
+      const body = parsedBody.data;
+      const [maxResult] = await db
+        .select({ maxVersion: max(prompt_versions.version) })
+        .from(prompt_versions)
+        .where(eq(prompt_versions.prompt_family_id, familyId));
+
+      const nextVersion = (maxResult?.maxVersion ?? 0) + 1;
+      const normalizedName =
+        normalizeOptionalString(body.name) ?? buildDefaultPromptName(nextVersion);
+
+      const result = await db
+        .insert(prompt_versions)
+        .values({
+          prompt_family_id: familyId,
+          project_id: legacyProjectId,
+          version: nextVersion,
+          content: body.content,
+          name: normalizedName,
+          memo: body.memo ?? null,
+          workflow_definition: body.workflow_definition
+            ? JSON.stringify(body.workflow_definition)
+            : null,
+          parent_version_id: null,
+          created_at: Date.now(),
+        })
+        .returning();
+
+      const created = result[0];
+      if (!created) {
+        return c.json({ error: "Failed to create PromptVersion" }, 500);
+      }
+
+      await linkPromptVersionToProject(created.id, legacyProjectId);
+      return c.json(serializePromptVersionForProject(created, legacyProjectId), 201);
+    }
+
+    const body = parsedBody.data as z.infer<typeof createPromptVersionSchema>;
     const { prompt_family_id } = body;
 
     const [maxResult] = await db
@@ -160,10 +318,21 @@ export function createPromptVersionsRouter(db: DB) {
 
   // GET /api/prompt-versions/:id - 単件取得
   router.get("/:id", async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
     if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
+    }
+    if (legacyProjectId !== undefined) {
+      const version = await getLegacyProjectVersion(legacyProjectId, id);
+      if (!version) {
+        return c.json({ error: "PromptVersion not found" }, 404);
+      }
+      return c.json(serializePromptVersionForProject(version, legacyProjectId));
     }
 
     const [version] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
@@ -177,13 +346,20 @@ export function createPromptVersionsRouter(db: DB) {
 
   // PATCH /api/prompt-versions/:id - 部分更新
   router.patch("/:id", zValidator("json", updatePromptVersionSchema), async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
     if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [existing] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+    const existing =
+      legacyProjectId !== undefined
+        ? await getLegacyProjectVersion(legacyProjectId, id)
+        : (await db.select().from(prompt_versions).where(eq(prompt_versions.id, id)))[0];
 
     if (!existing) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -224,18 +400,25 @@ export function createPromptVersionsRouter(db: DB) {
       return c.json({ error: "Failed to update PromptVersion" }, 500);
     }
 
-    return c.json(serializePromptVersion(updated));
+    return c.json(serializePromptVersionForProject(updated, legacyProjectId));
   });
 
   // POST /api/prompt-versions/:id/branch - 分岐バージョン作成
   router.post("/:id/branch", zValidator("json", branchPromptVersionSchema), async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
     if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [parent] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+    const parent =
+      legacyProjectId !== undefined
+        ? await getLegacyProjectVersion(legacyProjectId, id)
+        : (await db.select().from(prompt_versions).where(eq(prompt_versions.id, id)))[0];
 
     if (!parent) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -254,6 +437,7 @@ export function createPromptVersionsRouter(db: DB) {
       .insert(prompt_versions)
       .values({
         prompt_family_id: parent.prompt_family_id,
+        ...(legacyProjectId !== undefined ? { project_id: legacyProjectId } : {}),
         version: nextVersion,
         content: parent.content,
         name: body.name ?? null,
@@ -269,18 +453,29 @@ export function createPromptVersionsRouter(db: DB) {
       return c.json({ error: "Failed to create branch PromptVersion" }, 500);
     }
 
-    return c.json(serializePromptVersion(created), 201);
+    if (legacyProjectId !== undefined) {
+      await linkPromptVersionToProject(created.id, legacyProjectId);
+    }
+
+    return c.json(serializePromptVersionForProject(created, legacyProjectId), 201);
   });
 
   // PATCH /api/prompt-versions/:id/selected - family内で選択切り替え（1family1件制約）
   router.patch("/:id/selected", async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
     const id = Number(c.req.param("id"));
 
+    if (legacyProjectId === null) {
+      return c.json({ error: "Invalid projectId" }, 400);
+    }
     if (Number.isNaN(id)) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const [existing] = await db.select().from(prompt_versions).where(eq(prompt_versions.id, id));
+    const existing =
+      legacyProjectId !== undefined
+        ? await getLegacyProjectVersion(legacyProjectId, id)
+        : (await db.select().from(prompt_versions).where(eq(prompt_versions.id, id)))[0];
 
     if (!existing) {
       return c.json({ error: "PromptVersion not found" }, 404);
@@ -302,7 +497,7 @@ export function createPromptVersionsRouter(db: DB) {
       return c.json({ error: "Failed to update PromptVersion" }, 500);
     }
 
-    return c.json(serializePromptVersion(updated));
+    return c.json(serializePromptVersionForProject(updated, legacyProjectId));
   });
 
   // PUT /api/prompt-versions/:id/projects - プロジェクト紐付け更新


### PR DESCRIPTION
## 概要
- 旧 `/api/projects/:projectId/prompt-versions` を互換レイヤとして復活
- `prompt_version_projects` を使って project に見える prompt version を解決
- legacy path の CRUD / branch / selected で `project_id` を補完

## 変更内容
- `packages/server/src/index.ts`
  - 旧 `/api/projects/:projectId/prompt-versions` を `createPromptVersionsRouter` に再接続
- `packages/server/src/routes/prompt-versions.ts`
  - legacy path を判定して `prompt_version_projects` 経由で project 配下の version を取得
  - legacy レスポンスでは `project_id` をリクエスト中の project で補完
  - legacy POST は既存 family が 1 件ならその family に作成、0 件なら family を新規作成、複数件なら 409 を返却
  - legacy branch 作成時に project link を追加
- `packages/server/src/routes/prompt-versions.test.ts`
  - legacy path の一覧・詳細・作成・更新・branch・selected の互換テストを追加

## 確認
- `pnpm test -- packages/server/src/routes/prompt-versions.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run check`