### PR TITLE
Issue #139 annotation 設計キックオフ条件を整理

### DIFF
--- a/doc/annotation-feature-spec.md
+++ b/doc/annotation-feature-spec.md
@@ -308,6 +308,82 @@ Labels:
 - AI の抽出結果は JSON 契約に寄せる
 - 初期 Task は `会話価値抽出` を基本とする
 
+## 設計キックオフ条件
+
+annotation の本格設計を開始してよいのは、次の前提がすべて文書として確認できる状態になってからとする。
+
+1. `context_assets` / `test_cases` / `runs` の責務境界が固まっている
+2. annotation 対象本文の source of truth が決まっている
+3. run から Candidate を作る接続点が決まっている
+
+この文書では、以下の節でその前提を固定する。
+
+- `annotation対象本文の責務`
+- `runs と Candidate の接続設計`
+
+なお、旧 project 親子モデルの互換レイヤ削除（Issue #21）はこの開始条件に含めない。annotation の設計は、旧導線が残っていても上記前提が固まっていれば始めてよい。
+
+## 初回設計スコープ
+
+初回 annotation 設計は、最小限の review ループを成立させることに集中する。
+
+固定するスコープ:
+
+- `span_label`
+- Candidate / Gold Annotation の分離
+- Review 画面
+
+初回設計に含めるもの:
+
+- Task / Label の最小モデル
+- line range ベースの annotation
+- run 出力からの Candidate 生成
+- Candidate の採用 / 却下 / 修正
+- Gold Annotation の保存
+- 本文表示とハイライト
+
+初回設計に含めないもの:
+
+- 文書全体分類専用モード
+- 階層構造や relation 抽出
+- 文字単位の厳密な offset 編集
+- annotator 複数人対応
+- annotation versioning
+- 高度な export / analytics
+- `context_assets.content` 直接 annotation
+
+## 実装 Issue の切り方
+
+annotation 実装は、少なくとも次の 4 系統に分けて Issue 化する。
+
+### 1. schema / migration
+
+- Task / Label / Candidate / Gold Annotation の永続化モデル
+- `run_id` / `target_text_ref` / review status の保持
+- 必要なら将来拡張に備えた最小限の履歴カラム
+
+### 2. API
+
+- Task / Label CRUD
+- Candidate 一覧取得
+- Candidate の採用 / 却下 / 修正
+- Gold Annotation の作成 / 更新
+- Runs から Candidate 生成を呼び出す接続
+
+### 3. UI
+
+- Task Settings 画面
+- Annotation Review 画面
+- Runs 画面から Review 画面への導線
+
+### 4. import / review
+
+- `structured_json` / `final_answer` から Candidate JSON を解釈する処理
+- 行番号と quote の整合チェック
+- Review 画面での本文ハイライト
+
+この 4 分割を先に固定しておくことで、annotation の本格設計を開始する時点で実装 Issue の粒度を揃えやすくする。
+
 ## annotation対象本文の責務
 
 ### annotation 一次対象

--- a/doc/migration-plan.md
+++ b/doc/migration-plan.md
@@ -1113,3 +1113,86 @@ annotation 機能の本格設計は、少なくとも次が終わってから始
 逆に、Issue 21 の完了は annotation 設計開始の必須条件ではない。
 
 旧互換レイヤが残っていても、上記の前提が固まっていれば annotation の本格設計には着手できる。
+
+## annotation 設計キックオフ条件
+
+annotation の本格設計を開始してよい条件は、次の 3 つが文書として固定されていること。
+
+1. `context_assets` / `test_cases` / `runs` の責務境界が説明できる
+2. annotation 対象本文の source of truth が決まっている
+3. run から Candidate を作る接続点が決まっている
+
+それぞれの確認先:
+
+- 責務境界
+  - `context_assets` は素材置き場
+  - `test_cases.context_content` は annotation 対象本文のスナップショット
+  - `runs` は run 出力保存と Candidate 生成トリガーを担う
+- source of truth
+  - annotation 一次対象は `test_cases.context_content`
+  - 改行正規化と行番号ルールが定義済み
+- Candidate 接続点
+  - Candidate 生成元は `final_answer` / `structured_json` / `trace_step`
+  - 初期実装では `structured_json` 優先、なければ `final_answer`
+  - Candidate 生成トリガーは Runs 側の責務として扱う
+
+上記が固まっていれば、旧互換 UI / API の削除前でも annotation 設計を始めてよい。つまり Issue 21 の完了は annotation 設計開始条件に含めない。
+
+## annotation 初回設計スコープ
+
+Issue 24 時点で固定する初回設計スコープは次のとおり。
+
+- `span_label` のみを扱う
+- Candidate と Gold Annotation を分離して扱う
+- Review 画面を中心に操作フローを設計する
+
+初回スコープに含める具体項目:
+
+- Task / Label の最小モデル
+- Candidate の最小メタデータ
+- Gold Annotation の最小フィールド
+- Run から Candidate を生成して Review へ渡す導線
+- Review 画面での採用 / 却下 / 修正
+
+初回スコープから除外する項目:
+
+- 文書全体分類専用モード
+- 階層ラベルや関係抽出
+- 文字単位の厳密な span 編集
+- annotator 複数人対応
+- annotation の版管理
+- 高度な export / 集計機能
+- `context_assets.content` 直接 annotation
+
+## 次に起票する annotation 実装 Issue の粒度
+
+annotation の本格設計を実装へ落とす際は、少なくとも以下の 4 系統に分けて Issue を切る。
+
+1. schema / migration
+2. API
+3. UI
+4. import / review
+
+想定する粒度:
+
+- schema / migration
+  - `annotation_tasks`
+  - `annotation_labels`
+  - `annotation_candidates`
+  - `gold_annotations`
+  - 必要なら review 操作履歴や状態管理の最小カラム
+- API
+  - Task / Label CRUD
+  - Candidate 一覧、採用 / 却下 / 修正
+  - Gold Annotation の作成 / 更新
+  - Runs からの Candidate 生成トリガー接続
+- UI
+  - Task Settings 画面
+  - Annotation Review 画面
+  - Runs から Review への導線
+- import / review
+  - run 出力から Candidate JSON を解釈する処理
+  - `structured_json` / `final_answer` のフォールバック方針実装
+  - 本文ハイライトと行番号整合の確認
+
+この分け方により、annotation 設計を始める時点で「どこまでを 1 Issue に閉じ込めるか」が先に見えるようにする。


### PR DESCRIPTION
## 概要
- annotation 設計を開始してよい前提条件を doc/migration-plan.md に明文化
- 初回 annotation 設計スコープと除外範囲を doc/annotation-feature-spec.md に明文化
- 次に切る annotation 実装 Issue の粒度を schema / API / UI / import-review の4系統で整理

## 変更内容
- doc/migration-plan.md
  - annotation 設計キックオフ条件を追加
  - 初回設計スコープと除外範囲を追加
  - 次に起票する実装 Issue の粒度を追加
- doc/annotation-feature-spec.md
  - 設計キックオフ条件を追加
  - 初回設計スコープを追加
  - 実装 Issue の切り方を追加
  - Issue #21 完了は設計開始の必須条件ではないことを明記

## 検証
- pnpm run check
- pnpm run test
- pnpm run typecheck は既存の packages/core/src/seed.ts の型エラーで失敗