### PR TITLE
feat: annotation済みtest caseのcontext_content更新を禁止する

### DIFF
--- a/packages/server/src/lib/annotation-guard.ts
+++ b/packages/server/src/lib/annotation-guard.ts
@@ -1,0 +1,27 @@
+import type { DB } from "@prompt-reviewer/core";
+import { annotation_candidates, gold_annotations } from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
+
+/**
+ * 指定した test case に annotation データ（候補または確定）が存在するか確認する。
+ * 存在する場合は context_content の更新を禁止するために使用する。
+ */
+export async function hasAnnotationData(db: DB, testCaseId: number): Promise<boolean> {
+  const ref = `test_case:${testCaseId}`;
+
+  const [candidate] = await db
+    .select({ id: annotation_candidates.id })
+    .from(annotation_candidates)
+    .where(eq(annotation_candidates.target_text_ref, ref))
+    .limit(1);
+
+  if (candidate) return true;
+
+  const [gold] = await db
+    .select({ id: gold_annotations.id })
+    .from(gold_annotations)
+    .where(eq(gold_annotations.target_text_ref, ref))
+    .limit(1);
+
+  return !!gold;
+}

--- a/packages/server/src/routes/test-cases.test.ts
+++ b/packages/server/src/routes/test-cases.test.ts
@@ -549,6 +549,152 @@ describe("PATCH /api/test-cases/:id", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Invalid ID");
   });
+
+  it("Candidateが存在するtest caseのcontext_content更新は409を返す", async () => {
+    let fromCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => {
+          fromCallCount++;
+          if (fromCallCount === 1) {
+            return {
+              where: () => Promise.resolve([sampleTestCase]),
+            };
+          }
+          // annotation_candidates チェック
+          return {
+            where: () => ({
+              limit: () => Promise.resolve([{ id: 99 }]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ context_content: "新しいコンテンツ" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("annotation済み");
+  });
+
+  it("Gold Annotationが存在するtest caseのcontext_content更新は409を返す", async () => {
+    let fromCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => {
+          fromCallCount++;
+          if (fromCallCount === 1) {
+            return {
+              where: () => Promise.resolve([sampleTestCase]),
+            };
+          }
+          if (fromCallCount === 2) {
+            // annotation_candidates チェック（空）
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([]),
+              }),
+            };
+          }
+          // gold_annotations チェック
+          return {
+            where: () => ({
+              limit: () => Promise.resolve([{ id: 55 }]),
+            }),
+          };
+        },
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ context_content: "新しいコンテンツ" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("annotation済み");
+  });
+
+  it("annotationが存在しないtest caseのcontext_contentは更新できる", async () => {
+    const updated = { ...sampleTestCase, context_content: "新しいコンテンツ", updated_at: 2000000 };
+
+    let fromCallCount = 0;
+    const db = {
+      select: () => ({
+        from: () => {
+          fromCallCount++;
+          if (fromCallCount === 1) {
+            return {
+              where: () => Promise.resolve([sampleTestCase]),
+            };
+          }
+          // annotation チェック（空 = annotationなし）
+          return {
+            where: () => ({
+              limit: () => Promise.resolve([]),
+            }),
+          };
+        },
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ context_content: "新しいコンテンツ" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ParsedTestCase;
+    expect(body.context_content).toBe("新しいコンテンツ");
+  });
+
+  it("Candidateありでもcontext_content以外のフィールド更新は許可される", async () => {
+    const updated = { ...sampleTestCase, title: "新しいタイトル", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleTestCase]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "新しいタイトル" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ParsedTestCase;
+    expect(body.title).toBe("新しいタイトル");
+  });
 });
 
 // ---- DELETE /api/test-cases/:id ----

--- a/packages/server/src/routes/test-cases.ts
+++ b/packages/server/src/routes/test-cases.ts
@@ -11,6 +11,7 @@ import type { Turn } from "@prompt-reviewer/core";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
+import { hasAnnotationData } from "../lib/annotation-guard.js";
 
 const turnSchema = z.object({
   role: z.enum(["user", "assistant"]),
@@ -184,6 +185,15 @@ export function createTestCasesRouter(db: DB) {
     }
 
     const body = c.req.valid("json");
+
+    // context_content を更新しようとしている場合、annotation データの存在確認
+    if (body.context_content !== undefined) {
+      const frozen = await hasAnnotationData(db, id);
+      if (frozen) {
+        return c.json({ error: "annotation済みのtest caseのcontext_contentは更新できません" }, 409);
+      }
+    }
+
     const updateData: {
       title?: string;
       turns?: string;


### PR DESCRIPTION
## Summary

- `annotation_candidates` または `gold_annotations` が存在する test case の `context_content` 更新を `PATCH /test-cases/:id` で 409 エラーとして拒否する
- 判定ロジックを `packages/server/src/lib/annotation-guard.ts` の `hasAnnotationData()` に集約（route ごとの重複を排除）
- `context_content` 以外のフィールド（title, turns 等）の更新は従来どおり許可

## Test plan

- [x] Candidate が存在する test case の `context_content` 更新 → 409
- [x] Gold Annotation が存在する test case の `context_content` 更新 → 409  
- [x] annotation なしの test case の `context_content` 更新 → 200
- [x] annotation ありでも `context_content` 以外のフィールド更新 → 200
- [x] 全 358 テスト通過

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)