### PR TITLE
feat: annotation 初回実装の schema / migration を追加する

### DIFF
--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     "./src/schema/prompt-versions.ts",
     "./src/schema/runs.ts",
     "./src/schema/scores.ts",
+    "./src/schema/annotations.ts",
   ],
   out: "./drizzle",
   dbCredentials: {

--- a/packages/core/drizzle/0015_noisy_gauntlet.sql
+++ b/packages/core/drizzle/0015_noisy_gauntlet.sql
@@ -1,0 +1,95 @@
+CREATE TABLE `annotation_candidates` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`run_id` integer NOT NULL,
+	`annotation_task_id` integer NOT NULL,
+	`target_text_ref` text NOT NULL,
+	`source_type` text NOT NULL,
+	`source_step_id` text,
+	`label` text NOT NULL,
+	`start_line` integer NOT NULL,
+	`end_line` integer NOT NULL,
+	`quote` text NOT NULL,
+	`rationale` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`note` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`run_id`) REFERENCES `runs`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `annotation_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`annotation_task_id` integer NOT NULL,
+	`key` text NOT NULL,
+	`name` text NOT NULL,
+	`color` text,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `annotation_labels_task_key_unique` ON `annotation_labels` (`annotation_task_id`,`key`);--> statement-breakpoint
+CREATE TABLE `annotation_tasks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`output_mode` text DEFAULT 'span_label' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `gold_annotations` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`annotation_task_id` integer NOT NULL,
+	`target_text_ref` text NOT NULL,
+	`label` text NOT NULL,
+	`start_line` integer NOT NULL,
+	`end_line` integer NOT NULL,
+	`quote` text NOT NULL,
+	`note` text,
+	`source_candidate_id` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`source_candidate_id`) REFERENCES `annotation_candidates`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_test_cases` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`title` text NOT NULL,
+	`turns` text NOT NULL,
+	`context_content` text DEFAULT '' NOT NULL,
+	`expected_description` text,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_test_cases`("id", "title", "turns", "context_content", "expected_description", "display_order", "created_at", "updated_at") SELECT "id", "title", "turns", "context_content", "expected_description", "display_order", "created_at", "updated_at" FROM `test_cases`;--> statement-breakpoint
+DROP TABLE `test_cases`;--> statement-breakpoint
+ALTER TABLE `__new_test_cases` RENAME TO `test_cases`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_prompt_versions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`prompt_family_id` integer NOT NULL,
+	`project_id` integer,
+	`version` integer NOT NULL,
+	`name` text,
+	`memo` text,
+	`content` text NOT NULL,
+	`workflow_definition` text,
+	`parent_version_id` integer,
+	`created_at` integer NOT NULL,
+	`is_selected` integer DEFAULT false NOT NULL,
+	FOREIGN KEY (`prompt_family_id`) REFERENCES `prompt_families`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`parent_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_prompt_versions`("id", "prompt_family_id", "project_id", "version", "name", "memo", "content", "workflow_definition", "parent_version_id", "created_at", "is_selected") SELECT "id", "prompt_family_id", "project_id", "version", "name", "memo", "content", "workflow_definition", "parent_version_id", "created_at", "is_selected" FROM `prompt_versions`;--> statement-breakpoint
+DROP TABLE `prompt_versions`;--> statement-breakpoint
+ALTER TABLE `__new_prompt_versions` RENAME TO `prompt_versions`;--> statement-breakpoint
+ALTER TABLE `runs` ADD `structured_output` text;

--- a/packages/core/drizzle/0015_noisy_gauntlet.sql
+++ b/packages/core/drizzle/0015_noisy_gauntlet.sql
@@ -1,3 +1,27 @@
+CREATE TABLE `annotation_tasks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`output_mode` text DEFAULT 'span_label' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT "annotation_tasks_output_mode_check" CHECK("annotation_tasks"."output_mode" in ('span_label'))
+);
+--> statement-breakpoint
+CREATE TABLE `annotation_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`annotation_task_id` integer NOT NULL,
+	`key` text NOT NULL,
+	`name` text NOT NULL,
+	`color` text,
+	`display_order` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `annotation_labels_task_key_unique` ON `annotation_labels` (`annotation_task_id`,`key`);
+--> statement-breakpoint
 CREATE TABLE `annotation_candidates` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
 	`run_id` integer NOT NULL,
@@ -15,29 +39,9 @@ CREATE TABLE `annotation_candidates` (
 	`created_at` integer NOT NULL,
 	`updated_at` integer NOT NULL,
 	FOREIGN KEY (`run_id`) REFERENCES `runs`(`id`) ON UPDATE no action ON DELETE no action,
-	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
-CREATE TABLE `annotation_labels` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`annotation_task_id` integer NOT NULL,
-	`key` text NOT NULL,
-	`name` text NOT NULL,
-	`color` text,
-	`display_order` integer DEFAULT 0 NOT NULL,
-	`created_at` integer NOT NULL,
-	`updated_at` integer NOT NULL,
-	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
-CREATE UNIQUE INDEX `annotation_labels_task_key_unique` ON `annotation_labels` (`annotation_task_id`,`key`);--> statement-breakpoint
-CREATE TABLE `annotation_tasks` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`name` text NOT NULL,
-	`description` text,
-	`output_mode` text DEFAULT 'span_label' NOT NULL,
-	`created_at` integer NOT NULL,
-	`updated_at` integer NOT NULL
+	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "annotation_candidates_source_type_check" CHECK("annotation_candidates"."source_type" in ('final_answer', 'structured_json', 'trace_step')),
+	CONSTRAINT "annotation_candidates_status_check" CHECK("annotation_candidates"."status" in ('pending', 'accepted', 'rejected'))
 );
 --> statement-breakpoint
 CREATE TABLE `gold_annotations` (
@@ -55,41 +59,3 @@ CREATE TABLE `gold_annotations` (
 	FOREIGN KEY (`annotation_task_id`) REFERENCES `annotation_tasks`(`id`) ON UPDATE no action ON DELETE no action,
 	FOREIGN KEY (`source_candidate_id`) REFERENCES `annotation_candidates`(`id`) ON UPDATE no action ON DELETE no action
 );
---> statement-breakpoint
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
-CREATE TABLE `__new_test_cases` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`title` text NOT NULL,
-	`turns` text NOT NULL,
-	`context_content` text DEFAULT '' NOT NULL,
-	`expected_description` text,
-	`display_order` integer DEFAULT 0 NOT NULL,
-	`created_at` integer NOT NULL,
-	`updated_at` integer NOT NULL
-);
---> statement-breakpoint
-INSERT INTO `__new_test_cases`("id", "title", "turns", "context_content", "expected_description", "display_order", "created_at", "updated_at") SELECT "id", "title", "turns", "context_content", "expected_description", "display_order", "created_at", "updated_at" FROM `test_cases`;--> statement-breakpoint
-DROP TABLE `test_cases`;--> statement-breakpoint
-ALTER TABLE `__new_test_cases` RENAME TO `test_cases`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
-CREATE TABLE `__new_prompt_versions` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`prompt_family_id` integer NOT NULL,
-	`project_id` integer,
-	`version` integer NOT NULL,
-	`name` text,
-	`memo` text,
-	`content` text NOT NULL,
-	`workflow_definition` text,
-	`parent_version_id` integer,
-	`created_at` integer NOT NULL,
-	`is_selected` integer DEFAULT false NOT NULL,
-	FOREIGN KEY (`prompt_family_id`) REFERENCES `prompt_families`(`id`) ON UPDATE no action ON DELETE no action,
-	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
-	FOREIGN KEY (`parent_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
-INSERT INTO `__new_prompt_versions`("id", "prompt_family_id", "project_id", "version", "name", "memo", "content", "workflow_definition", "parent_version_id", "created_at", "is_selected") SELECT "id", "prompt_family_id", "project_id", "version", "name", "memo", "content", "workflow_definition", "parent_version_id", "created_at", "is_selected" FROM `prompt_versions`;--> statement-breakpoint
-DROP TABLE `prompt_versions`;--> statement-breakpoint
-ALTER TABLE `__new_prompt_versions` RENAME TO `prompt_versions`;--> statement-breakpoint
-ALTER TABLE `runs` ADD `structured_output` text;

--- a/packages/core/drizzle/meta/0015_snapshot.json
+++ b/packages/core/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1394 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fc76cd12-cbaf-465b-9bed-8528c8bea533",
+  "prevId": "ba577263-9a6b-48c9-88f8-c8026a37ca8f",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_settings_project_id_unique": {
+          "name": "project_settings_project_id_unique",
+          "columns": ["project_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_families": {
+      "name": "prompt_families",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_profiles": {
+      "name": "execution_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "execution_profiles_name_unique": {
+          "name": "execution_profiles_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_assets": {
+      "name": "context_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_asset_projects": {
+      "name": "context_asset_projects",
+      "columns": {
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "context_asset_projects_context_asset_id_context_assets_id_fk": {
+          "name": "context_asset_projects_context_asset_id_context_assets_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_asset_projects_project_id_projects_id_fk": {
+          "name": "context_asset_projects_project_id_projects_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "context_asset_projects_context_asset_id_project_id_pk": {
+          "columns": ["context_asset_id", "project_id"],
+          "name": "context_asset_projects_context_asset_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_family_context_assets": {
+      "name": "prompt_family_context_assets",
+      "columns": {
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "prompt_families",
+          "columnsFrom": ["prompt_family_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_family_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "prompt_family_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_family_context_assets_prompt_family_id_context_asset_id_pk": {
+          "columns": ["prompt_family_id", "context_asset_id"],
+          "name": "prompt_family_context_assets_prompt_family_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_version_projects": {
+      "name": "prompt_version_projects",
+      "columns": {
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_version_projects_prompt_version_id_prompt_versions_id_fk": {
+          "name": "prompt_version_projects_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["prompt_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_version_projects_project_id_projects_id_fk": {
+          "name": "prompt_version_projects_project_id_projects_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_version_projects_prompt_version_id_project_id_pk": {
+          "columns": ["prompt_version_id", "project_id"],
+          "name": "prompt_version_projects_prompt_version_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_context_assets": {
+      "name": "test_case_context_assets",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_context_assets_test_case_id_test_cases_id_fk": {
+          "name": "test_case_context_assets_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "test_case_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": ["context_asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_context_assets_test_case_id_context_asset_id_pk": {
+          "columns": ["test_case_id", "context_asset_id"],
+          "name": "test_case_context_assets_test_case_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_projects": {
+      "name": "test_case_projects",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_projects_test_case_id_test_cases_id_fk": {
+          "name": "test_case_projects_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_projects_project_id_projects_id_fk": {
+          "name": "test_case_projects_project_id_projects_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_projects_test_case_id_project_id_pk": {
+          "columns": ["test_case_id", "project_id"],
+          "name": "test_case_projects_test_case_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_definition": {
+          "name": "workflow_definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_versions_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_families",
+          "columnsFrom": ["prompt_family_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["parent_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "execution_profile_id": {
+          "name": "execution_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_execution_profile_id_execution_profiles_id_fk": {
+          "name": "runs_execution_profile_id_execution_profiles_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "execution_profiles",
+          "columnsFrom": ["execution_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "prompt_versions",
+          "columnsFrom": ["prompt_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_reason": {
+          "name": "judge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_run_id_runs_id_fk": {
+          "name": "scores_run_id_runs_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotation_candidates": {
+      "name": "annotation_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text_ref": {
+          "name": "target_text_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_step_id": {
+          "name": "source_step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "annotation_candidates_run_id_runs_id_fk": {
+          "name": "annotation_candidates_run_id_runs_id_fk",
+          "tableFrom": "annotation_candidates",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "annotation_candidates_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "annotation_candidates_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "annotation_candidates",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": ["annotation_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotation_labels": {
+      "name": "annotation_labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "annotation_labels_task_key_unique": {
+          "name": "annotation_labels_task_key_unique",
+          "columns": ["annotation_task_id", "key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "annotation_labels_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "annotation_labels_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "annotation_labels",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": ["annotation_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotation_tasks": {
+      "name": "annotation_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_mode": {
+          "name": "output_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'span_label'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gold_annotations": {
+      "name": "gold_annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text_ref": {
+          "name": "target_text_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_candidate_id": {
+          "name": "source_candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gold_annotations_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "gold_annotations_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "gold_annotations",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": ["annotation_task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gold_annotations_source_candidate_id_annotation_candidates_id_fk": {
+          "name": "gold_annotations_source_candidate_id_annotation_candidates_id_fk",
+          "tableFrom": "gold_annotations",
+          "tableTo": "annotation_candidates",
+          "columnsFrom": ["source_candidate_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/0015_snapshot.json
+++ b/packages/core/drizzle/meta/0015_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "fc76cd12-cbaf-465b-9bed-8528c8bea533",
-  "prevId": "ba577263-9a6b-48c9-88f8-c8026a37ca8f",
+  "id": "b4ca6c35-a32e-471e-b66a-bc5fb5a5181d",
+  "prevId": "fc76cd12-cbaf-465b-9bed-8528c8bea533",
   "tables": {
     "project_settings": {
       "name": "project_settings",
@@ -1136,7 +1136,16 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
-      "checkConstraints": {}
+      "checkConstraints": {
+        "annotation_candidates_source_type_check": {
+          "name": "annotation_candidates_source_type_check",
+          "value": "\"annotation_candidates\".\"source_type\" in ('final_answer', 'structured_json', 'trace_step')"
+        },
+        "annotation_candidates_status_check": {
+          "name": "annotation_candidates_status_check",
+          "value": "\"annotation_candidates\".\"status\" in ('pending', 'accepted', 'rejected')"
+        }
+      }
     },
     "annotation_labels": {
       "name": "annotation_labels",
@@ -1272,7 +1281,12 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
-      "checkConstraints": {}
+      "checkConstraints": {
+        "annotation_tasks_output_mode_check": {
+          "name": "annotation_tasks_output_mode_check",
+          "value": "\"annotation_tasks\".\"output_mode\" in ('span_label')"
+        }
+      }
     },
     "gold_annotations": {
       "name": "gold_annotations",

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776640800000,
       "tag": "0014_runs_structured_output",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1776658349002,
+      "tag": "0015_noisy_gauntlet",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/schema-check.ts
+++ b/packages/core/src/db/schema-check.ts
@@ -4,6 +4,32 @@ import Database from "better-sqlite3";
 const expectedSchema = {
   prompt_versions: ["workflow_definition"],
   runs: ["execution_trace", "structured_output"],
+  annotation_tasks: ["name", "description", "output_mode"],
+  annotation_labels: ["annotation_task_id", "key", "name", "color", "display_order"],
+  annotation_candidates: [
+    "run_id",
+    "annotation_task_id",
+    "target_text_ref",
+    "source_type",
+    "source_step_id",
+    "label",
+    "start_line",
+    "end_line",
+    "quote",
+    "rationale",
+    "status",
+    "note",
+  ],
+  gold_annotations: [
+    "annotation_task_id",
+    "target_text_ref",
+    "label",
+    "start_line",
+    "end_line",
+    "quote",
+    "note",
+    "source_candidate_id",
+  ],
 } as const;
 
 function getColumns(db: Database.Database, tableName: string): string[] {

--- a/packages/core/src/schema/annotations.test.ts
+++ b/packages/core/src/schema/annotations.test.ts
@@ -1,0 +1,282 @@
+/**
+ * annotations スキーマの型定義テスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * ここではDBへの実際の接続なしにスキーマの型安全性のみを検証する。
+ * マイグレーションの動作検証は `pnpm run migrate` で別途確認済み。
+ */
+import { describe, expectTypeOf, it } from "vitest";
+import type {
+  AnnotationCandidate,
+  AnnotationCandidateStatus,
+  AnnotationLabel,
+  AnnotationOutputMode,
+  AnnotationSourceType,
+  AnnotationTask,
+  GoldAnnotation,
+  NewAnnotationCandidate,
+  NewAnnotationLabel,
+  NewAnnotationTask,
+  NewGoldAnnotation,
+} from "./annotations.js";
+
+describe("annotation_tasks スキーマ型定義", () => {
+  it("AnnotationTask は必須フィールドを持つ", () => {
+    type RequiredFields = {
+      id: number;
+      name: string;
+      output_mode: "span_label";
+      created_at: number;
+      updated_at: number;
+    };
+    expectTypeOf<
+      Pick<AnnotationTask, "id" | "name" | "output_mode" | "created_at" | "updated_at">
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("AnnotationTask の description はオプショナル（null許容）", () => {
+    expectTypeOf<AnnotationTask["description"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("AnnotationTask の output_mode は span_label のみ許容", () => {
+    expectTypeOf<AnnotationTask["output_mode"]>().toEqualTypeOf<"span_label">();
+  });
+
+  it("NewAnnotationTask は id なしで作成できる（AutoIncrement）", () => {
+    const now = Date.now();
+    const task: NewAnnotationTask = {
+      name: "会話価値抽出",
+      output_mode: "span_label",
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(task).toMatchTypeOf<NewAnnotationTask>();
+  });
+
+  it("NewAnnotationTask の output_mode はデフォルト値があるためオプショナル", () => {
+    expectTypeOf<NewAnnotationTask["output_mode"]>().toEqualTypeOf<"span_label" | undefined>();
+  });
+});
+
+describe("annotation_labels スキーマ型定義", () => {
+  it("AnnotationLabel は必須フィールドを持つ", () => {
+    type RequiredFields = {
+      id: number;
+      annotation_task_id: number;
+      key: string;
+      name: string;
+      display_order: number;
+      created_at: number;
+      updated_at: number;
+    };
+    expectTypeOf<
+      Pick<
+        AnnotationLabel,
+        "id" | "annotation_task_id" | "key" | "name" | "display_order" | "created_at" | "updated_at"
+      >
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("AnnotationLabel の color はオプショナル（null許容）", () => {
+    expectTypeOf<AnnotationLabel["color"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("NewAnnotationLabel を作成できる", () => {
+    const now = Date.now();
+    const label: NewAnnotationLabel = {
+      annotation_task_id: 1,
+      key: "insight",
+      name: "気づき",
+      color: "#FF5733",
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(label).toMatchTypeOf<NewAnnotationLabel>();
+  });
+
+  it("NewAnnotationLabel の display_order はデフォルト値があるためオプショナル", () => {
+    expectTypeOf<NewAnnotationLabel["display_order"]>().toEqualTypeOf<number | undefined>();
+  });
+});
+
+describe("annotation_candidates スキーマ型定義", () => {
+  it("AnnotationCandidate は必須フィールドを持つ", () => {
+    type RequiredFields = {
+      id: number;
+      run_id: number;
+      annotation_task_id: number;
+      target_text_ref: string;
+      source_type: "final_answer" | "structured_json" | "trace_step";
+      label: string;
+      start_line: number;
+      end_line: number;
+      quote: string;
+      status: "pending" | "accepted" | "rejected";
+      created_at: number;
+      updated_at: number;
+    };
+    expectTypeOf<
+      Pick<
+        AnnotationCandidate,
+        | "id"
+        | "run_id"
+        | "annotation_task_id"
+        | "target_text_ref"
+        | "source_type"
+        | "label"
+        | "start_line"
+        | "end_line"
+        | "quote"
+        | "status"
+        | "created_at"
+        | "updated_at"
+      >
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("AnnotationCandidate の source_step_id はオプショナル（null許容）", () => {
+    expectTypeOf<AnnotationCandidate["source_step_id"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("AnnotationCandidate の rationale はオプショナル（null許容）", () => {
+    expectTypeOf<AnnotationCandidate["rationale"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("AnnotationCandidate の note はオプショナル（null許容）", () => {
+    expectTypeOf<AnnotationCandidate["note"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("AnnotationCandidate の status は pending / accepted / rejected のみ許容", () => {
+    expectTypeOf<AnnotationCandidate["status"]>().toEqualTypeOf<
+      "pending" | "accepted" | "rejected"
+    >();
+  });
+
+  it("NewAnnotationCandidate を structured_json ソースで作成できる", () => {
+    const now = Date.now();
+    const candidate: NewAnnotationCandidate = {
+      run_id: 1,
+      annotation_task_id: 1,
+      target_text_ref: "test_case:42",
+      source_type: "structured_json",
+      label: "insight",
+      start_line: 5,
+      end_line: 8,
+      quote: "新しい認識が含まれているため",
+      rationale: "気づきのパターンに一致する",
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(candidate).toMatchTypeOf<NewAnnotationCandidate>();
+  });
+
+  it("NewAnnotationCandidate を trace_step ソースで作成できる", () => {
+    const now = Date.now();
+    const candidate: NewAnnotationCandidate = {
+      run_id: 2,
+      annotation_task_id: 1,
+      target_text_ref: "test_case:42",
+      source_type: "trace_step",
+      source_step_id: "step-001",
+      label: "action_trigger",
+      start_line: 12,
+      end_line: 15,
+      quote: "行動を促す表現が含まれる",
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(candidate).toMatchTypeOf<NewAnnotationCandidate>();
+  });
+
+  it("NewAnnotationCandidate の status はデフォルト値があるためオプショナル", () => {
+    expectTypeOf<NewAnnotationCandidate["status"]>().toEqualTypeOf<
+      "pending" | "accepted" | "rejected" | undefined
+    >();
+  });
+});
+
+describe("gold_annotations スキーマ型定義", () => {
+  it("GoldAnnotation は必須フィールドを持つ", () => {
+    type RequiredFields = {
+      id: number;
+      annotation_task_id: number;
+      target_text_ref: string;
+      label: string;
+      start_line: number;
+      end_line: number;
+      quote: string;
+      created_at: number;
+      updated_at: number;
+    };
+    expectTypeOf<
+      Pick<
+        GoldAnnotation,
+        | "id"
+        | "annotation_task_id"
+        | "target_text_ref"
+        | "label"
+        | "start_line"
+        | "end_line"
+        | "quote"
+        | "created_at"
+        | "updated_at"
+      >
+    >().toMatchTypeOf<RequiredFields>();
+  });
+
+  it("GoldAnnotation の note はオプショナル（null許容）", () => {
+    expectTypeOf<GoldAnnotation["note"]>().toEqualTypeOf<string | null>();
+  });
+
+  it("GoldAnnotation の source_candidate_id はオプショナル（null許容）", () => {
+    expectTypeOf<GoldAnnotation["source_candidate_id"]>().toEqualTypeOf<number | null>();
+  });
+
+  it("NewGoldAnnotation を候補採用で作成できる", () => {
+    const now = Date.now();
+    const gold: NewGoldAnnotation = {
+      annotation_task_id: 1,
+      target_text_ref: "test_case:42",
+      label: "insight",
+      start_line: 5,
+      end_line: 8,
+      quote: "新しい認識が含まれているため",
+      source_candidate_id: 10,
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(gold).toMatchTypeOf<NewGoldAnnotation>();
+  });
+
+  it("NewGoldAnnotation を手動作成できる（source_candidate_id なし）", () => {
+    const now = Date.now();
+    const gold: NewGoldAnnotation = {
+      annotation_task_id: 1,
+      target_text_ref: "test_case:42",
+      label: "idea",
+      start_line: 20,
+      end_line: 22,
+      quote: "アイディアの断片",
+      note: "手動で追加したアノテーション",
+      created_at: now,
+      updated_at: now,
+    };
+    expectTypeOf(gold).toMatchTypeOf<NewGoldAnnotation>();
+  });
+});
+
+describe("AnnotationSourceType / AnnotationCandidateStatus / AnnotationOutputMode ユーティリティ型", () => {
+  it("AnnotationSourceType は 3 種類の値を持つ", () => {
+    expectTypeOf<AnnotationSourceType>().toEqualTypeOf<
+      "final_answer" | "structured_json" | "trace_step"
+    >();
+  });
+
+  it("AnnotationCandidateStatus は 3 種類の値を持つ", () => {
+    expectTypeOf<AnnotationCandidateStatus>().toEqualTypeOf<"pending" | "accepted" | "rejected">();
+  });
+
+  it("AnnotationOutputMode は span_label のみ", () => {
+    expectTypeOf<AnnotationOutputMode>().toEqualTypeOf<"span_label">();
+  });
+});

--- a/packages/core/src/schema/annotations.ts
+++ b/packages/core/src/schema/annotations.ts
@@ -1,0 +1,89 @@
+import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { runs } from "./runs";
+
+export const annotation_tasks = sqliteTable("annotation_tasks", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  description: text("description"),
+  output_mode: text("output_mode", { enum: ["span_label"] })
+    .notNull()
+    .default("span_label"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export const annotation_labels = sqliteTable(
+  "annotation_labels",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    annotation_task_id: integer("annotation_task_id")
+      .notNull()
+      .references(() => annotation_tasks.id),
+    key: text("key").notNull(),
+    name: text("name").notNull(),
+    color: text("color"),
+    display_order: integer("display_order").notNull().default(0),
+    created_at: integer("created_at").notNull(),
+    updated_at: integer("updated_at").notNull(),
+  },
+  (t) => [uniqueIndex("annotation_labels_task_key_unique").on(t.annotation_task_id, t.key)],
+);
+
+export const annotation_candidates = sqliteTable("annotation_candidates", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  run_id: integer("run_id")
+    .notNull()
+    .references(() => runs.id),
+  annotation_task_id: integer("annotation_task_id")
+    .notNull()
+    .references(() => annotation_tasks.id),
+  // "test_case:{id}" 形式。将来 "context_asset:{id}" へ拡張可能
+  target_text_ref: text("target_text_ref").notNull(),
+  source_type: text("source_type", {
+    enum: ["final_answer", "structured_json", "trace_step"],
+  }).notNull(),
+  source_step_id: text("source_step_id"),
+  label: text("label").notNull(),
+  start_line: integer("start_line").notNull(),
+  end_line: integer("end_line").notNull(),
+  quote: text("quote").notNull(),
+  rationale: text("rationale"),
+  status: text("status", { enum: ["pending", "accepted", "rejected"] })
+    .notNull()
+    .default("pending"),
+  note: text("note"),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export const gold_annotations = sqliteTable("gold_annotations", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  annotation_task_id: integer("annotation_task_id")
+    .notNull()
+    .references(() => annotation_tasks.id),
+  target_text_ref: text("target_text_ref").notNull(),
+  label: text("label").notNull(),
+  start_line: integer("start_line").notNull(),
+  end_line: integer("end_line").notNull(),
+  quote: text("quote").notNull(),
+  note: text("note"),
+  source_candidate_id: integer("source_candidate_id").references(() => annotation_candidates.id),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+});
+
+export type AnnotationTask = typeof annotation_tasks.$inferSelect;
+export type NewAnnotationTask = typeof annotation_tasks.$inferInsert;
+
+export type AnnotationLabel = typeof annotation_labels.$inferSelect;
+export type NewAnnotationLabel = typeof annotation_labels.$inferInsert;
+
+export type AnnotationCandidate = typeof annotation_candidates.$inferSelect;
+export type NewAnnotationCandidate = typeof annotation_candidates.$inferInsert;
+
+export type GoldAnnotation = typeof gold_annotations.$inferSelect;
+export type NewGoldAnnotation = typeof gold_annotations.$inferInsert;
+
+export type AnnotationSourceType = "final_answer" | "structured_json" | "trace_step";
+export type AnnotationCandidateStatus = "pending" | "accepted" | "rejected";
+export type AnnotationOutputMode = "span_label";

--- a/packages/core/src/schema/annotations.ts
+++ b/packages/core/src/schema/annotations.ts
@@ -1,16 +1,21 @@
-import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { check, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { runs } from "./runs";
 
-export const annotation_tasks = sqliteTable("annotation_tasks", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  name: text("name").notNull(),
-  description: text("description"),
-  output_mode: text("output_mode", { enum: ["span_label"] })
-    .notNull()
-    .default("span_label"),
-  created_at: integer("created_at").notNull(),
-  updated_at: integer("updated_at").notNull(),
-});
+export const annotation_tasks = sqliteTable(
+  "annotation_tasks",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    name: text("name").notNull(),
+    description: text("description"),
+    output_mode: text("output_mode", { enum: ["span_label"] })
+      .notNull()
+      .default("span_label"),
+    created_at: integer("created_at").notNull(),
+    updated_at: integer("updated_at").notNull(),
+  },
+  (t) => [check("annotation_tasks_output_mode_check", sql`${t.output_mode} in ('span_label')`)],
+);
 
 export const annotation_labels = sqliteTable(
   "annotation_labels",
@@ -29,32 +34,45 @@ export const annotation_labels = sqliteTable(
   (t) => [uniqueIndex("annotation_labels_task_key_unique").on(t.annotation_task_id, t.key)],
 );
 
-export const annotation_candidates = sqliteTable("annotation_candidates", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  run_id: integer("run_id")
-    .notNull()
-    .references(() => runs.id),
-  annotation_task_id: integer("annotation_task_id")
-    .notNull()
-    .references(() => annotation_tasks.id),
-  // "test_case:{id}" 形式。将来 "context_asset:{id}" へ拡張可能
-  target_text_ref: text("target_text_ref").notNull(),
-  source_type: text("source_type", {
-    enum: ["final_answer", "structured_json", "trace_step"],
-  }).notNull(),
-  source_step_id: text("source_step_id"),
-  label: text("label").notNull(),
-  start_line: integer("start_line").notNull(),
-  end_line: integer("end_line").notNull(),
-  quote: text("quote").notNull(),
-  rationale: text("rationale"),
-  status: text("status", { enum: ["pending", "accepted", "rejected"] })
-    .notNull()
-    .default("pending"),
-  note: text("note"),
-  created_at: integer("created_at").notNull(),
-  updated_at: integer("updated_at").notNull(),
-});
+export const annotation_candidates = sqliteTable(
+  "annotation_candidates",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    run_id: integer("run_id")
+      .notNull()
+      .references(() => runs.id),
+    annotation_task_id: integer("annotation_task_id")
+      .notNull()
+      .references(() => annotation_tasks.id),
+    // "test_case:{id}" 形式。将来 "context_asset:{id}" へ拡張可能
+    target_text_ref: text("target_text_ref").notNull(),
+    source_type: text("source_type", {
+      enum: ["final_answer", "structured_json", "trace_step"],
+    }).notNull(),
+    source_step_id: text("source_step_id"),
+    label: text("label").notNull(),
+    start_line: integer("start_line").notNull(),
+    end_line: integer("end_line").notNull(),
+    quote: text("quote").notNull(),
+    rationale: text("rationale"),
+    status: text("status", { enum: ["pending", "accepted", "rejected"] })
+      .notNull()
+      .default("pending"),
+    note: text("note"),
+    created_at: integer("created_at").notNull(),
+    updated_at: integer("updated_at").notNull(),
+  },
+  (t) => [
+    check(
+      "annotation_candidates_source_type_check",
+      sql`${t.source_type} in ('final_answer', 'structured_json', 'trace_step')`,
+    ),
+    check(
+      "annotation_candidates_status_check",
+      sql`${t.status} in ('pending', 'accepted', 'rejected')`,
+    ),
+  ],
+);
 
 export const gold_annotations = sqliteTable("gold_annotations", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -11,3 +11,4 @@ export * from "./test-cases";
 export * from "./prompt-versions";
 export * from "./runs";
 export * from "./scores";
+export * from "./annotations";


### PR DESCRIPTION
## Summary

- `annotation_tasks` / `annotation_labels` / `annotation_candidates` / `gold_annotations` テーブルを追加
- `annotation_labels` に task 内 `key` 一意制約を追加（`uniqueIndex`）
- `annotation_candidates.status` は `pending` / `accepted` / `rejected` のみ許容（enum制約）
- `target_text_ref` は `"test_case:{id}"` 形式、将来 `"context_asset:{id}"` へ拡張可能な設計
- `packages/core/drizzle/0015_noisy_gauntlet.sql` マイグレーションファイルを生成
- `schema-check.ts` に annotation 4テーブルのカラム検証を追加
- 型テスト 25件を追加（`annotations.test.ts`）

## Test plan

- [x] `pnpm run check` — biome チェック通過
- [x] `pnpm run typecheck` — TypeScript 型チェック通過
- [x] `npx vitest run` — 354件テスト全パス（annotation 型テスト 25件含む）
- [x] `pnpm --filter @prompt-reviewer/core generate` — マイグレーションファイル生成確認済み

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)