### PR TITLE
fix: seed.ts の test_cases 挿入を現行スキーマに合わせて修正 (#145)

### DIFF
--- a/packages/core/src/seed.ts
+++ b/packages/core/src/seed.ts
@@ -91,7 +91,6 @@ async function seed() {
     await db
       .insert(schema.test_cases)
       .values({
-        project_id: project.id,
         title: "配送遅延の問い合わせ",
         turns: turns1,
         context_content:
@@ -111,7 +110,6 @@ async function seed() {
     await db
       .insert(schema.test_cases)
       .values({
-        project_id: project.id,
         title: "返品条件外の返品依頼（マルチターン）",
         turns: turns2,
         context_content:
@@ -126,6 +124,13 @@ async function seed() {
     "testCase2",
   );
   console.log(`テストケース2作成: id=${testCase2.id}`);
+
+  // テストケースとプロジェクトの関連付け
+  await db.insert(schema.test_case_projects).values([
+    { test_case_id: testCase1.id, project_id: project.id, created_at: now },
+    { test_case_id: testCase2.id, project_id: project.id, created_at: now },
+  ]);
+  console.log("テストケースとプロジェクトを関連付けました");
 
   // 4. プロンプトファミリー作成
   const promptFamily = getFirstOrThrow(


### PR DESCRIPTION
## Summary

- `seed.ts` の `test_cases` INSERT から `project_id` を削除
- `test_case_projects` 中間テーブルへの INSERT を追加してプロジェクト関連付けを維持
- `pnpm run typecheck` と `pnpm run check` が通ることを確認済み

## 背景

`test_cases` テーブルの設計変更により `project_id` が削除され、`test_case_projects` 中間テーブルで関連付けを管理する構造に変更された。しかし `seed.ts` が旧スキーマのままだったため型エラーが発生していた。

## Test plan

- [x] `pnpm run typecheck` が通ることを確認
- [x] `pnpm run check` (biome) が通ることを確認

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)