### PR TITLE
feat: annotation review API と gold annotation 管理を追加する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,10 @@ import { assertRequiredSchema, db } from "@prompt-reviewer/core";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import {
+  createAnnotationCandidatesRouter,
+  createGoldAnnotationsRouter,
+} from "./routes/annotation-review.js";
+import {
   createAnnotationLabelsRouter,
   createAnnotationTasksRouter,
 } from "./routes/annotation-tasks.js";
@@ -78,6 +82,8 @@ app.get("/api/health", (c) => {
 
 app.route("/api/annotation-tasks", createAnnotationTasksRouter(db));
 app.route("/api/annotation-labels", createAnnotationLabelsRouter(db));
+app.route("/api/annotation-candidates", createAnnotationCandidatesRouter(db));
+app.route("/api/gold-annotations", createGoldAnnotationsRouter(db));
 app.route("/api/context-assets", createContextAssetsRouter(db));
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/execution-profiles", createExecutionProfilesRouter(db));

--- a/packages/server/src/routes/annotation-review.test.ts
+++ b/packages/server/src/routes/annotation-review.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Annotation Review (Candidates / Gold Annotations) エンドポイントのテスト
+ *
+ * better-sqlite3 はネイティブバイナリのビルドが必要なため、
+ * 実際のDB接続は行わず、Drizzle の DB インターフェースを模倣した
+ * モックを使用してルートハンドラの動作を検証する。
+ */
+
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAnnotationCandidatesRouter,
+  createGoldAnnotationsRouter,
+} from "./annotation-review.js";
+
+// ---- 型定義 ----
+
+type MockCandidate = {
+  id: number;
+  run_id: number;
+  annotation_task_id: number;
+  target_text_ref: string;
+  source_type: "final_answer" | "structured_json" | "trace_step";
+  source_step_id: string | null;
+  label: string;
+  start_line: number;
+  end_line: number;
+  quote: string;
+  rationale: string | null;
+  status: "pending" | "accepted" | "rejected";
+  note: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type MockGoldAnnotation = {
+  id: number;
+  annotation_task_id: number;
+  target_text_ref: string;
+  label: string;
+  start_line: number;
+  end_line: number;
+  quote: string;
+  note: string | null;
+  source_candidate_id: number | null;
+  created_at: number;
+  updated_at: number;
+};
+
+// ---- テスト用アプリビルダー ----
+
+function buildApp(db: unknown) {
+  const app = new Hono();
+  app.route("/api/annotation-candidates", createAnnotationCandidatesRouter(db as DB));
+  app.route("/api/gold-annotations", createGoldAnnotationsRouter(db as DB));
+  return app;
+}
+
+// ---- テストデータ ----
+
+const sampleCandidate: MockCandidate = {
+  id: 1,
+  run_id: 10,
+  annotation_task_id: 2,
+  target_text_ref: "test_case:5",
+  source_type: "final_answer",
+  source_step_id: null,
+  label: "bug",
+  start_line: 3,
+  end_line: 7,
+  quote: "サンプルの引用テキスト",
+  rationale: null,
+  status: "pending",
+  note: null,
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+const sampleGold: MockGoldAnnotation = {
+  id: 1,
+  annotation_task_id: 2,
+  target_text_ref: "test_case:5",
+  label: "bug",
+  start_line: 3,
+  end_line: 7,
+  quote: "サンプルの引用テキスト",
+  note: null,
+  source_candidate_id: 1,
+  created_at: 1000000,
+  updated_at: 1000000,
+};
+
+// ---- annotation-candidates GET テスト ----
+
+describe("GET /api/annotation-candidates", () => {
+  it("status フィルターで pending のみを返す", async () => {
+    const pendingCandidate = { ...sampleCandidate, id: 1, status: "pending" as const };
+    const acceptedCandidate = { ...sampleCandidate, id: 2, status: "accepted" as const };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve([pendingCandidate]),
+          }),
+          orderBy: () => Promise.resolve([pendingCandidate, acceptedCandidate]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates?status=pending");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockCandidate[];
+    expect(body).toHaveLength(1);
+    expect(body.at(0)?.status).toBe("pending");
+  });
+
+  it("annotation_task_id フィルターで該当するcandidatesを返す", async () => {
+    const candidates = [
+      { ...sampleCandidate, id: 1, annotation_task_id: 2 },
+      { ...sampleCandidate, id: 2, annotation_task_id: 2 },
+    ];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve(candidates),
+          }),
+          orderBy: () => Promise.resolve(candidates),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates?annotation_task_id=2");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockCandidate[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.annotation_task_id).toBe(2);
+  });
+
+  it("run_id フィルターで該当するcandidatesを返す", async () => {
+    const candidates = [{ ...sampleCandidate, id: 1, run_id: 10 }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve(candidates),
+          }),
+          orderBy: () => Promise.resolve(candidates),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates?run_id=10");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockCandidate[];
+    expect(body).toHaveLength(1);
+    expect(body.at(0)?.run_id).toBe(10);
+  });
+
+  it("test_case_id フィルターで target_text_ref='test_case:5' のcandidatesを返す", async () => {
+    const candidates = [
+      { ...sampleCandidate, id: 1, target_text_ref: "test_case:5" },
+      { ...sampleCandidate, id: 2, target_text_ref: "test_case:5" },
+    ];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve(candidates),
+          }),
+          orderBy: () => Promise.resolve(candidates),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates?test_case_id=5");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockCandidate[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.target_text_ref).toBe("test_case:5");
+    expect(body.at(1)?.target_text_ref).toBe("test_case:5");
+  });
+});
+
+// ---- annotation-candidates PATCH テスト ----
+
+describe("PATCH /api/annotation-candidates/:id", () => {
+  it("label, start_line, end_line, note を更新して200で返す", async () => {
+    const updated: MockCandidate = {
+      ...sampleCandidate,
+      label: "feature",
+      start_line: 5,
+      end_line: 10,
+      note: "更新メモ",
+      updated_at: 2000000,
+    };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleCandidate]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([updated]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "feature", start_line: 5, end_line: 10, note: "更新メモ" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { candidate: MockCandidate };
+    expect(body.candidate.label).toBe("feature");
+    expect(body.candidate.start_line).toBe(5);
+    expect(body.candidate.end_line).toBe(10);
+    expect(body.candidate.note).toBe("更新メモ");
+  });
+
+  it("status='accepted' に変更するとgold_annotationを作成して {candidate, gold} を返す", async () => {
+    const accepted: MockCandidate = { ...sampleCandidate, status: "accepted", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleCandidate]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([accepted]),
+          }),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([sampleGold]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "accepted" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { candidate: MockCandidate; gold: MockGoldAnnotation };
+    expect(body.candidate.status).toBe("accepted");
+    expect(body.gold).toBeDefined();
+    expect(body.gold.source_candidate_id).toBe(1);
+    expect(body.gold.label).toBe("bug");
+  });
+
+  it("status='rejected' に変更してもgold_annotationは作成されず {candidate} のみ返す", async () => {
+    const rejected: MockCandidate = { ...sampleCandidate, status: "rejected", updated_at: 2000000 };
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([sampleCandidate]),
+        }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([rejected]),
+          }),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "rejected" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { candidate: MockCandidate; gold?: MockGoldAnnotation };
+    expect(body.candidate.status).toBe("rejected");
+    expect(body.gold).toBeUndefined();
+  });
+
+  it("start_line が end_line より大きい場合400を返す", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ start_line: 10, end_line: 5 }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("存在しないIDに対して404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/999", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "bug" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Annotation candidate not found");
+  });
+});
+
+// ---- gold-annotations GET テスト ----
+
+describe("GET /api/gold-annotations", () => {
+  it("annotation_task_id フィルターで該当するgold_annotationsを返す", async () => {
+    const golds = [
+      { ...sampleGold, id: 1, annotation_task_id: 2 },
+      { ...sampleGold, id: 2, annotation_task_id: 2 },
+    ];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve(golds),
+          }),
+          orderBy: () => Promise.resolve(golds),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/gold-annotations?annotation_task_id=2");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockGoldAnnotation[];
+    expect(body).toHaveLength(2);
+    expect(body.at(0)?.annotation_task_id).toBe(2);
+  });
+
+  it("test_case_id フィルターで target_text_ref='test_case:5' のgold_annotationsを返す", async () => {
+    const golds = [{ ...sampleGold, id: 1, target_text_ref: "test_case:5" }];
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => Promise.resolve(golds),
+          }),
+          orderBy: () => Promise.resolve(golds),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/gold-annotations?test_case_id=5");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MockGoldAnnotation[];
+    expect(body).toHaveLength(1);
+    expect(body.at(0)?.target_text_ref).toBe("test_case:5");
+  });
+});

--- a/packages/server/src/routes/annotation-review.test.ts
+++ b/packages/server/src/routes/annotation-review.test.ts
@@ -216,8 +216,11 @@ describe("PATCH /api/annotation-candidates/:id", () => {
 
     const db = {
       select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([sampleCandidate]),
+        from: (table?: { key?: unknown }) => ({
+          where: () =>
+            Promise.resolve(
+              table && "key" in table ? [{ key: "bug" }, { key: "feature" }] : [sampleCandidate],
+            ),
         }),
       }),
       update: () => ({
@@ -246,13 +249,24 @@ describe("PATCH /api/annotation-candidates/:id", () => {
 
   it("status='accepted' に変更するとgold_annotationを作成して {candidate, gold} を返す", async () => {
     const accepted: MockCandidate = { ...sampleCandidate, status: "accepted", updated_at: 2000000 };
+    let selectCallCount = 0;
 
     const db = {
-      select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([sampleCandidate]),
-        }),
-      }),
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([sampleCandidate]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([]),
+          }),
+        };
+      },
       update: () => ({
         set: () => ({
           where: () => ({
@@ -280,6 +294,64 @@ describe("PATCH /api/annotation-candidates/:id", () => {
     expect(body.gold).toBeDefined();
     expect(body.gold.source_candidate_id).toBe(1);
     expect(body.gold.label).toBe("bug");
+  });
+
+  it("すでに同じcandidate由来のgoldがある場合は再作成せず既存goldを返す", async () => {
+    const accepted: MockCandidate = { ...sampleCandidate, status: "accepted", updated_at: 2000000 };
+    let selectCallCount = 0;
+    let insertCalled = false;
+
+    const existingGold: MockGoldAnnotation = {
+      ...sampleGold,
+      id: 99,
+      source_candidate_id: 1,
+    };
+
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([sampleCandidate]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([existingGold]),
+          }),
+        };
+      },
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: () => Promise.resolve([accepted]),
+          }),
+        }),
+      }),
+      insert: () => {
+        insertCalled = true;
+        return {
+          values: () => ({
+            returning: () => Promise.resolve([sampleGold]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "accepted" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { candidate: MockCandidate; gold: MockGoldAnnotation };
+    expect(body.candidate.status).toBe("accepted");
+    expect(body.gold.id).toBe(99);
+    expect(insertCalled).toBe(false);
   });
 
   it("status='rejected' に変更してもgold_annotationは作成されず {candidate} のみ返す", async () => {
@@ -343,6 +415,38 @@ describe("PATCH /api/annotation-candidates/:id", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Annotation candidate not found");
+  });
+
+  it("annotation_task に存在しない label へ更新しようとすると400を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([sampleCandidate]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([{ key: "bug" }, { key: "question" }]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/annotation-candidates/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "feature" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("feature");
   });
 });
 

--- a/packages/server/src/routes/annotation-review.ts
+++ b/packages/server/src/routes/annotation-review.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import type { DB } from "@prompt-reviewer/core";
-import { annotation_candidates, gold_annotations } from "@prompt-reviewer/core";
+import { annotation_candidates, annotation_labels, gold_annotations } from "@prompt-reviewer/core";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -100,6 +100,21 @@ export function createAnnotationCandidatesRouter(db: DB) {
       return c.json({ error: "Annotation candidate not found" }, 404);
     }
 
+    if (body.label !== undefined) {
+      const labels = await db
+        .select({ key: annotation_labels.key })
+        .from(annotation_labels)
+        .where(eq(annotation_labels.annotation_task_id, existing.annotation_task_id));
+      const validLabelKeys = new Set(labels.map((label) => label.key));
+
+      if (!validLabelKeys.has(body.label)) {
+        return c.json(
+          { error: `Label "${body.label}" is not valid for this annotation task` },
+          400,
+        );
+      }
+    }
+
     // 片方のみ指定された場合の start_line > end_line チェック
     const resolvedStartLine = body.start_line ?? existing.start_line;
     const resolvedEndLine = body.end_line ?? existing.end_line;
@@ -139,6 +154,15 @@ export function createAnnotationCandidatesRouter(db: DB) {
 
     // status が "accepted" に変更された場合は gold_annotation を作成する
     if (body.status === "accepted") {
+      const [existingGold] = await db
+        .select()
+        .from(gold_annotations)
+        .where(eq(gold_annotations.source_candidate_id, updatedCandidate.id));
+
+      if (existingGold) {
+        return c.json({ candidate: updatedCandidate, gold: existingGold });
+      }
+
       const inserted = await db
         .insert(gold_annotations)
         .values({

--- a/packages/server/src/routes/annotation-review.ts
+++ b/packages/server/src/routes/annotation-review.ts
@@ -1,0 +1,208 @@
+import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { annotation_candidates, gold_annotations } from "@prompt-reviewer/core";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+// ---- スキーマ定義 ----
+
+const patchCandidateSchema = z
+  .object({
+    label: z.string().min(1).optional(),
+    start_line: z.number().int().min(1).optional(),
+    end_line: z.number().int().optional(),
+    note: z.string().nullable().optional(),
+    status: z.enum(["pending", "accepted", "rejected"]).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.start_line !== undefined && data.end_line !== undefined) {
+        return data.end_line >= data.start_line;
+      }
+      return true;
+    },
+    { message: "end_line は start_line 以上でなければなりません", path: ["end_line"] },
+  );
+
+// ---- annotation_candidates ルーター ----
+
+export function createAnnotationCandidatesRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/annotation-candidates
+  router.get("/", async (c) => {
+    const annotationTaskIdParam = c.req.query("annotation_task_id");
+    const runIdParam = c.req.query("run_id");
+    const testCaseIdParam = c.req.query("test_case_id");
+    const statusParam = c.req.query("status");
+
+    const conditions = [];
+
+    if (annotationTaskIdParam !== undefined) {
+      const annotationTaskId = Number(annotationTaskIdParam);
+      if (!Number.isNaN(annotationTaskId)) {
+        conditions.push(eq(annotation_candidates.annotation_task_id, annotationTaskId));
+      }
+    }
+
+    if (runIdParam !== undefined) {
+      const runId = Number(runIdParam);
+      if (!Number.isNaN(runId)) {
+        conditions.push(eq(annotation_candidates.run_id, runId));
+      }
+    }
+
+    if (testCaseIdParam !== undefined) {
+      const testCaseId = Number(testCaseIdParam);
+      if (!Number.isNaN(testCaseId)) {
+        conditions.push(eq(annotation_candidates.target_text_ref, `test_case:${testCaseId}`));
+      }
+    }
+
+    if (statusParam !== undefined) {
+      if (statusParam === "pending" || statusParam === "accepted" || statusParam === "rejected") {
+        conditions.push(eq(annotation_candidates.status, statusParam));
+      }
+    }
+
+    const query = db.select().from(annotation_candidates);
+
+    const result =
+      conditions.length === 0
+        ? await query.orderBy(annotation_candidates.id)
+        : conditions.length === 1
+          ? await query.where(conditions[0]).orderBy(annotation_candidates.id)
+          : await query.where(and(...conditions)).orderBy(annotation_candidates.id);
+
+    return c.json(result);
+  });
+
+  // PATCH /api/annotation-candidates/:id
+  router.patch("/:id", zValidator("json", patchCandidateSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+
+    if (Number.isNaN(id)) {
+      return c.json({ error: "Invalid ID" }, 400);
+    }
+
+    const body = c.req.valid("json");
+
+    // start_line のみ指定されて end_line が省略の場合、既存 end_line と比較できないためここでは許容
+    // (start_line > end_line のチェックは zod の refine で両方指定時のみ行う)
+
+    const [existing] = await db
+      .select()
+      .from(annotation_candidates)
+      .where(eq(annotation_candidates.id, id));
+
+    if (!existing) {
+      return c.json({ error: "Annotation candidate not found" }, 404);
+    }
+
+    // 片方のみ指定された場合の start_line > end_line チェック
+    const resolvedStartLine = body.start_line ?? existing.start_line;
+    const resolvedEndLine = body.end_line ?? existing.end_line;
+
+    if (resolvedEndLine < resolvedStartLine) {
+      return c.json({ error: "end_line は start_line 以上でなければなりません" }, 400);
+    }
+
+    const now = Date.now();
+
+    const updateData: {
+      label?: string;
+      start_line?: number;
+      end_line?: number;
+      note?: string | null;
+      status?: "pending" | "accepted" | "rejected";
+      updated_at: number;
+    } = { updated_at: now };
+
+    if (body.label !== undefined) updateData.label = body.label;
+    if (body.start_line !== undefined) updateData.start_line = body.start_line;
+    if (body.end_line !== undefined) updateData.end_line = body.end_line;
+    if (body.note !== undefined) updateData.note = body.note;
+    if (body.status !== undefined) updateData.status = body.status;
+
+    const updated = await db
+      .update(annotation_candidates)
+      .set(updateData)
+      .where(eq(annotation_candidates.id, id))
+      .returning();
+
+    const updatedCandidate = updated[0];
+
+    if (!updatedCandidate) {
+      return c.json({ error: "Annotation candidate not found" }, 404);
+    }
+
+    // status が "accepted" に変更された場合は gold_annotation を作成する
+    if (body.status === "accepted") {
+      const inserted = await db
+        .insert(gold_annotations)
+        .values({
+          annotation_task_id: updatedCandidate.annotation_task_id,
+          target_text_ref: updatedCandidate.target_text_ref,
+          label: updatedCandidate.label,
+          start_line: updatedCandidate.start_line,
+          end_line: updatedCandidate.end_line,
+          quote: updatedCandidate.quote,
+          note: updatedCandidate.note ?? null,
+          source_candidate_id: updatedCandidate.id,
+          created_at: now,
+          updated_at: now,
+        })
+        .returning();
+
+      const createdGold = inserted[0];
+
+      return c.json({ candidate: updatedCandidate, gold: createdGold });
+    }
+
+    return c.json({ candidate: updatedCandidate });
+  });
+
+  return router;
+}
+
+// ---- gold_annotations ルーター ----
+
+export function createGoldAnnotationsRouter(db: DB) {
+  const router = new Hono();
+
+  // GET /api/gold-annotations
+  router.get("/", async (c) => {
+    const annotationTaskIdParam = c.req.query("annotation_task_id");
+    const testCaseIdParam = c.req.query("test_case_id");
+
+    const conditions = [];
+
+    if (annotationTaskIdParam !== undefined) {
+      const annotationTaskId = Number(annotationTaskIdParam);
+      if (!Number.isNaN(annotationTaskId)) {
+        conditions.push(eq(gold_annotations.annotation_task_id, annotationTaskId));
+      }
+    }
+
+    if (testCaseIdParam !== undefined) {
+      const testCaseId = Number(testCaseIdParam);
+      if (!Number.isNaN(testCaseId)) {
+        conditions.push(eq(gold_annotations.target_text_ref, `test_case:${testCaseId}`));
+      }
+    }
+
+    const query = db.select().from(gold_annotations);
+
+    const result =
+      conditions.length === 0
+        ? await query.orderBy(gold_annotations.id)
+        : conditions.length === 1
+          ? await query.where(conditions[0]).orderBy(gold_annotations.id)
+          : await query.where(and(...conditions)).orderBy(gold_annotations.id);
+
+    return c.json(result);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `GET /api/annotation-candidates` — annotation_task_id / run_id / test_case_id / status でフィルタ可能な Candidate 一覧 API
- `PATCH /api/annotation-candidates/:id` — label / start_line / end_line / note / status を更新。`status=accepted` 時に Gold Annotation を自動作成し `{ candidate, gold }` を返す。`status=rejected` 時は `{ candidate }` のみ返す
- `GET /api/gold-annotations` — annotation_task_id / test_case_id でフィルタ可能な Gold Annotation 一覧 API
- `start_line > end_line` のバリデーションを入れ、不正値には 400 を返す

## Test plan

- [ ] Candidate 一覧フィルタテスト (status / annotation_task_id / run_id / test_case_id)
- [ ] 採用時に Gold が作成されるテスト (`{ candidate, gold }` が返ること)
- [ ] 却下時に Gold が作成されないテスト (`gold` キーが存在しないこと)
- [ ] line range バリデーションテスト (start_line > end_line で 400)
- [ ] 存在しない ID に 404 を返すテスト
- [ ] Gold 一覧フィルタテスト

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)