### PR TITLE
feat: Annotation Task / Label API を追加する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,10 @@ import { serve } from "@hono/node-server";
 import { assertRequiredSchema, db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import {
+  createAnnotationLabelsRouter,
+  createAnnotationTasksRouter,
+} from "./routes/annotation-tasks.js";
 import { createContextAssetsRouter } from "./routes/context-assets.js";
 import { createContextFilesRouter } from "./routes/context-files.js";
 import { createExecutionProfilesRouter } from "./routes/execution-profiles.js";
@@ -72,6 +76,8 @@ app.get("/api/health", (c) => {
   return c.json({ status: "ok" });
 });
 
+app.route("/api/annotation-tasks", createAnnotationTasksRouter(db));
+app.route("/api/annotation-labels", createAnnotationLabelsRouter(db));
 app.route("/api/context-assets", createContextAssetsRouter(db));
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/execution-profiles", createExecutionProfilesRouter(db));

--- a/packages/server/src/routes/annotation-tasks.test.ts
+++ b/packages/server/src/routes/annotation-tasks.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Annotation Task / Label CRUD エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createAnnotationLabelsRouter, createAnnotationTasksRouter } from "./annotation-tasks.js";
+
+// ---- 型定義 ----
+
+type MockTask = {
+  id: number;
+  name: string;
+  description: string | null;
+  output_mode: "span_label";
+  created_at: number;
+  updated_at: number;
+};
+
+type MockLabel = {
+  id: number;
+  annotation_task_id: number;
+  key: string;
+  name: string;
+  color: string | null;
+  display_order: number;
+  created_at: number;
+  updated_at: number;
+};
+
+// ---- テスト用アプリビルダー ----
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/annotation-tasks", createAnnotationTasksRouter(db as DB));
+  app.route("/api/annotation-labels", createAnnotationLabelsRouter(db as DB));
+  return app;
+}
+
+// ---- テストデータ ----
+
+const sampleTask: MockTask = {
+  id: 1,
+  name: "テストタスク",
+  description: "説明文",
+  output_mode: "span_label",
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+const sampleLabel: MockLabel = {
+  id: 1,
+  annotation_task_id: 1,
+  key: "bug",
+  name: "バグ",
+  color: "#ff0000",
+  display_order: 0,
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+// ---- Task CRUD テスト ----
+
+describe("GET /api/annotation-tasks", () => {
+  it("タスク一覧を200で返す", async () => {
+    const tasks = [sampleTask, { ...sampleTask, id: 2, name: "別タスク" }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve(tasks),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockTask[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.name).toBe("テストタスク");
+    expect(body.at(1)?.name).toBe("別タスク");
+  });
+
+  it("タスクが0件のとき空配列を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          orderBy: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockTask[];
+    expect(body).toHaveLength(0);
+  });
+});
+
+describe("POST /api/annotation-tasks", () => {
+  it("バリデーション通過時に201でタスクを返す", async () => {
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([sampleTask]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストタスク", output_mode: "span_label" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockTask;
+    expect(body.name).toBe("テストタスク");
+    expect(body.output_mode).toBe("span_label");
+  });
+
+  it("name が空文字列のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "", output_mode: "span_label" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("output_mode が span_label 以外のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストタスク", output_mode: "invalid_mode" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("output_mode が未指定のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストタスク" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("description 省略時も正常に作成できる", async () => {
+    const created = { ...sampleTask, description: null };
+
+    const db = {
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "テストタスク", output_mode: "span_label" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockTask;
+    expect(body.description).toBeNull();
+  });
+});
+
+describe("GET /api/annotation-tasks/:id", () => {
+  it("存在するIDに対して200でタスクとlabelsを返す", async () => {
+    const labels = [sampleLabel];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleTask]),
+          orderBy: () => Promise.resolve(labels),
+        }),
+      }),
+    };
+
+    // labelsのselect用に追加のwhere/orderByチェーン対応
+    let selectCallCount = 0;
+    const dbWithLabels = {
+      select: () => {
+        selectCallCount++;
+        const callIndex = selectCallCount;
+        return {
+          from: () => ({
+            where: () => {
+              if (callIndex === 1) {
+                return Promise.resolve([sampleTask]);
+              }
+              return {
+                orderBy: () => Promise.resolve(labels),
+              };
+            },
+            orderBy: () => Promise.resolve([]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(dbWithLabels);
+    const res = await app.request("/api/annotation-tasks/1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockTask & { labels: MockLabel[] };
+    expect(body.id).toBe(1);
+    expect(body.name).toBe("テストタスク");
+    expect(Array.isArray(body.labels)).toBe(true);
+    expect(body.labels).toHaveLength(1);
+    expect(body.labels.at(0)?.key).toBe("bug");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/999");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation task not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/abc");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/annotation-tasks/:id", () => {
+  it("存在するIDに対して200で更新されたタスクを返す", async () => {
+    const updated = { ...sampleTask, name: "更新後のタスク", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleTask]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後のタスク" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockTask;
+    expect(body.name).toBe("更新後のタスク");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation task not found");
+  });
+
+  it("name が空文字列のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/annotation-tasks/:id", () => {
+  it("存在するIDに対して204を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleTask]),
+        }),
+      }),
+      delete: () => ({
+        where: () => Promise.resolve(),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/999", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation task not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/abc", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---- Label CRUD テスト ----
+
+describe("POST /api/annotation-tasks/:id/labels", () => {
+  it("バリデーション通過時に201でラベルを返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const callIndex = selectCallCount;
+        return {
+          from: () => ({
+            where: () => {
+              if (callIndex === 1) return Promise.resolve([sampleTask]);
+              // 重複チェック: 存在しない
+              return Promise.resolve([]);
+            },
+          }),
+        };
+      },
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([sampleLabel]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/1/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug", name: "バグ", color: "#ff0000" }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as MockLabel;
+    expect(body.key).toBe("bug");
+    expect(body.name).toBe("バグ");
+    expect(body.annotation_task_id).toBe(1);
+  });
+
+  it("同一task内で key が重複する場合409を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const callIndex = selectCallCount;
+        return {
+          from: () => ({
+            where: () => {
+              if (callIndex === 1) return Promise.resolve([sampleTask]);
+              // 重複チェック: 既存ラベルが存在する
+              return Promise.resolve([sampleLabel]);
+            },
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/1/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug", name: "重複バグ" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Label key already exists in this task");
+  });
+
+  it("key が空文字列のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/1/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "", name: "バグ" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("name が空文字列のとき400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/1/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug", name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("存在しないタスクIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-tasks/999/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug", name: "バグ" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation task not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-tasks/abc/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug", name: "バグ" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/annotation-labels/:id", () => {
+  it("存在するIDに対して200で更新されたラベルを返す", async () => {
+    const updated = { ...sampleLabel, name: "更新後のバグ", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleLabel]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-labels/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後のバグ" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockLabel;
+    expect(body.name).toBe("更新後のバグ");
+  });
+
+  it("key 変更時に同一task内で重複する場合409を返す", async () => {
+    const labelWithDifferentKey = { ...sampleLabel, id: 2, key: "other" };
+
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        const callIndex = selectCallCount;
+        return {
+          from: () => ({
+            where: () => {
+              if (callIndex === 1) return Promise.resolve([labelWithDifferentKey]);
+              // 重複チェック: 変更先keyが既存ラベルとぶつかる
+              return Promise.resolve([sampleLabel]);
+            },
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-labels/2", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bug" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Label key already exists in this task");
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-labels/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation label not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-labels/abc", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "更新後" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/annotation-labels/:id", () => {
+  it("存在するIDに対して204を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleLabel]),
+        }),
+      }),
+      delete: () => ({
+        where: () => Promise.resolve(),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-labels/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(204);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-labels/999", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation label not found");
+  });
+
+  it("数値以外のIDに対して400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-labels/abc", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/annotation-tasks.ts
+++ b/packages/server/src/routes/annotation-tasks.ts
@@ -1,0 +1,267 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { annotation_labels, annotation_tasks } from "@prompt-reviewer/core";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const createTaskSchema = z.object({
+  name: z.string().min(1, "名前は1文字以上必要です"),
+  description: z.string().optional(),
+  output_mode: z.literal("span_label"),
+});
+
+const updateTaskSchema = z.object({
+  name: z.string().min(1, "名前は1文字以上必要です").optional(),
+  description: z.string().nullable().optional(),
+});
+
+const createLabelSchema = z.object({
+  key: z.string().min(1, "keyは1文字以上必要です"),
+  name: z.string().min(1, "名前は1文字以上必要です"),
+  color: z.string().optional(),
+  display_order: z.number().int().optional(),
+});
+
+const updateLabelSchema = z.object({
+  key: z.string().min(1, "keyは1文字以上必要です").optional(),
+  name: z.string().min(1, "名前は1文字以上必要です").optional(),
+  color: z.string().nullable().optional(),
+  display_order: z.number().int().optional(),
+});
+
+export function createAnnotationTasksRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/annotation-tasks
+  router.get("/", async (c) => {
+    const result = await db.select().from(annotation_tasks).orderBy(annotation_tasks.id);
+    return c.json(result);
+  });
+
+  // POST /api/annotation-tasks
+  router.post("/", zValidator("json", createTaskSchema), async (c) => {
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [task] = await db
+      .insert(annotation_tasks)
+      .values({
+        name: body.name,
+        description: body.description ?? null,
+        output_mode: body.output_mode,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    return c.json(task, 201);
+  });
+
+  // GET /api/annotation-tasks/:id
+  router.get("/:id", async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [task] = await db.select().from(annotation_tasks).where(eq(annotation_tasks.id, id));
+
+    if (!task) {
+      return c.json({ error: "Annotation task not found" }, 404);
+    }
+
+    const labels = await db
+      .select()
+      .from(annotation_labels)
+      .where(eq(annotation_labels.annotation_task_id, id))
+      .orderBy(annotation_labels.display_order, annotation_labels.id);
+
+    return c.json({ ...task, labels });
+  });
+
+  // PATCH /api/annotation-tasks/:id
+  router.patch("/:id", zValidator("json", updateTaskSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    const [existing] = await db.select().from(annotation_tasks).where(eq(annotation_tasks.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Annotation task not found" }, 404);
+    }
+
+    const updateData: {
+      name?: string;
+      description?: string | null;
+      updated_at: number;
+    } = { updated_at: Date.now() };
+
+    if (body.name !== undefined) updateData.name = body.name;
+    if (body.description !== undefined) updateData.description = body.description;
+
+    const [updated] = await db
+      .update(annotation_tasks)
+      .set(updateData)
+      .where(eq(annotation_tasks.id, id))
+      .returning();
+
+    return c.json(updated);
+  });
+
+  // DELETE /api/annotation-tasks/:id
+  router.delete("/:id", async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db.select().from(annotation_tasks).where(eq(annotation_tasks.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Annotation task not found" }, 404);
+    }
+
+    await db.delete(annotation_tasks).where(eq(annotation_tasks.id, id));
+
+    return c.body(null, 204);
+  });
+
+  // POST /api/annotation-tasks/:id/labels
+  router.post("/:id/labels", zValidator("json", createLabelSchema), async (c) => {
+    const taskId = Number(c.req.param("id"));
+
+    if (Number.isNaN(taskId)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [task] = await db.select().from(annotation_tasks).where(eq(annotation_tasks.id, taskId));
+
+    if (!task) {
+      return c.json({ error: "Annotation task not found" }, 404);
+    }
+
+    const body = c.req.valid("json");
+    const now = Date.now();
+
+    const [existing] = await db
+      .select()
+      .from(annotation_labels)
+      .where(
+        and(eq(annotation_labels.annotation_task_id, taskId), eq(annotation_labels.key, body.key)),
+      );
+
+    if (existing) {
+      return c.json({ error: "Label key already exists in this task" }, 409);
+    }
+
+    const [label] = await db
+      .insert(annotation_labels)
+      .values({
+        annotation_task_id: taskId,
+        key: body.key,
+        name: body.name,
+        color: body.color ?? null,
+        display_order: body.display_order ?? 0,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
+
+    return c.json(label, 201);
+  });
+
+  return router;
+}
+
+export function createAnnotationLabelsRouter(db: DB) {
+  const router = new Hono();
+
+  // PATCH /api/annotation-labels/:id
+  router.patch("/:id", zValidator("json", updateLabelSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    const [existing] = await db
+      .select()
+      .from(annotation_labels)
+      .where(eq(annotation_labels.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Annotation label not found" }, 404);
+    }
+
+    if (body.key !== undefined && body.key !== existing.key) {
+      const [duplicate] = await db
+        .select()
+        .from(annotation_labels)
+        .where(
+          and(
+            eq(annotation_labels.annotation_task_id, existing.annotation_task_id),
+            eq(annotation_labels.key, body.key),
+          ),
+        );
+
+      if (duplicate) {
+        return c.json({ error: "Label key already exists in this task" }, 409);
+      }
+    }
+
+    const updateData: {
+      key?: string;
+      name?: string;
+      color?: string | null;
+      display_order?: number;
+      updated_at: number;
+    } = { updated_at: Date.now() };
+
+    if (body.key !== undefined) updateData.key = body.key;
+    if (body.name !== undefined) updateData.name = body.name;
+    if (body.color !== undefined) updateData.color = body.color;
+    if (body.display_order !== undefined) updateData.display_order = body.display_order;
+
+    const [updated] = await db
+      .update(annotation_labels)
+      .set(updateData)
+      .where(eq(annotation_labels.id, id))
+      .returning();
+
+    return c.json(updated);
+  });
+
+  // DELETE /api/annotation-labels/:id
+  router.delete("/:id", async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const [existing] = await db
+      .select()
+      .from(annotation_labels)
+      .where(eq(annotation_labels.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Annotation label not found" }, 404);
+    }
+
+    await db.delete(annotation_labels).where(eq(annotation_labels.id, id));
+
+    return c.body(null, 204);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `GET/POST/PATCH/DELETE /api/annotation-tasks` の CRUD エンドポイントを実装
- `POST /api/annotation-tasks/:id/labels` でラベル追加（同一タスク内 key 重複時 409 Conflict）
- `PATCH/DELETE /api/annotation-labels/:id` でラベル更新・削除
- `GET /api/annotation-tasks/:id` はタスク詳細に `labels` 配列を含むレスポンスを返す
- `output_mode` は `"span_label"` のみ許可（それ以外は 400 Bad Request）
- `packages/server/src/index.ts` に両ルーターを登録

## Test plan

- [x] Task CRUD テスト（一覧・詳細+labels・作成・更新・削除）
- [x] Label CRUD テスト（追加・更新・削除）
- [x] 同一 task 内 `key` 重複の 409 テスト
- [x] `output_mode` バリデーションテスト（span_label 以外で 400）
- [x] 存在しない ID への 404 テスト
- [x] 数値以外の ID への 400 テスト
- [x] `pnpm run check` / `pnpm run typecheck` / `pnpm run test` 全パス（384 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)