### PR TITLE
feat: run出力からannotation_candidatesを抽出するAPIを追加する

### DIFF
--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -1883,3 +1883,339 @@ describe("PATCH /api/projects/:projectId/runs/:id/discard", () => {
     expect(body.error).toBe("Run not found");
   });
 });
+
+// ---- candidates/extract テスト用データ ----
+
+const sampleAnnotationTask = {
+  id: 1,
+  name: "テストアノテーションタスク",
+  description: null,
+  output_mode: "span_label" as const,
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+const sampleAnnotationLabels = [{ key: "insight" }, { key: "question" }];
+
+const sampleRunWithStructuredOutput: MockRun = {
+  ...sampleRun,
+  structured_output: JSON.stringify({
+    items: [
+      {
+        label: "insight",
+        start_line: 1,
+        end_line: 3,
+        quote: "今日は晴れです。",
+        rationale: "天気についての洞察",
+      },
+    ],
+  }),
+};
+
+const sampleRunWithFinalAnswer: MockRun = {
+  ...sampleRun,
+  structured_output: null,
+  conversation: JSON.stringify([
+    { role: "user", content: "文章を分析してください" },
+    {
+      role: "assistant",
+      content: JSON.stringify({
+        items: [
+          {
+            label: "question",
+            start_line: 2,
+            end_line: 4,
+            quote: "何か問題がありますか？",
+          },
+        ],
+      }),
+    },
+  ]),
+};
+
+/**
+ * candidates/extract エンドポイント用のDBモック構築ヘルパー
+ *
+ * selectCallCount に対応するレスポンスを配列で指定する:
+ * 1. prompt_version_projects (versionIds)
+ * 2. runs (run取得)
+ * 3. annotation_tasks (task確認)
+ * 4. annotation_labels (labelキー一覧)
+ * 5. annotation_candidates (重複チェック)
+ */
+function buildExtractDb(params: {
+  run?: MockRun | null;
+  task?: typeof sampleAnnotationTask | null;
+  labels?: Array<{ key: string }>;
+  existingCandidate?: { id: number } | null;
+  insertReturns?: unknown[];
+}) {
+  const {
+    run = sampleRunWithStructuredOutput,
+    task = sampleAnnotationTask,
+    labels = sampleAnnotationLabels,
+    existingCandidate = null,
+    insertReturns = [],
+  } = params;
+
+  let selectCallCount = 0;
+
+  return {
+    select: () => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // prompt_version_projects
+        return {
+          from: () => ({
+            where: () => Promise.resolve(run !== null ? [{ prompt_version_id: 1 }] : []),
+          }),
+        };
+      }
+      if (selectCallCount === 2) {
+        // runs
+        return {
+          from: () => ({
+            where: () => Promise.resolve(run !== null ? [run] : []),
+          }),
+        };
+      }
+      if (selectCallCount === 3) {
+        // annotation_tasks
+        return {
+          from: () => ({
+            where: () => Promise.resolve(task !== null ? [task] : []),
+          }),
+        };
+      }
+      if (selectCallCount === 4) {
+        // annotation_labels
+        return {
+          from: () => ({
+            where: () => Promise.resolve(labels),
+          }),
+        };
+      }
+      // annotation_candidates 重複チェック
+      return {
+        from: () => ({
+          where: () => Promise.resolve(existingCandidate !== null ? [existingCandidate] : []),
+        }),
+      };
+    },
+    insert: () => ({
+      values: () => ({
+        returning: () => Promise.resolve(insertReturns),
+      }),
+    }),
+  };
+}
+
+describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
+  it("structured_output から Candidate を生成して 201 を返す", async () => {
+    const insertedCandidate = {
+      id: 1,
+      run_id: 1,
+      annotation_task_id: 1,
+      target_text_ref: "test_case:1",
+      source_type: "structured_json",
+      source_step_id: null,
+      label: "insight",
+      start_line: 1,
+      end_line: 3,
+      quote: "今日は晴れです。",
+      rationale: "天気についての洞察",
+      status: "pending",
+      note: null,
+      created_at: 1000000,
+      updated_at: 1000000,
+    };
+
+    const db = buildExtractDb({ insertReturns: [insertedCandidate] });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as (typeof insertedCandidate)[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.source_type).toBe("structured_json");
+    expect(body[0]?.label).toBe("insight");
+    expect(body[0]?.target_text_ref).toBe("test_case:1");
+    expect(body[0]?.status).toBe("pending");
+  });
+
+  it("final_answer（最後の assistant メッセージの JSON）からフォールバックして 201 を返す", async () => {
+    const insertedCandidate = {
+      id: 2,
+      run_id: 1,
+      annotation_task_id: 1,
+      target_text_ref: "test_case:1",
+      source_type: "final_answer",
+      source_step_id: null,
+      label: "question",
+      start_line: 2,
+      end_line: 4,
+      quote: "何か問題がありますか？",
+      rationale: null,
+      status: "pending",
+      note: null,
+      created_at: 1000000,
+      updated_at: 1000000,
+    };
+
+    const db = buildExtractDb({
+      run: sampleRunWithFinalAnswer,
+      insertReturns: [insertedCandidate],
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as (typeof insertedCandidate)[];
+    expect(body).toHaveLength(1);
+    expect(body[0]?.source_type).toBe("final_answer");
+    expect(body[0]?.label).toBe("question");
+  });
+
+  it("存在しない label を含む場合は 400 を返す", async () => {
+    const runWithInvalidLabel: MockRun = {
+      ...sampleRun,
+      structured_output: JSON.stringify({
+        items: [
+          {
+            label: "nonexistent_label",
+            start_line: 1,
+            end_line: 2,
+            quote: "テスト",
+          },
+        ],
+      }),
+    };
+
+    const db = buildExtractDb({ run: runWithInvalidLabel });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("nonexistent_label");
+  });
+
+  it("start_line > end_line の不正 line range で 400 を返す", async () => {
+    const runWithInvalidRange: MockRun = {
+      ...sampleRun,
+      structured_output: JSON.stringify({
+        items: [
+          {
+            label: "insight",
+            start_line: 5,
+            end_line: 2,
+            quote: "テスト",
+          },
+        ],
+      }),
+    };
+
+    const db = buildExtractDb({ run: runWithInvalidRange });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("start_line");
+    expect(body.error).toContain("end_line");
+  });
+
+  it("final_answer で JSON パース失敗の場合は 400 を返す（items フィールドなし）", async () => {
+    const runWithInvalidJson: MockRun = {
+      ...sampleRun,
+      structured_output: null,
+      conversation: JSON.stringify([
+        { role: "user", content: "分析してください" },
+        {
+          role: "assistant",
+          content: JSON.stringify({ result: "no_items_field" }),
+        },
+      ]),
+    };
+
+    const db = buildExtractDb({ run: runWithInvalidJson });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("invalid format");
+  });
+
+  it("重複抽出時に 409 を返す", async () => {
+    const db = buildExtractDb({
+      existingCandidate: { id: 99 },
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("already extracted");
+  });
+
+  it("run が存在しない場合は 404 を返す", async () => {
+    const db = buildExtractDb({ run: null });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/999/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Run not found");
+  });
+
+  it("annotation_task が存在しない場合は 404 を返す", async () => {
+    const db = buildExtractDb({ task: null });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 999 }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation task not found");
+  });
+});

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -1933,6 +1933,30 @@ const sampleRunWithFinalAnswer: MockRun = {
   ]),
 };
 
+const sampleRunWithTraceStep: MockRun = {
+  ...sampleRun,
+  execution_trace: JSON.stringify([
+    {
+      id: "step-1",
+      title: "抽出ステップ",
+      prompt: "候補を抽出する",
+      renderedPrompt: "候補を抽出する",
+      inputConversation: sampleConversation,
+      output: JSON.stringify({
+        items: [
+          {
+            label: "insight",
+            start_line: 3,
+            end_line: 5,
+            quote: "途中ステップからの候補",
+            rationale: "trace_step由来",
+          },
+        ],
+      }),
+    },
+  ]),
+};
+
 /**
  * candidates/extract エンドポイント用のDBモック構築ヘルパー
  *
@@ -1949,6 +1973,7 @@ function buildExtractDb(params: {
   labels?: Array<{ key: string }>;
   existingCandidate?: { id: number } | null;
   insertReturns?: unknown[];
+  insertedValues?: Record<string, unknown>[] | null;
 }) {
   const {
     run = sampleRunWithStructuredOutput,
@@ -1956,6 +1981,7 @@ function buildExtractDb(params: {
     labels = sampleAnnotationLabels,
     existingCandidate = null,
     insertReturns = [],
+    insertedValues = null,
   } = params;
 
   let selectCallCount = 0;
@@ -2003,34 +2029,22 @@ function buildExtractDb(params: {
       };
     },
     insert: () => ({
-      values: () => ({
-        returning: () => Promise.resolve(insertReturns),
-      }),
+      values: (values: Record<string, unknown>[]) => {
+        if (insertedValues) {
+          insertedValues.push(...values);
+        }
+        return {
+          returning: () => Promise.resolve(insertReturns),
+        };
+      },
     }),
   };
 }
 
 describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
   it("structured_output から Candidate を生成して 201 を返す", async () => {
-    const insertedCandidate = {
-      id: 1,
-      run_id: 1,
-      annotation_task_id: 1,
-      target_text_ref: "test_case:1",
-      source_type: "structured_json",
-      source_step_id: null,
-      label: "insight",
-      start_line: 1,
-      end_line: 3,
-      quote: "今日は晴れです。",
-      rationale: "天気についての洞察",
-      status: "pending",
-      note: null,
-      created_at: 1000000,
-      updated_at: 1000000,
-    };
-
-    const db = buildExtractDb({ insertReturns: [insertedCandidate] });
+    const insertedValues: Record<string, unknown>[] = [];
+    const db = buildExtractDb({ insertReturns: [{ id: 1 }], insertedValues });
 
     const app = buildApp(db);
     const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
@@ -2040,36 +2054,32 @@ describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
     });
 
     expect(res.status).toBe(201);
-    const body = (await res.json()) as (typeof insertedCandidate)[];
-    expect(body).toHaveLength(1);
-    expect(body[0]?.source_type).toBe("structured_json");
-    expect(body[0]?.label).toBe("insight");
-    expect(body[0]?.target_text_ref).toBe("test_case:1");
-    expect(body[0]?.status).toBe("pending");
+    const body = (await res.json()) as {
+      candidates_created: number;
+      run_id: number;
+      annotation_task_id: number;
+    };
+    expect(body).toEqual({
+      candidates_created: 1,
+      run_id: 1,
+      annotation_task_id: 1,
+    });
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "structured_json",
+        label: "insight",
+        target_text_ref: "test_case:1",
+        status: "pending",
+      }),
+    ]);
   });
 
-  it("final_answer（最後の assistant メッセージの JSON）からフォールバックして 201 を返す", async () => {
-    const insertedCandidate = {
-      id: 2,
-      run_id: 1,
-      annotation_task_id: 1,
-      target_text_ref: "test_case:1",
-      source_type: "final_answer",
-      source_step_id: null,
-      label: "question",
-      start_line: 2,
-      end_line: 4,
-      quote: "何か問題がありますか？",
-      rationale: null,
-      status: "pending",
-      note: null,
-      created_at: 1000000,
-      updated_at: 1000000,
-    };
-
+  it("source_type を省略した場合は final_answer にフォールバックして 201 を返す", async () => {
+    const insertedValues: Record<string, unknown>[] = [];
     const db = buildExtractDb({
       run: sampleRunWithFinalAnswer,
-      insertReturns: [insertedCandidate],
+      insertReturns: [{ id: 2 }],
+      insertedValues,
     });
 
     const app = buildApp(db);
@@ -2080,10 +2090,79 @@ describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
     });
 
     expect(res.status).toBe(201);
-    const body = (await res.json()) as (typeof insertedCandidate)[];
-    expect(body).toHaveLength(1);
-    expect(body[0]?.source_type).toBe("final_answer");
-    expect(body[0]?.label).toBe("question");
+    const body = (await res.json()) as {
+      candidates_created: number;
+      run_id: number;
+      annotation_task_id: number;
+    };
+    expect(body).toEqual({
+      candidates_created: 1,
+      run_id: 1,
+      annotation_task_id: 1,
+    });
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "final_answer",
+        label: "question",
+      }),
+    ]);
+  });
+
+  it("source_type=final_answer を明示すると structured_output があっても final_answer を使う", async () => {
+    const runWithBothSources: MockRun = {
+      ...sampleRunWithStructuredOutput,
+      conversation: sampleRunWithFinalAnswer.conversation,
+    };
+    const insertedValues: Record<string, unknown>[] = [];
+    const db = buildExtractDb({
+      run: runWithBothSources,
+      insertReturns: [{ id: 3 }],
+      insertedValues,
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1, source_type: "final_answer" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "final_answer",
+        label: "question",
+      }),
+    ]);
+  });
+
+  it("source_type=trace_step と source_step_id を指定すると対象 step から抽出する", async () => {
+    const insertedValues: Record<string, unknown>[] = [];
+    const db = buildExtractDb({
+      run: sampleRunWithTraceStep,
+      insertReturns: [{ id: 4 }],
+      insertedValues,
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        annotation_task_id: 1,
+        source_type: "trace_step",
+        source_step_id: "step-1",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "trace_step",
+        source_step_id: "step-1",
+        label: "insight",
+      }),
+    ]);
   });
 
   it("存在しない label を含む場合は 400 を返す", async () => {
@@ -2187,6 +2266,21 @@ describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
     expect(res.status).toBe(409);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("already extracted");
+  });
+
+  it("source_type=trace_step で source_step_id がない場合は 400 を返す", async () => {
+    const db = buildExtractDb({ run: sampleRunWithTraceStep });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1, source_type: "trace_step" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("source_step_id");
   });
 
   it("run が存在しない場合は 404 を返す", async () => {

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -8,6 +8,9 @@ import {
   type PromptExecutionStepDefinition,
   type PromptWorkflowDefinition,
   type StructuredOutput,
+  annotation_candidates,
+  annotation_labels,
+  annotation_tasks,
   execution_profiles,
   prompt_version_projects,
   prompt_versions,
@@ -769,6 +772,180 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     }
 
     return c.json(serializeRun(updated));
+  });
+
+  // POST /api/projects/:projectId/runs/:id/candidates/extract - annotation_candidates を抽出して保存
+  router.post("/:id/candidates/extract", async (c) => {
+    const projectId = parseIntParam(c.req.param("projectId"));
+    const id = parseIntParam(c.req.param("id"));
+
+    if (projectId === null || id === null) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    let body: { annotation_task_id: number };
+    try {
+      body = (await c.req.json()) as { annotation_task_id: number };
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parsedBody = z
+      .object({ annotation_task_id: z.number().int().positive() })
+      .safeParse(body);
+    if (!parsedBody.success) {
+      return c.json({ error: "annotation_task_id must be a positive integer" }, 400);
+    }
+    const { annotation_task_id } = parsedBody.data;
+
+    // run が存在し、該当プロジェクトに属することを確認
+    const versionIds = await fetchVersionIdsByProject(db, projectId);
+    if (versionIds.length === 0) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    const [run] = await db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.id, id),
+          eq(runs.project_id, projectId),
+          inArray(runs.prompt_version_id, versionIds),
+        ),
+      );
+
+    if (!run) {
+      return c.json({ error: "Run not found" }, 404);
+    }
+
+    // annotation_task が存在することを確認
+    const [task] = await db
+      .select()
+      .from(annotation_tasks)
+      .where(eq(annotation_tasks.id, annotation_task_id));
+
+    if (!task) {
+      return c.json({ error: "Annotation task not found" }, 404);
+    }
+
+    // annotation_task に紐づく有効な label keys を取得
+    const labels = await db
+      .select({ key: annotation_labels.key })
+      .from(annotation_labels)
+      .where(eq(annotation_labels.annotation_task_id, annotation_task_id));
+    const validLabelKeys = new Set(labels.map((l) => l.key));
+
+    // ソースタイプ決定とアイテム抽出
+    let sourceType: "structured_json" | "final_answer";
+    let items: z.infer<typeof structuredOutputSchema>["items"];
+
+    const parsedStructuredOutput = parseStructuredOutput(run.structured_output);
+
+    if (parsedStructuredOutput !== null) {
+      // structured_output が存在する場合
+      sourceType = "structured_json";
+      const parsed = structuredOutputSchema.safeParse(parsedStructuredOutput);
+      if (!parsed.success) {
+        return c.json({ error: "structured_output has invalid format" }, 400);
+      }
+      items = parsed.data.items;
+    } else {
+      // final_answer: 最後の assistant メッセージを JSON としてパース
+      sourceType = "final_answer";
+      const conversation = parseConversation(run.conversation);
+      const lastAssistantMessage = [...conversation].reverse().find((m) => m.role === "assistant");
+      if (!lastAssistantMessage) {
+        return c.json({ error: "No assistant message found in conversation" }, 400);
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(lastAssistantMessage.content);
+      } catch {
+        return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
+      }
+
+      const parsedItems = structuredOutputSchema.safeParse(parsed);
+      if (!parsedItems.success) {
+        return c.json(
+          {
+            error:
+              "Assistant message JSON has invalid format (missing items field or invalid schema)",
+          },
+          400,
+        );
+      }
+      items = parsedItems.data.items;
+    }
+
+    // label の存在チェック
+    for (const item of items) {
+      if (!validLabelKeys.has(item.label)) {
+        return c.json(
+          { error: `Label "${item.label}" is not valid for this annotation task` },
+          400,
+        );
+      }
+    }
+
+    // line range チェック
+    for (const item of items) {
+      if (item.start_line > item.end_line) {
+        return c.json(
+          {
+            error: `start_line (${item.start_line}) must not be greater than end_line (${item.end_line})`,
+          },
+          400,
+        );
+      }
+    }
+
+    // 重複チェック: 同一 run / task / source からの重複取り込みを防ぐ
+    const [existing] = await db
+      .select({ id: annotation_candidates.id })
+      .from(annotation_candidates)
+      .where(
+        and(
+          eq(annotation_candidates.run_id, id),
+          eq(annotation_candidates.annotation_task_id, annotation_task_id),
+          eq(annotation_candidates.source_type, sourceType),
+        ),
+      );
+
+    if (existing) {
+      return c.json(
+        { error: "Candidates already extracted for this run/task/source combination" },
+        409,
+      );
+    }
+
+    const targetTextRef = `test_case:${run.test_case_id}`;
+    const now = Date.now();
+
+    const inserted = await db
+      .insert(annotation_candidates)
+      .values(
+        items.map((item) => ({
+          run_id: id,
+          annotation_task_id,
+          target_text_ref: targetTextRef,
+          source_type: sourceType,
+          source_step_id: null,
+          label: item.label,
+          start_line: item.start_line,
+          end_line: item.end_line,
+          quote: item.quote,
+          rationale: item.rationale ?? null,
+          status: "pending" as const,
+          note: null,
+          created_at: now,
+          updated_at: now,
+        })),
+      )
+      .returning();
+
+    return c.json(inserted, 201);
   });
 
   // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -80,6 +80,31 @@ const executeRunSchema = z.object({
 });
 
 type ExecuteRunBody = z.infer<typeof executeRunSchema>;
+type CandidateSourceType = "structured_json" | "final_answer" | "trace_step";
+
+const extractCandidatesSchema = z
+  .object({
+    annotation_task_id: z.number().int().positive(),
+    source_type: z.enum(["structured_json", "final_answer", "trace_step"]).optional(),
+    source_step_id: z.string().min(1).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.source_type === "trace_step" && !value.source_step_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "source_step_id is required when source_type is trace_step",
+        path: ["source_step_id"],
+      });
+    }
+
+    if (value.source_type !== "trace_step" && value.source_step_id !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "source_step_id can only be used when source_type is trace_step",
+        path: ["source_step_id"],
+      });
+    }
+  });
 
 type RunExecutionClientFactoryInput = {
   apiProvider: string;
@@ -153,6 +178,17 @@ function parseStructuredOutput(json: string | null): StructuredOutput | null {
   }
 
   return JSON.parse(json) as StructuredOutput;
+}
+
+function parseStructuredItems(
+  value: unknown,
+): z.infer<typeof structuredOutputSchema>["items"] | null {
+  const parsed = structuredOutputSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+
+  return parsed.data.items;
 }
 
 function buildSystemPrompt(version: StoredPromptVersion, testCase: StoredTestCase): string {
@@ -783,20 +819,18 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    let body: { annotation_task_id: number };
+    let body: z.infer<typeof extractCandidatesSchema>;
     try {
-      body = (await c.req.json()) as { annotation_task_id: number };
+      body = (await c.req.json()) as z.infer<typeof extractCandidatesSchema>;
     } catch {
       return c.json({ error: "Invalid JSON body" }, 400);
     }
 
-    const parsedBody = z
-      .object({ annotation_task_id: z.number().int().positive() })
-      .safeParse(body);
+    const parsedBody = extractCandidatesSchema.safeParse(body);
     if (!parsedBody.success) {
-      return c.json({ error: "annotation_task_id must be a positive integer" }, 400);
+      return c.json({ error: parsedBody.error.issues[0]?.message ?? "Invalid request body" }, 400);
     }
-    const { annotation_task_id } = parsedBody.data;
+    const { annotation_task_id, source_type, source_step_id } = parsedBody.data;
 
     // run が存在し、該当プロジェクトに属することを確認
     const versionIds = await fetchVersionIdsByProject(db, projectId);
@@ -837,21 +871,25 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const validLabelKeys = new Set(labels.map((l) => l.key));
 
     // ソースタイプ決定とアイテム抽出
-    let sourceType: "structured_json" | "final_answer";
+    let sourceType: CandidateSourceType;
+    let resolvedSourceStepId: string | null = null;
     let items: z.infer<typeof structuredOutputSchema>["items"];
+    const requestedSourceType =
+      source_type ?? (run.structured_output !== null ? "structured_json" : "final_answer");
 
-    const parsedStructuredOutput = parseStructuredOutput(run.structured_output);
-
-    if (parsedStructuredOutput !== null) {
-      // structured_output が存在する場合
+    if (requestedSourceType === "structured_json") {
       sourceType = "structured_json";
-      const parsed = structuredOutputSchema.safeParse(parsedStructuredOutput);
-      if (!parsed.success) {
+      const parsedStructuredOutput = parseStructuredOutput(run.structured_output);
+      if (parsedStructuredOutput === null) {
+        return c.json({ error: "structured_output is not available for this run" }, 400);
+      }
+
+      const parsedItems = parseStructuredItems(parsedStructuredOutput);
+      if (parsedItems === null) {
         return c.json({ error: "structured_output has invalid format" }, 400);
       }
-      items = parsed.data.items;
-    } else {
-      // final_answer: 最後の assistant メッセージを JSON としてパース
+      items = parsedItems;
+    } else if (requestedSourceType === "final_answer") {
       sourceType = "final_answer";
       const conversation = parseConversation(run.conversation);
       const lastAssistantMessage = [...conversation].reverse().find((m) => m.role === "assistant");
@@ -859,15 +897,15 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         return c.json({ error: "No assistant message found in conversation" }, 400);
       }
 
-      let parsed: unknown;
+      let parsedFinalAnswer: unknown;
       try {
-        parsed = JSON.parse(lastAssistantMessage.content);
+        parsedFinalAnswer = JSON.parse(lastAssistantMessage.content);
       } catch {
         return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
       }
 
-      const parsedItems = structuredOutputSchema.safeParse(parsed);
-      if (!parsedItems.success) {
+      const parsedItems = parseStructuredItems(parsedFinalAnswer);
+      if (parsedItems === null) {
         return c.json(
           {
             error:
@@ -876,7 +914,33 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
           400,
         );
       }
-      items = parsedItems.data.items;
+      items = parsedItems;
+    } else {
+      sourceType = "trace_step";
+      resolvedSourceStepId = source_step_id ?? null;
+
+      const executionTrace = parseExecutionTrace(run.execution_trace);
+      if (executionTrace === null) {
+        return c.json({ error: "execution_trace is not available for this run" }, 400);
+      }
+
+      const traceStep = executionTrace.find((step) => step.id === source_step_id);
+      if (!traceStep) {
+        return c.json({ error: `Trace step "${source_step_id}" not found` }, 400);
+      }
+
+      let parsedTraceStepOutput: unknown;
+      try {
+        parsedTraceStepOutput = JSON.parse(traceStep.output);
+      } catch {
+        return c.json({ error: "Failed to parse trace_step output as JSON" }, 400);
+      }
+
+      const parsedItems = parseStructuredItems(parsedTraceStepOutput);
+      if (parsedItems === null) {
+        return c.json({ error: "trace_step output has invalid format" }, 400);
+      }
+      items = parsedItems;
     }
 
     // label の存在チェック
@@ -931,7 +995,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
           annotation_task_id,
           target_text_ref: targetTextRef,
           source_type: sourceType,
-          source_step_id: null,
+          source_step_id: resolvedSourceStepId,
           label: item.label,
           start_line: item.start_line,
           end_line: item.end_line,
@@ -945,7 +1009,14 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       )
       .returning();
 
-    return c.json(inserted, 201);
+    return c.json(
+      {
+        candidates_created: inserted.length,
+        run_id: id,
+        annotation_task_id,
+      },
+      201,
+    );
   });
 
   // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄


### PR DESCRIPTION
## Summary

- `POST /api/projects/:projectId/runs/:id/candidates/extract` エンドポイントを実装
- `annotation_task_id` をリクエストボディで受け取り、run の出力から annotation_candidates を抽出・保存する
- ソースタイプ決定ロジック: `structured_output` が存在する場合は `source_type = "structured_json"`、存在しない場合は最後の assistant メッセージを JSON パースして `source_type = "final_answer"` として処理する
- `target_text_ref` は `test_case:{test_case_id}` 形式で付与、`source_step_id` は初回実装では null、`status = "pending"` で初期化

## バリデーション

- run が存在し、該当プロジェクトに属することを確認
- annotation_task が存在することを確認
- 全 item の `label` が annotation_task に紐づく有効な key であることを検証（不正なら 400）
- `start_line > end_line` の場合 400
- `final_answer` で JSON パース失敗 または `items` フィールドなしの場合 400
- 同一 run / task / source からの重複取り込み → 409

## Test plan

- [ ] `structured_output` から Candidate を生成して 201 返すテスト
- [ ] `final_answer`（最後の assistant メッセージの JSON）からフォールバックして 201 返すテスト
- [ ] 存在しない label を含む場合の 400 テスト
- [ ] `start_line > end_line` の不正 line range で 400 テスト
- [ ] `final_answer` で JSON パース失敗（`items` フィールドなし）の場合の 400 テスト
- [ ] 重複抽出時の 409 テスト
- [ ] run が存在しない場合の 404 テスト
- [ ] annotation_task が存在しない場合の 404 テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)