### PR TITLE
context_assets API を追加する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { serve } from "@hono/node-server";
 import { assertRequiredSchema, db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createContextAssetsRouter } from "./routes/context-assets.js";
 import { createContextFilesRouter } from "./routes/context-files.js";
 import { createExecutionProfilesRouter } from "./routes/execution-profiles.js";
 import { createProjectSettingsRouter } from "./routes/project-settings.js";
@@ -71,6 +72,7 @@ app.get("/api/health", (c) => {
   return c.json({ status: "ok" });
 });
 
+app.route("/api/context-assets", createContextAssetsRouter(db));
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/execution-profiles", createExecutionProfilesRouter(db));
 app.route("/api/prompt-families", createPromptFamiliesRouter(db));

--- a/packages/server/src/routes/context-assets.test.ts
+++ b/packages/server/src/routes/context-assets.test.ts
@@ -20,6 +20,8 @@ type MockContextAsset = {
   updated_at: number;
 };
 
+type MockContextAssetSummary = Omit<MockContextAsset, "content">;
+
 function buildApp(db: unknown) {
   const app = new Hono();
   app.route("/api/context-assets", createContextAssetsRouter(db as DB));
@@ -37,6 +39,16 @@ const sampleAsset: MockContextAsset = {
   updated_at: 1000000,
 };
 
+const sampleAssetSummary: MockContextAssetSummary = {
+  id: 1,
+  name: "refund-policy.md",
+  path: "policies/refund-policy.md",
+  mime_type: "text/markdown",
+  content_hash: "sha256:old",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
 describe("GET /api/context-assets", () => {
   it("一覧を 200 で返す", async () => {
     const db = {
@@ -48,7 +60,21 @@ describe("GET /api/context-assets", () => {
     const res = await buildApp(db).request("/api/context-assets");
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual([sampleAsset]);
+    await expect(res.json()).resolves.toEqual([sampleAssetSummary]);
+  });
+
+  it("一覧レスポンスに content を含めない", async () => {
+    const db = {
+      select: () => ({
+        from: () => Promise.resolve([sampleAsset]),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<Record<string, unknown>>;
+    expect(body[0]).not.toHaveProperty("content");
   });
 
   it("q で name / path を部分一致検索できる", async () => {
@@ -70,7 +96,7 @@ describe("GET /api/context-assets", () => {
     const res = await buildApp(db).request("/api/context-assets?q=refund");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as MockContextAsset[];
+    const body = (await res.json()) as MockContextAssetSummary[];
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe(1);
   });
@@ -111,7 +137,7 @@ describe("GET /api/context-assets", () => {
     const res = await app.request("/api/context-assets?project_id=10");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as MockContextAsset[];
+    const body = (await res.json()) as MockContextAssetSummary[];
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe(1);
   });
@@ -136,7 +162,7 @@ describe("GET /api/context-assets", () => {
     const res = await app.request("/api/context-assets?unclassified=true");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as MockContextAsset[];
+    const body = (await res.json()) as MockContextAssetSummary[];
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe(2);
   });
@@ -162,7 +188,7 @@ describe("GET /api/context-assets", () => {
     const res = await app.request("/api/context-assets?linked_to=test_case:12");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as MockContextAsset[];
+    const body = (await res.json()) as MockContextAssetSummary[];
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe(2);
   });
@@ -188,7 +214,7 @@ describe("GET /api/context-assets", () => {
     const res = await app.request("/api/context-assets?linked_to=prompt_family:4");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as MockContextAsset[];
+    const body = (await res.json()) as MockContextAssetSummary[];
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe(1);
   });

--- a/packages/server/src/routes/context-assets.test.ts
+++ b/packages/server/src/routes/context-assets.test.ts
@@ -1,0 +1,438 @@
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createContextAssetsRouter } from "./context-assets.js";
+
+type MockContextAsset = {
+  id: number;
+  name: string;
+  path: string;
+  content: string;
+  mime_type: string;
+  content_hash: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/context-assets", createContextAssetsRouter(db as DB));
+  return app;
+}
+
+const sampleAsset: MockContextAsset = {
+  id: 1,
+  name: "refund-policy.md",
+  path: "policies/refund-policy.md",
+  content: "購入から30日以内であれば返金可能です。",
+  mime_type: "text/markdown",
+  content_hash: "sha256:old",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+describe("GET /api/context-assets", () => {
+  it("一覧を 200 で返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => Promise.resolve([sampleAsset]),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([sampleAsset]);
+  });
+
+  it("q で name / path を部分一致検索できる", async () => {
+    const assets = [
+      sampleAsset,
+      {
+        ...sampleAsset,
+        id: 2,
+        name: "shipping-guide.md",
+        path: "docs/shipping-guide.md",
+      },
+    ];
+    const db = {
+      select: () => ({
+        from: () => Promise.resolve(assets),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets?q=refund");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockContextAsset[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(1);
+  });
+
+  it("project_id でラベル付け済み素材に絞り込める", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ context_asset_id: 1 }]);
+            }
+            return Promise.resolve([]);
+          },
+        }),
+      }),
+    };
+
+    const app = buildApp({
+      ...db,
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => Promise.resolve([sampleAsset, { ...sampleAsset, id: 2 }]),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([{ context_asset_id: 1 }]),
+          }),
+        };
+      },
+    });
+
+    const res = await app.request("/api/context-assets?project_id=10");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockContextAsset[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(1);
+  });
+
+  it("unclassified=true でラベル未設定の素材だけ返す", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => Promise.resolve([sampleAsset, { ...sampleAsset, id: 2 }]),
+          };
+        }
+        return {
+          select: undefined,
+          from: () => Promise.resolve([{ context_asset_id: 1 }]),
+        };
+      },
+    });
+
+    const res = await app.request("/api/context-assets?unclassified=true");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockContextAsset[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(2);
+  });
+
+  it("linked_to=test_case:* で関連素材に絞り込める", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => Promise.resolve([sampleAsset, { ...sampleAsset, id: 2 }]),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([{ context_asset_id: 2 }]),
+          }),
+        };
+      },
+    });
+
+    const res = await app.request("/api/context-assets?linked_to=test_case:12");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockContextAsset[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(2);
+  });
+
+  it("linked_to=prompt_family:* で関連素材に絞り込める", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => Promise.resolve([sampleAsset, { ...sampleAsset, id: 2 }]),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([{ context_asset_id: 1 }]),
+          }),
+        };
+      },
+    });
+
+    const res = await app.request("/api/context-assets?linked_to=prompt_family:4");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockContextAsset[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.id).toBe(1);
+  });
+
+  it("不正な project_id は 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/context-assets?project_id=abc");
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid project_id" });
+  });
+});
+
+describe("POST /api/context-assets", () => {
+  it("新規作成して 201 を返す", async () => {
+    const created = { ...sampleAsset };
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            returning: () => Promise.resolve([created]),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: sampleAsset.name,
+        path: sampleAsset.path,
+        content: sampleAsset.content,
+        mime_type: sampleAsset.mime_type,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(capturedValues.name).toBe(sampleAsset.name);
+    expect(capturedValues.path).toBe(sampleAsset.path);
+    expect(capturedValues.mime_type).toBe(sampleAsset.mime_type);
+    expect(typeof capturedValues.content_hash).toBe("string");
+  });
+
+  it("name が空なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/context-assets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "",
+        path: sampleAsset.path,
+        content: sampleAsset.content,
+        mime_type: sampleAsset.mime_type,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/context-assets/:id", () => {
+  it("詳細を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleAsset]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/1");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(sampleAsset);
+  });
+
+  it("見つからない場合は 404 を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/999");
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "ContextAsset not found" });
+  });
+});
+
+describe("PATCH /api/context-assets/:id", () => {
+  it("更新して 200 を返す", async () => {
+    const updated = { ...sampleAsset, name: "refund-policy-v2.md", updated_at: 2000000 };
+    let capturedValues: Record<string, unknown> = {};
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleAsset]),
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          capturedValues = values;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "refund-policy-v2.md", content: "更新後本文" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedValues.name).toBe("refund-policy-v2.md");
+    expect(capturedValues.content).toBe("更新後本文");
+    expect(typeof capturedValues.content_hash).toBe("string");
+  });
+
+  it("更新項目が空なら 400 を返す", async () => {
+    const res = await buildApp({}).request("/api/context-assets/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/context-assets/:id", () => {
+  it("関連付けを外してから削除し 204 を返す", async () => {
+    let deleteCallCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleAsset]),
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCallCount++;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+    expect(deleteCallCount).toBe(4);
+  });
+});
+
+describe("PUT /api/context-assets/:id/projects", () => {
+  it("project_ids で関連ラベルを全置換する", async () => {
+    let selectCallCount = 0;
+    const inserted: Array<{ context_asset_id: number; project_id: number }> = [];
+    let deleteCalled = false;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleAsset]);
+            }
+            return Promise.resolve([{ id: 10 }]);
+          },
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
+      }),
+      insert: () => ({
+        values: (values: { context_asset_id: number; project_id: number }) => {
+          inserted.push(values);
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_ids: [10, 10, 11] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deleteCalled).toBe(true);
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0]).toMatchObject({ context_asset_id: 1, project_id: 10 });
+    expect(inserted[1]).toMatchObject({ context_asset_id: 1, project_id: 11 });
+  });
+
+  it("存在しない project を指定すると 404 を返す", async () => {
+    let selectCallCount = 0;
+    let deleteCalled = false;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([sampleAsset]);
+            }
+            return Promise.resolve([]);
+          },
+        }),
+      }),
+      delete: () => ({
+        where: () => {
+          deleteCalled = true;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const res = await buildApp(db).request("/api/context-assets/1/projects", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project_ids: [999] }),
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Project not found" });
+    expect(deleteCalled).toBe(false);
+  });
+});

--- a/packages/server/src/routes/context-assets.ts
+++ b/packages/server/src/routes/context-assets.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto";
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import {
+  context_asset_projects,
+  context_assets,
+  projects,
+  prompt_family_context_assets,
+  test_case_context_assets,
+} from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createContextAssetSchema = z.object({
+  name: z.string().min(1, "nameは1文字以上必要です"),
+  path: z.string().min(1, "pathは1文字以上必要です"),
+  content: z.string(),
+  mime_type: z.string().min(1, "mime_typeは1文字以上必要です"),
+});
+
+const updateContextAssetSchema = z
+  .object({
+    name: z.string().min(1, "nameは1文字以上必要です").optional(),
+    path: z.string().min(1, "pathは1文字以上必要です").optional(),
+    content: z.string().optional(),
+    mime_type: z.string().min(1, "mime_typeは1文字以上必要です").optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "更新項目が必要です",
+  });
+
+const updateContextAssetProjectsSchema = z.object({
+  project_ids: z.array(z.number().int().positive("project_idは正の整数が必要です")),
+});
+
+type ContextAssetRecord = typeof context_assets.$inferSelect;
+
+function parseIdParam(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function parseOptionalInt(value: string | undefined): number | null | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function parseBooleanQuery(value: string | undefined): boolean | null | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return null;
+}
+
+function parseLinkedTo(
+  value: string | undefined,
+): { type: "test_case"; id: number } | { type: "prompt_family"; id: number } | null | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const [type, rawId] = value.split(":");
+  const id = parseOptionalInt(rawId);
+  if (id === null || id === undefined) {
+    return null;
+  }
+
+  if (type === "test_case") {
+    return { type: "test_case", id };
+  }
+  if (type === "prompt_family") {
+    return { type: "prompt_family", id };
+  }
+
+  return null;
+}
+
+function buildContentHash(content: string): string {
+  return `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
+}
+
+function filterByQuery(
+  assets: ContextAssetRecord[],
+  query: string | undefined,
+): ContextAssetRecord[] {
+  const normalized = query?.trim().toLocaleLowerCase();
+  if (!normalized) {
+    return assets;
+  }
+
+  return assets.filter((asset) => {
+    return (
+      asset.name.toLocaleLowerCase().includes(normalized) ||
+      asset.path.toLocaleLowerCase().includes(normalized)
+    );
+  });
+}
+
+function filterByIds(assets: ContextAssetRecord[], ids: Set<number>): ContextAssetRecord[] {
+  return assets.filter((asset) => ids.has(asset.id));
+}
+
+export function createContextAssetsRouter(db: DB) {
+  const router = new Hono();
+
+  router.get("/", async (c) => {
+    const projectId = parseOptionalInt(c.req.query("project_id"));
+    if (projectId === null) {
+      return c.json({ error: "Invalid project_id" }, 400);
+    }
+
+    const unclassified = parseBooleanQuery(c.req.query("unclassified"));
+    if (unclassified === null) {
+      return c.json({ error: "Invalid unclassified" }, 400);
+    }
+
+    const linkedTo = parseLinkedTo(c.req.query("linked_to"));
+    if (linkedTo === null) {
+      return c.json({ error: "Invalid linked_to" }, 400);
+    }
+
+    let assets = await db.select().from(context_assets);
+    assets = filterByQuery(assets, c.req.query("q"));
+
+    if (projectId !== undefined) {
+      const links = await db
+        .select({ context_asset_id: context_asset_projects.context_asset_id })
+        .from(context_asset_projects)
+        .where(eq(context_asset_projects.project_id, projectId));
+      assets = filterByIds(assets, new Set(links.map((link) => link.context_asset_id)));
+    }
+
+    if (unclassified === true) {
+      const links = await db
+        .select({ context_asset_id: context_asset_projects.context_asset_id })
+        .from(context_asset_projects);
+      const linkedIds = new Set(links.map((link) => link.context_asset_id));
+      assets = assets.filter((asset) => !linkedIds.has(asset.id));
+    }
+
+    if (linkedTo !== undefined) {
+      const links =
+        linkedTo.type === "test_case"
+          ? await db
+              .select({ context_asset_id: test_case_context_assets.context_asset_id })
+              .from(test_case_context_assets)
+              .where(eq(test_case_context_assets.test_case_id, linkedTo.id))
+          : await db
+              .select({ context_asset_id: prompt_family_context_assets.context_asset_id })
+              .from(prompt_family_context_assets)
+              .where(eq(prompt_family_context_assets.prompt_family_id, linkedTo.id));
+
+      assets = filterByIds(assets, new Set(links.map((link) => link.context_asset_id)));
+    }
+
+    assets.sort((a, b) => b.updated_at - a.updated_at || a.id - b.id);
+    return c.json(assets);
+  });
+
+  router.post("/", zValidator("json", createContextAssetSchema), async (c) => {
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [created] = await db
+      .insert(context_assets)
+      .values({
+        name: body.name,
+        path: body.path,
+        content: body.content,
+        mime_type: body.mime_type,
+        content_hash: buildContentHash(body.content),
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    if (!created) {
+      return c.json({ error: "Failed to create ContextAsset" }, 500);
+    }
+
+    return c.json(created, 201);
+  });
+
+  router.get("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [asset] = await db.select().from(context_assets).where(eq(context_assets.id, id));
+    if (!asset) {
+      return c.json({ error: "ContextAsset not found" }, 404);
+    }
+
+    return c.json(asset);
+  });
+
+  router.patch("/:id", zValidator("json", updateContextAssetSchema), async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(context_assets).where(eq(context_assets.id, id));
+    if (!existing) {
+      return c.json({ error: "ContextAsset not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const nextContent = body.content ?? existing.content;
+    const updateData: {
+      name?: string;
+      path?: string;
+      content?: string;
+      mime_type?: string;
+      content_hash?: string;
+      updated_at: number;
+    } = {
+      updated_at: Date.now(),
+    };
+
+    if (body.name !== undefined) updateData.name = body.name;
+    if (body.path !== undefined) updateData.path = body.path;
+    if (body.content !== undefined) updateData.content = body.content;
+    if (body.mime_type !== undefined) updateData.mime_type = body.mime_type;
+    if (body.content !== undefined) {
+      updateData.content_hash = buildContentHash(nextContent);
+    }
+
+    const [updated] = await db
+      .update(context_assets)
+      .set(updateData)
+      .where(eq(context_assets.id, id))
+      .returning();
+
+    if (!updated) {
+      return c.json({ error: "Failed to update ContextAsset" }, 500);
+    }
+
+    return c.json(updated);
+  });
+
+  router.delete("/:id", async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(context_assets).where(eq(context_assets.id, id));
+    if (!existing) {
+      return c.json({ error: "ContextAsset not found" }, 404);
+    }
+
+    await db.delete(context_asset_projects).where(eq(context_asset_projects.context_asset_id, id));
+    await db
+      .delete(test_case_context_assets)
+      .where(eq(test_case_context_assets.context_asset_id, id));
+    await db
+      .delete(prompt_family_context_assets)
+      .where(eq(prompt_family_context_assets.context_asset_id, id));
+    await db.delete(context_assets).where(eq(context_assets.id, id));
+
+    return c.body(null, 204);
+  });
+
+  router.put("/:id/projects", zValidator("json", updateContextAssetProjectsSchema), async (c) => {
+    const id = parseIdParam(c.req.param("id"));
+    if (id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(context_assets).where(eq(context_assets.id, id));
+    if (!existing) {
+      return c.json({ error: "ContextAsset not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const projectIds = [...new Set(body.project_ids)];
+
+    for (const projectId of projectIds) {
+      const [project] = await db.select().from(projects).where(eq(projects.id, projectId));
+      if (!project) {
+        return c.json({ error: "Project not found" }, 404);
+      }
+    }
+
+    await db.delete(context_asset_projects).where(eq(context_asset_projects.context_asset_id, id));
+
+    for (const projectId of projectIds) {
+      await db.insert(context_asset_projects).values({
+        context_asset_id: id,
+        project_id: projectId,
+        created_at: Date.now(),
+      });
+    }
+
+    return c.json(existing);
+  });
+
+  return router;
+}

--- a/packages/server/src/routes/context-assets.ts
+++ b/packages/server/src/routes/context-assets.ts
@@ -35,6 +35,7 @@ const updateContextAssetProjectsSchema = z.object({
 });
 
 type ContextAssetRecord = typeof context_assets.$inferSelect;
+type ContextAssetSummary = Omit<ContextAssetRecord, "content">;
 
 function parseIdParam(value: string): number | null {
   const parsed = Number(value);
@@ -111,6 +112,11 @@ function filterByIds(assets: ContextAssetRecord[], ids: Set<number>): ContextAss
   return assets.filter((asset) => ids.has(asset.id));
 }
 
+function serializeContextAssetSummary(asset: ContextAssetRecord): ContextAssetSummary {
+  const { content: _content, ...summary } = asset;
+  return summary;
+}
+
 export function createContextAssetsRouter(db: DB) {
   const router = new Hono();
 
@@ -165,7 +171,7 @@ export function createContextAssetsRouter(db: DB) {
     }
 
     assets.sort((a, b) => b.updated_at - a.updated_at || a.id - b.id);
-    return c.json(assets);
+    return c.json(assets.map(serializeContextAssetSummary));
   });
 
   router.post("/", zValidator("json", createContextAssetSchema), async (c) => {


### PR DESCRIPTION
## 概要
- context-assets ルーターを追加して CRUD API を実装
- q / project_id / unclassified / linked_to フィルタに対応
- project ラベル全置換 API とルーティング配線、ルートテストを追加

## テスト
- pnpm run test -- packages/server/src/routes/context-assets.test.ts
- pnpm run typecheck
- pnpm run check

Closes #114