### PR TITLE
Issue #151 アノテーション設定UIを追加し関連不具合を修正

### DIFF
--- a/packages/server/src/routes/project-settings.test.ts
+++ b/packages/server/src/routes/project-settings.test.ts
@@ -92,31 +92,51 @@ function makeReturning(rows: unknown[]) {
 
 function makeInsertTxMock(options: {
   projectSettingsRows?: unknown[];
-  onExecutionProfileUpsert?: (values: Record<string, unknown>) => void;
+  executionProfileRows?: unknown[];
+  onExecutionProfileInsert?: (values: Record<string, unknown>) => void;
+  onExecutionProfileUpdate?: (values: Record<string, unknown>) => void;
   onProjectSettingsValues?: (values: Record<string, unknown>) => void;
-  onProjectSettingsConflict?: (config: { target: unknown; set: Record<string, unknown> }) => void;
 }) {
   return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          all: () => (table === execution_profiles ? (options.executionProfileRows ?? []) : []),
+        }),
+      }),
+    }),
     insert: (table: unknown) => ({
-      values: (values: Record<string, unknown>) => ({
-        onConflictDoUpdate: (config: { target: unknown; set: Record<string, unknown> }) => {
+      values: (values: Record<string, unknown>) => {
+        if (table === execution_profiles) {
+          return {
+            run: () => options.onExecutionProfileInsert?.(values),
+          };
+        }
+
+        if (table === project_settings) {
+          options.onProjectSettingsValues?.(values);
+          return {
+            returning: () => makeReturning(options.projectSettingsRows ?? []),
+          };
+        }
+
+        return {
+          run: () => {},
+          returning: () => makeReturning([]),
+        };
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
           if (table === execution_profiles) {
             return {
-              run: () => options.onExecutionProfileUpsert?.(values),
-            };
-          }
-
-          if (table === project_settings) {
-            options.onProjectSettingsValues?.(values);
-            options.onProjectSettingsConflict?.(config);
-            return {
-              returning: () => makeReturning(options.projectSettingsRows ?? []),
+              run: () => options.onExecutionProfileUpdate?.(values),
             };
           }
 
           return {
-            run: () => {},
-            returning: () => makeReturning([]),
+            returning: () => makeReturning(options.projectSettingsRows ?? []),
           };
         },
       }),
@@ -233,18 +253,39 @@ describe("PUT /api/projects/:projectId/settings", () => {
 
     // トランザクション内の tx モック
     const tx = {
-      insert: () => ({
-        values: () => ({
-          onConflictDoUpdate: () => ({
-            run: () => {},
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            all: () =>
+              table === execution_profiles
+                ? [
+                    {
+                      id: 77,
+                      name: "project-1-default",
+                    },
+                  ]
+                : [],
           }),
         }),
       }),
+      insert: () => ({
+        values: () => ({
+          run: () => {},
+        }),
+      }),
       update: (table: unknown) => ({
-        set: () => ({
-          where: () => ({
-            returning: () => makeReturning(table === project_settings ? [updated] : []),
-          }),
+        set: (data: Record<string, unknown>) => ({
+          where: () => {
+            if (table === execution_profiles) {
+              return {
+                run: () => {},
+              };
+            }
+
+            return {
+              returning: () => makeReturning(table === project_settings ? [updated] : []),
+            };
+          },
         }),
       }),
     };
@@ -409,24 +450,45 @@ describe("PUT /api/projects/:projectId/settings", () => {
     };
 
     const tx = {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            all: () =>
+              table === execution_profiles
+                ? [
+                    {
+                      id: 88,
+                      name: "project-1-default",
+                    },
+                  ]
+                : [],
+          }),
+        }),
+      }),
       insert: () => ({
         values: () => ({
-          onConflictDoUpdate: () => ({
-            run: () => {},
-          }),
+          run: () => {},
         }),
       }),
       update: (table: unknown) => ({
         set: (data: Record<string, unknown>) => ({
-          where: () => ({
-            returning: () => {
-              if (table === project_settings) {
-                capturedUpdateData = data;
-                return makeReturning([updated]);
-              }
-              return makeReturning([]);
-            },
-          }),
+          where: () => {
+            if (table === execution_profiles) {
+              return {
+                run: () => {},
+              };
+            }
+
+            return {
+              returning: () => {
+                if (table === project_settings) {
+                  capturedUpdateData = data;
+                  return makeReturning([updated]);
+                }
+                return makeReturning([]);
+              },
+            };
+          },
         }),
       }),
     };
@@ -517,7 +579,7 @@ describe("PUT /api/projects/:projectId/settings", () => {
 // ---- 新旧整合テスト ----
 
 describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", () => {
-  it("settings 新規作成時に execution_profiles への insert(upsert) が実行される", async () => {
+  it("settings 新規作成時に execution_profiles へ insert が実行される", async () => {
     const created: MockSettings = {
       id: 1,
       project_id: 1,
@@ -533,7 +595,7 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
 
     const tx = makeInsertTxMock({
       projectSettingsRows: [created],
-      onExecutionProfileUpsert: (values) => {
+      onExecutionProfileInsert: (values) => {
         executionProfileInsertCalled = true;
         executionProfileInsertValues = values;
       },
@@ -563,34 +625,53 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
     expect(executionProfileInsertValues.api_provider).toBe("anthropic");
   });
 
-  it("settings 更新時に execution_profiles の upsert が実行される", async () => {
+  it("settings 更新時に既存 execution_profiles を更新する", async () => {
     const updatedSettings: MockSettings = {
       ...sampleSettings,
       model: "claude-haiku-4-5",
       updated_at: 6000000,
     };
 
-    let executionProfileUpsertCalled = false;
-    let executionProfileUpsertValues: Record<string, unknown> = {};
+    let executionProfileUpdateCalled = false;
+    let executionProfileUpdateValues: Record<string, unknown> = {};
 
     const tx = {
-      insert: (table: unknown) => ({
-        values: (values: Record<string, unknown>) => ({
-          onConflictDoUpdate: () => ({
-            run: () => {
-              if (table === execution_profiles) {
-                executionProfileUpsertCalled = true;
-                executionProfileUpsertValues = values;
-              }
-            },
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            all: () =>
+              table === execution_profiles
+                ? [
+                    {
+                      id: 55,
+                      name: "project-1-default",
+                    },
+                  ]
+                : [],
           }),
         }),
       }),
+      insert: () => ({
+        values: () => ({
+          run: () => {},
+        }),
+      }),
       update: (table: unknown) => ({
-        set: () => ({
-          where: () => ({
-            returning: () => makeReturning(table === project_settings ? [updatedSettings] : []),
-          }),
+        set: (values: Record<string, unknown>) => ({
+          where: () => {
+            if (table === execution_profiles) {
+              return {
+                run: () => {
+                  executionProfileUpdateCalled = true;
+                  executionProfileUpdateValues = values;
+                },
+              };
+            }
+
+            return {
+              returning: () => makeReturning(table === project_settings ? [updatedSettings] : []),
+            };
+          },
         }),
       }),
     };
@@ -612,8 +693,8 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
     });
 
     expect(res.status).toBe(200);
-    expect(executionProfileUpsertCalled).toBe(true);
-    expect(executionProfileUpsertValues.model).toBe("claude-haiku-4-5");
+    expect(executionProfileUpdateCalled).toBe(true);
+    expect(executionProfileUpdateValues.model).toBe("claude-haiku-4-5");
   });
 
   it("project-{projectId}-default という名前で execution_profile を識別する", async () => {
@@ -631,7 +712,7 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
 
     const tx = makeInsertTxMock({
       projectSettingsRows: [created],
-      onExecutionProfileUpsert: (values) => {
+      onExecutionProfileInsert: (values) => {
         capturedProfileName = values.name as string;
       },
     });
@@ -655,7 +736,7 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
     expect(capturedProfileName).toBe("project-42-default");
   });
 
-  it("settings 新規作成時に project_settings.project_id を conflict target に使う", async () => {
+  it("settings 新規作成時に project_settings へ project_id を含めて保存する", async () => {
     const created: MockSettings = {
       id: 1,
       project_id: 7,
@@ -666,14 +747,12 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
       updated_at: 7100000,
     };
 
-    let conflictTarget: unknown;
-    let conflictSet: Record<string, unknown> | undefined;
+    let capturedValues: Record<string, unknown> = {};
 
     const tx = makeInsertTxMock({
       projectSettingsRows: [created],
-      onProjectSettingsConflict: (config) => {
-        conflictTarget = config.target;
-        conflictSet = config.set;
+      onProjectSettingsValues: (values) => {
+        capturedValues = values;
       },
     });
 
@@ -694,8 +773,8 @@ describe("PUT /api/projects/:projectId/settings - execution_profiles 同期", ()
     });
 
     expect(res.status).toBe(201);
-    expect(conflictTarget).toBe(project_settings.project_id);
-    expect(conflictSet).toMatchObject({
+    expect(capturedValues).toMatchObject({
+      project_id: 7,
       model: "gpt-4o",
       temperature: 0.4,
       api_provider: "openai",

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -28,7 +28,7 @@ type ProjectSettingsRouterOptions = {
   modelClientFactory?: ExecutionProfileModelClientFactory;
 };
 
-type ProjectSettingsWriteTx = Pick<DB, "insert" | "update">;
+type ProjectSettingsWriteTx = Pick<DB, "select" | "insert" | "update">;
 
 function parseIntParam(value: string | undefined): number | null {
   if (value === undefined) return null;
@@ -50,24 +50,35 @@ function upsertDefaultExecutionProfile(
   body: UpsertBody,
   now: number,
 ) {
+  const profileName = defaultProfileName(projectId);
+  const [existing] = tx
+    .select()
+    .from(execution_profiles)
+    .where(eq(execution_profiles.name, profileName))
+    .all();
+
+  if (existing) {
+    tx.update(execution_profiles)
+      .set({
+        model: body.model,
+        temperature: body.temperature,
+        api_provider: body.api_provider,
+        updated_at: now,
+      })
+      .where(eq(execution_profiles.id, existing.id))
+      .run();
+    return;
+  }
+
   tx.insert(execution_profiles)
     .values({
-      name: defaultProfileName(projectId),
+      name: profileName,
       description: null,
       model: body.model,
       temperature: body.temperature,
       api_provider: body.api_provider,
       created_at: now,
       updated_at: now,
-    })
-    .onConflictDoUpdate({
-      target: execution_profiles.name,
-      set: {
-        model: body.model,
-        temperature: body.temperature,
-        api_provider: body.api_provider,
-        updated_at: now,
-      },
     })
     .run();
 }
@@ -154,15 +165,6 @@ export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRout
           api_provider: body.api_provider,
           created_at: now,
           updated_at: now,
-        })
-        .onConflictDoUpdate({
-          target: project_settings.project_id,
-          set: {
-            model: body.model,
-            temperature: body.temperature,
-            api_provider: body.api_provider,
-            updated_at: now,
-          },
         })
         .returning()
         .all();

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -604,7 +604,7 @@ describe("POST /api/projects/:projectId/runs", () => {
 });
 
 describe("POST /api/projects/:projectId/runs/execute", () => {
-  it("execution_profile_id が未指定のとき400を返す", async () => {
+  it("execution_profile_id が未指定でも project_settings にフォールバックして実行できる", async () => {
     const version = {
       id: 1,
       project_id: 1,
@@ -616,9 +616,35 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
       project_id: 1,
       turns: JSON.stringify([{ role: "user", content: "要約してください" }]),
       context_content: "",
+      title: "テストケース1",
+      expected_description: null,
+      display_order: 0,
+      created_at: 0,
+      updated_at: 0,
+    };
+    const projectSettings = {
+      id: 1,
+      project_id: 1,
+      model: "claude-opus-4-5",
+      temperature: 0.7,
+      api_provider: "anthropic" as const,
+      created_at: 0,
+      updated_at: 0,
+    };
+    const created = {
+      ...sampleRun,
+      conversation: JSON.stringify([
+        { role: "user", content: "要約してください" },
+        { role: "assistant", content: "要約結果です" },
+      ]),
+      model: projectSettings.model,
+      temperature: projectSettings.temperature,
+      api_provider: projectSettings.api_provider,
+      execution_profile_id: null,
     };
 
     let selectCallCount = 0;
+    const capturedRequests: LLMRequest[] = [];
     const db = {
       select: () => {
         selectCallCount++;
@@ -642,11 +668,40 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
         if (selectCallCount === 3) {
           return { from: () => ({ where: () => Promise.resolve([version]) }) };
         }
-        return { from: () => ({ where: () => Promise.resolve([testCase]) }) };
+        if (selectCallCount === 4) {
+          return { from: () => ({ where: () => Promise.resolve([testCase]) }) };
+        }
+        return { from: () => ({ where: () => Promise.resolve([projectSettings]) }) };
       },
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
     };
 
-    const app = buildApp(db);
+    const app = new Hono();
+    app.route(
+      "/api/projects/:projectId/runs",
+      createRunsRouter(db as unknown as DB, {
+        llmClientFactory: () => ({
+          async sendMessage() {
+            throw new Error("sendMessage should not be used for streaming execute");
+          },
+          async *stream(request: LLMRequest) {
+            capturedRequests.push(request);
+            yield {
+              type: "response" as const,
+              response: {
+                content: "要約結果です",
+                stopReason: "end_turn",
+                raw: {},
+              },
+            };
+          },
+        }),
+      }),
+    );
     const res = await app.request("/api/projects/1/runs/execute", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -658,9 +713,72 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
       }),
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]).toMatchObject({
+      model: projectSettings.model,
+      temperature: projectSettings.temperature,
+    });
+  });
+
+  it("execution_profile_id も project_settings も無いとき404を返す", async () => {
+    const version = {
+      id: 1,
+      project_id: 1,
+      content: "あなたは親切なアシスタントです。",
+      workflow_definition: null,
+    };
+    const testCase = {
+      id: 1,
+      project_id: 1,
+      turns: JSON.stringify([{ role: "user", content: "要約してください" }]),
+      context_content: "",
+    };
+
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([{ prompt_version_id: 1, project_id: 1, created_at: 0 }]),
+            }),
+          };
+        }
+        if (selectCallCount === 2) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ test_case_id: 1, project_id: 1, created_at: 0 }]),
+            }),
+          };
+        }
+        if (selectCallCount === 3) {
+          return { from: () => ({ where: () => Promise.resolve([version]) }) };
+        }
+        if (selectCallCount === 4) {
+          return { from: () => ({ where: () => Promise.resolve([testCase]) }) };
+        }
+        return { from: () => ({ where: () => Promise.resolve([]) }) };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("execution_profile_id is required");
+    expect(body.error).toBe("Project settings not found");
   });
 
   it("execution_profile からスナップショットを保存してLLM応答をSSEで返す", async () => {

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -12,6 +12,7 @@ import {
   annotation_labels,
   annotation_tasks,
   execution_profiles,
+  project_settings,
   prompt_version_projects,
   prompt_versions,
   runs,
@@ -529,8 +530,20 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       };
       resolvedExecutionProfileId = profile.id;
     } else {
-      // execution_profile_id 未指定の場合はデフォルト設定を使用
-      return c.json({ error: "execution_profile_id is required" }, 400);
+      const [projectSettings] = await db
+        .select()
+        .from(project_settings)
+        .where(eq(project_settings.project_id, projectId));
+
+      if (!projectSettings) {
+        return c.json({ error: "Project settings not found" }, 404);
+      }
+
+      settings = {
+        model: projectSettings.model,
+        temperature: projectSettings.temperature,
+        api_provider: projectSettings.api_provider,
+      };
     }
 
     const client = llmClientFactory({

--- a/packages/server/src/routes/test-cases.test.ts
+++ b/packages/server/src/routes/test-cases.test.ts
@@ -211,6 +211,83 @@ describe("POST /api/test-cases", () => {
     expect(body.turns).toEqual(sampleTurns);
   });
 
+  it("project_ids を指定すると作成後にプロジェクト関連付けを保存する", async () => {
+    const created = { ...sampleTestCase };
+    const insertCalls: unknown[] = [];
+    let insertCount = 0;
+
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([{ id: 10, name: "対象プロジェクト" }]),
+        }),
+      }),
+      insert: () => {
+        insertCount++;
+        if (insertCount === 1) {
+          return {
+            values: (payload: unknown) => {
+              insertCalls.push(payload);
+              return {
+                returning: () => Promise.resolve([created]),
+              };
+            },
+          };
+        }
+
+        return {
+          values: (payload: unknown) => {
+            insertCalls.push(payload);
+            return Promise.resolve();
+          },
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "プロジェクト紐付きテストケース",
+        turns: sampleTurns,
+        project_ids: [10],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertCalls).toHaveLength(2);
+    expect(insertCalls[1]).toMatchObject({
+      test_case_id: created.id,
+      project_id: 10,
+    });
+  });
+
+  it("存在しない project_id が含まれるとき404を返す", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/test-cases", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "テスト",
+        turns: sampleTurns,
+        project_ids: [999],
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project not found");
+  });
+
   it("レスポンスに project_id が含まれない（独立資産モデル）", async () => {
     const created = { ...sampleTestCase };
 

--- a/packages/server/src/routes/test-cases.ts
+++ b/packages/server/src/routes/test-cases.ts
@@ -24,6 +24,7 @@ const createTestCaseSchema = z.object({
   context_content: z.string().optional(),
   expected_description: z.string().optional(),
   display_order: z.number().int().optional(),
+  project_ids: z.array(z.number().int().positive("project_idは正の整数が必要です")).optional(),
 });
 
 const updateTestCaseSchema = z.object({
@@ -135,6 +136,14 @@ export function createTestCasesRouter(db: DB) {
   router.post("/", zValidator("json", createTestCaseSchema), async (c) => {
     const body = c.req.valid("json");
     const now = Date.now();
+    const projectIds = [...new Set(body.project_ids ?? [])];
+
+    for (const projectId of projectIds) {
+      const [project] = await db.select().from(projects).where(eq(projects.id, projectId));
+      if (!project) {
+        return c.json({ error: "Project not found" }, 404);
+      }
+    }
 
     const [testCase] = await db
       .insert(test_cases)
@@ -151,6 +160,14 @@ export function createTestCasesRouter(db: DB) {
 
     if (!testCase) {
       return c.json({ error: "Failed to create TestCase" }, 500);
+    }
+
+    for (const projectId of projectIds) {
+      await db.insert(test_case_projects).values({
+        test_case_id: testCase.id,
+        project_id: projectId,
+        created_at: now,
+      });
     }
 
     return c.json(serializeTestCase(testCase), 201);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { Layout } from "./components/Layout";
+import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
 import { ContextFilesPage } from "./pages/ContextFilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
@@ -38,6 +39,10 @@ export function App() {
             <Route path="projects/:id/runs" element={<RunsPage />} />
             <Route path="projects/:id/score" element={<ScorePage />} />
             <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
+            <Route
+              path="projects/:id/annotation-tasks"
+              element={<AnnotationTaskSettingsPage />}
+            />
             <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -21,6 +21,7 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
     { to: `/projects/${projectId}/runs`, label: "Run 一覧" },
     { to: `/projects/${projectId}/score`, label: "採点" },
     { to: `/projects/${projectId}/score-progression`, label: "スコア推移" },
+    { to: `/projects/${projectId}/annotation-tasks`, label: "アノテーション設定" },
     { to: `/projects/${projectId}/settings`, label: "設定" },
   ];
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -85,6 +85,87 @@ export function getProject(id: number): Promise<Project> {
   return api.get<Project>(`/projects/${id}`);
 }
 
+export type AnnotationOutputMode = "span_label";
+
+export type AnnotationTask = {
+  id: number;
+  name: string;
+  description: string | null;
+  output_mode: AnnotationOutputMode;
+  created_at: number;
+  updated_at: number;
+};
+
+export type AnnotationLabel = {
+  id: number;
+  annotation_task_id: number;
+  key: string;
+  name: string;
+  color: string | null;
+  display_order: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export type AnnotationTaskDetail = AnnotationTask & {
+  labels: AnnotationLabel[];
+};
+
+export function getAnnotationTasks(): Promise<AnnotationTask[]> {
+  return api.get<AnnotationTask[]>("/annotation-tasks");
+}
+
+export function getAnnotationTask(id: number): Promise<AnnotationTaskDetail> {
+  return api.get<AnnotationTaskDetail>(`/annotation-tasks/${id}`);
+}
+
+export function createAnnotationTask(data: {
+  name: string;
+  description?: string;
+  output_mode: AnnotationOutputMode;
+}): Promise<AnnotationTask> {
+  return api.post<AnnotationTask>("/annotation-tasks", data);
+}
+
+export function updateAnnotationTask(
+  id: number,
+  data: { name?: string; description?: string | null },
+): Promise<AnnotationTask> {
+  return api.patch<AnnotationTask>(`/annotation-tasks/${id}`, data);
+}
+
+export function deleteAnnotationTask(id: number): Promise<void> {
+  return api.delete<void>(`/annotation-tasks/${id}`);
+}
+
+export function createAnnotationLabel(
+  taskId: number,
+  data: {
+    key: string;
+    name: string;
+    color?: string;
+    display_order?: number;
+  },
+): Promise<AnnotationLabel> {
+  return api.post<AnnotationLabel>(`/annotation-tasks/${taskId}/labels`, data);
+}
+
+export function updateAnnotationLabel(
+  id: number,
+  data: {
+    key?: string;
+    name?: string;
+    color?: string | null;
+    display_order?: number;
+  },
+): Promise<AnnotationLabel> {
+  return api.patch<AnnotationLabel>(`/annotation-labels/${id}`, data);
+}
+
+export function deleteAnnotationLabel(id: number): Promise<void> {
+  return api.delete<void>(`/annotation-labels/${id}`);
+}
+
 export type ContextFileSummary = {
   name: string;
   path: string;
@@ -207,7 +288,6 @@ export type Turn = {
 
 export type TestCase = {
   id: number;
-  project_id: number;
   title: string;
   turns: Turn[];
   context_content: string;
@@ -218,11 +298,13 @@ export type TestCase = {
 };
 
 export function getTestCases(projectId: number): Promise<TestCase[]> {
-  return api.get<TestCase[]>(`/projects/${projectId}/test-cases`);
+  const params = new URLSearchParams({ project_id: String(projectId) });
+  return api.get<TestCase[]>(`/test-cases?${params}`);
 }
 
 export function getTestCase(projectId: number, id: number): Promise<TestCase> {
-  return api.get<TestCase>(`/projects/${projectId}/test-cases/${id}`);
+  void projectId;
+  return api.get<TestCase>(`/test-cases/${id}`);
 }
 
 export function createTestCase(
@@ -235,7 +317,10 @@ export function createTestCase(
     display_order?: number;
   },
 ): Promise<TestCase> {
-  return api.post<TestCase>(`/projects/${projectId}/test-cases`, data);
+  return api.post<TestCase>("/test-cases", {
+    ...data,
+    project_ids: [projectId],
+  });
 }
 
 export function updateTestCase(
@@ -249,11 +334,13 @@ export function updateTestCase(
     display_order?: number;
   },
 ): Promise<TestCase> {
-  return api.patch<TestCase>(`/projects/${projectId}/test-cases/${id}`, data);
+  void projectId;
+  return api.patch<TestCase>(`/test-cases/${id}`, data);
 }
 
 export function deleteTestCase(projectId: number, id: number): Promise<void> {
-  return api.delete<void>(`/projects/${projectId}/test-cases/${id}`);
+  void projectId;
+  return api.delete<void>(`/test-cases/${id}`);
 }
 
 // Run API

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
@@ -1,0 +1,376 @@
+.root {
+  --c-bg: #1e1e2e;
+  --c-surface: #313244;
+  --c-border: #45475a;
+  --c-text: #cdd6f4;
+  --c-subtext: #a6adc8;
+  --c-muted: #6c7086;
+  --c-accent: #f9e2af;
+  --c-accent-strong: #fab387;
+  --c-card: #181825;
+  --c-danger: #f38ba8;
+  --c-success: #a6e3a1;
+  --c-input: #11111b;
+  --c-chip: rgba(249, 226, 175, 0.12);
+
+  color: var(--c-text);
+}
+
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--c-accent);
+}
+
+.pageTitle {
+  margin: 0 0 8px;
+  font-size: 26px;
+}
+
+.pageDescription {
+  margin: 0;
+  max-width: 720px;
+  color: var(--c-subtext);
+  line-height: 1.6;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.sidebarSection,
+.contentSection,
+.labelSection,
+.taskList,
+.labelList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 18px;
+}
+
+.sectionHint {
+  margin: 6px 0 0;
+  color: var(--c-muted);
+  line-height: 1.5;
+  font-size: 13px;
+}
+
+.panel,
+.emptyState,
+.labelCard {
+  background:
+    linear-gradient(180deg, rgba(249, 226, 175, 0.06), transparent 28%),
+    var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.taskCard,
+.taskCardActive {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--c-border);
+  background: var(--c-card);
+  color: var(--c-text);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    transform 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.taskCard:hover,
+.taskCardActive:hover {
+  transform: translateY(-1px);
+}
+
+.taskCardActive {
+  border-color: var(--c-accent-strong);
+  background:
+    linear-gradient(135deg, rgba(250, 179, 135, 0.12), rgba(249, 226, 175, 0.04)),
+    var(--c-card);
+}
+
+.taskCardTitle {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.taskCardMeta,
+.taskCardMode {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.taskCardMode {
+  color: var(--c-accent);
+}
+
+.fieldGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fieldLabel {
+  font-size: 13px;
+  color: var(--c-subtext);
+}
+
+.requiredMark {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(250, 179, 135, 0.16);
+  color: var(--c-accent-strong);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+}
+
+.fieldInput,
+.fieldTextarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  background: var(--c-input);
+  color: var(--c-text);
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.fieldInput:focus,
+.fieldTextarea:focus {
+  outline: none;
+  border-color: var(--c-accent-strong);
+}
+
+.fieldInput:disabled,
+.fieldTextarea:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.fieldTextarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+.colorFieldRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.colorFieldRow .fieldInput {
+  flex: 1 1 auto;
+}
+
+.outputModeBox {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid var(--c-border);
+  background: var(--c-chip);
+}
+
+.outputModeLabel,
+.outputModeHint {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.outputModeValue {
+  font-size: 16px;
+  color: var(--c-accent);
+}
+
+.formFooter {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton,
+.ghostButton,
+.dangerButton {
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.primaryButton:hover,
+.secondaryButton:hover,
+.ghostButton:hover,
+.dangerButton:hover {
+  transform: translateY(-1px);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, var(--c-accent), var(--c-accent-strong));
+  color: #1e1e2e;
+  border: none;
+}
+
+.secondaryButton {
+  background: var(--c-surface);
+  color: var(--c-text);
+  border: 1px solid var(--c-border);
+}
+
+.ghostButton {
+  background: transparent;
+  color: var(--c-subtext);
+  border: 1px solid var(--c-border);
+}
+
+.dangerButton {
+  background: rgba(243, 139, 168, 0.12);
+  color: var(--c-danger);
+  border: 1px solid rgba(243, 139, 168, 0.35);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.ghostButton:disabled,
+.dangerButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.labelCard {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.labelCardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.labelTitle {
+  margin: 0;
+  font-size: 16px;
+}
+
+.labelMeta {
+  margin: 6px 0 0;
+  color: var(--c-muted);
+  font-size: 12px;
+}
+
+.labelActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.colorChip {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  flex: 0 0 auto;
+}
+
+.feedbackSuccess,
+.feedbackError,
+.fieldHint,
+.stateText,
+.errorText {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.fieldHint {
+  color: var(--c-muted);
+  font-size: 12px;
+}
+
+.feedbackSuccess {
+  color: var(--c-success);
+}
+
+.feedbackError,
+.errorText {
+  color: var(--c-danger);
+}
+
+.stateText {
+  color: var(--c-subtext);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .pageHeader,
+  .labelCardHeader,
+  .sectionHeader {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .fieldGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -1,0 +1,789 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router";
+import {
+  ApiError,
+  createAnnotationLabel,
+  createAnnotationTask,
+  deleteAnnotationLabel,
+  deleteAnnotationTask,
+  getAnnotationTask,
+  getAnnotationTasks,
+  getProject,
+  type AnnotationLabel,
+  updateAnnotationLabel,
+  updateAnnotationTask,
+} from "../lib/api";
+import styles from "./AnnotationTaskSettingsPage.module.css";
+
+type TaskFormState = {
+  name: string;
+  description: string;
+};
+
+type LabelFormState = {
+  key: string;
+  name: string;
+  color: string;
+  displayOrder: string;
+};
+
+const emptyTaskForm: TaskFormState = {
+  name: "",
+  description: "",
+};
+
+const emptyLabelForm: LabelFormState = {
+  key: "",
+  name: "",
+  color: "",
+  displayOrder: "0",
+};
+
+const autoLabelColors = [
+  "#ff7a59",
+  "#5cc8ff",
+  "#f7b801",
+  "#7bd389",
+  "#b794f4",
+  "#ff8fab",
+  "#4ecdc4",
+  "#f28482",
+  "#84a59d",
+  "#90be6d",
+];
+
+function buildLabelKey(value: string): string {
+  return value
+    .trim()
+    .normalize("NFKC")
+    .replace(/\s+/g, "_")
+    .replace(/[\\/:*?"<>|]+/g, "")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function buildAutoLabelColor(value: string): string {
+  const seed = buildLabelKey(value) || "label";
+  let hash = 0;
+
+  for (const character of seed) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return autoLabelColors[hash % autoLabelColors.length] || "#ff7a59";
+}
+
+function buildLabelPreviewColor(form: LabelFormState): string {
+  return form.color.trim() || buildAutoLabelColor(form.key || form.name);
+}
+
+function buildLabelPayload(form: LabelFormState) {
+  const derivedKey = buildLabelKey(form.key || form.name);
+  const derivedName = form.name.trim() || derivedKey;
+  const derivedColor = form.color.trim() || buildAutoLabelColor(derivedKey || derivedName);
+
+  return {
+    key: derivedKey,
+    name: derivedName,
+    color: derivedColor,
+    display_order: Number(form.displayOrder),
+  };
+}
+
+function buildTaskForm(task?: { name: string; description: string | null }): TaskFormState {
+  return {
+    name: task?.name ?? "",
+    description: task?.description ?? "",
+  };
+}
+
+function buildLabelForm(label?: AnnotationLabel): LabelFormState {
+  return {
+    key: label?.key ?? "",
+    name: label?.name ?? "",
+    color: label?.color ?? "",
+    displayOrder: String(label?.display_order ?? 0),
+  };
+}
+
+export function AnnotationTaskSettingsPage() {
+  const { id } = useParams<{ id: string }>();
+  const projectId = Number(id);
+  const queryClient = useQueryClient();
+
+  const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+  const [newTaskForm, setNewTaskForm] = useState<TaskFormState>(emptyTaskForm);
+  const [taskForm, setTaskForm] = useState<TaskFormState>(emptyTaskForm);
+  const [newLabelForm, setNewLabelForm] = useState<LabelFormState>(emptyLabelForm);
+  const [editingLabelId, setEditingLabelId] = useState<number | null>(null);
+  const [editingLabelForm, setEditingLabelForm] = useState<LabelFormState>(emptyLabelForm);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [feedbackTone, setFeedbackTone] = useState<"success" | "error" | null>(null);
+
+  const { data: project } = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => getProject(projectId),
+    enabled: !Number.isNaN(projectId),
+  });
+
+  const tasksQuery = useQuery({
+    queryKey: ["annotation-tasks"],
+    queryFn: getAnnotationTasks,
+  });
+
+  useEffect(() => {
+    const tasks = tasksQuery.data ?? [];
+
+    if (tasks.length === 0) {
+      setSelectedTaskId(null);
+      return;
+    }
+
+    const firstTask = tasks[0];
+    if (!firstTask) {
+      return;
+    }
+
+    if (selectedTaskId === null || !tasks.some((task) => task.id === selectedTaskId)) {
+      setSelectedTaskId(firstTask.id);
+    }
+  }, [selectedTaskId, tasksQuery.data]);
+
+  const taskDetailQuery = useQuery({
+    queryKey: ["annotation-task", selectedTaskId],
+    queryFn: () => getAnnotationTask(selectedTaskId as number),
+    enabled: selectedTaskId !== null,
+  });
+
+  useEffect(() => {
+    if (taskDetailQuery.data) {
+      setTaskForm(buildTaskForm(taskDetailQuery.data));
+
+      if (editingLabelId !== null) {
+        const nextLabel = taskDetailQuery.data.labels.find((label) => label.id === editingLabelId);
+        if (nextLabel) {
+          setEditingLabelForm(buildLabelForm(nextLabel));
+        } else {
+          setEditingLabelId(null);
+          setEditingLabelForm(emptyLabelForm);
+        }
+      }
+    }
+  }, [editingLabelId, taskDetailQuery.data]);
+
+  const sortedLabels = useMemo(
+    () => taskDetailQuery.data?.labels ?? [],
+    [taskDetailQuery.data?.labels],
+  );
+
+  function showFeedback(message: string, tone: "success" | "error") {
+    setFeedbackMessage(message);
+    setFeedbackTone(tone);
+  }
+
+  async function refreshTaskData(taskId?: number) {
+    await queryClient.invalidateQueries({ queryKey: ["annotation-tasks"] });
+    if (taskId !== undefined) {
+      await queryClient.invalidateQueries({ queryKey: ["annotation-task", taskId] });
+    }
+  }
+
+  const createTaskMutation = useMutation({
+    mutationFn: () =>
+      createAnnotationTask({
+        name: newTaskForm.name.trim(),
+        description: newTaskForm.description.trim() || undefined,
+        output_mode: "span_label",
+      }),
+    onSuccess: async (createdTask) => {
+      await refreshTaskData(createdTask.id);
+      setSelectedTaskId(createdTask.id);
+      setNewTaskForm(emptyTaskForm);
+      showFeedback("アノテーションタスクを作成しました。", "success");
+    },
+    onError: () => {
+      showFeedback("アノテーションタスクの作成に失敗しました。", "error");
+    },
+  });
+
+  const updateTaskMutation = useMutation({
+    mutationFn: () =>
+      updateAnnotationTask(selectedTaskId as number, {
+        name: taskForm.name.trim(),
+        description: taskForm.description.trim() || null,
+      }),
+    onSuccess: async () => {
+      if (selectedTaskId !== null) {
+        await refreshTaskData(selectedTaskId);
+      }
+      showFeedback("タスク設定を更新しました。", "success");
+    },
+    onError: () => {
+      showFeedback("タスク設定の更新に失敗しました。", "error");
+    },
+  });
+
+  const deleteTaskMutation = useMutation({
+    mutationFn: () => deleteAnnotationTask(selectedTaskId as number),
+    onSuccess: async () => {
+      const deletedTaskId = selectedTaskId;
+      setEditingLabelId(null);
+      setEditingLabelForm(emptyLabelForm);
+      await queryClient.invalidateQueries({ queryKey: ["annotation-tasks"] });
+      if (deletedTaskId !== null) {
+        queryClient.removeQueries({ queryKey: ["annotation-task", deletedTaskId] });
+      }
+      showFeedback("タスクを削除しました。", "success");
+    },
+    onError: () => {
+      showFeedback("タスクの削除に失敗しました。", "error");
+    },
+  });
+
+  const createLabelMutation = useMutation({
+    mutationFn: () =>
+      createAnnotationLabel(selectedTaskId as number, buildLabelPayload(newLabelForm)),
+    onSuccess: async () => {
+      if (selectedTaskId !== null) {
+        await refreshTaskData(selectedTaskId);
+      }
+      setNewLabelForm(emptyLabelForm);
+      showFeedback("ラベルを追加しました。", "success");
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 409) {
+        showFeedback("同じ key のラベルがすでに存在します。", "error");
+        return;
+      }
+      showFeedback("ラベルの追加に失敗しました。", "error");
+    },
+  });
+
+  const updateLabelMutation = useMutation({
+    mutationFn: () => updateAnnotationLabel(editingLabelId as number, buildLabelPayload(editingLabelForm)),
+    onSuccess: async () => {
+      if (selectedTaskId !== null) {
+        await refreshTaskData(selectedTaskId);
+      }
+      setEditingLabelId(null);
+      setEditingLabelForm(emptyLabelForm);
+      showFeedback("ラベルを更新しました。", "success");
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 409) {
+        showFeedback("同じ key のラベルがすでに存在します。", "error");
+        return;
+      }
+      showFeedback("ラベルの更新に失敗しました。", "error");
+    },
+  });
+
+  const deleteLabelMutation = useMutation({
+    mutationFn: (labelId: number) => deleteAnnotationLabel(labelId),
+    onSuccess: async () => {
+      if (selectedTaskId !== null) {
+        await refreshTaskData(selectedTaskId);
+      }
+      if (editingLabelId !== null) {
+        setEditingLabelId(null);
+        setEditingLabelForm(emptyLabelForm);
+      }
+      showFeedback("ラベルを削除しました。", "success");
+    },
+    onError: () => {
+      showFeedback("ラベルの削除に失敗しました。", "error");
+    },
+  });
+
+  const canCreateTask = newTaskForm.name.trim().length > 0 && !createTaskMutation.isPending;
+  const canUpdateTask =
+    selectedTaskId !== null && taskForm.name.trim().length > 0 && !updateTaskMutation.isPending;
+  const canCreateLabel =
+    selectedTaskId !== null &&
+    buildLabelKey(newLabelForm.key || newLabelForm.name).length > 0 &&
+    !createLabelMutation.isPending;
+  const canUpdateLabel =
+    editingLabelId !== null &&
+    buildLabelKey(editingLabelForm.key || editingLabelForm.name).length > 0 &&
+    !updateLabelMutation.isPending;
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <div>
+          <p className={styles.eyebrow}>Annotation Task Settings</p>
+          <h2 className={styles.pageTitle}>アノテーション設定</h2>
+          <p className={styles.pageDescription}>
+            {project?.name ?? "プロジェクト"} で使う annotation task と label を準備します。
+            現在の初期実装では output mode は <code>span_label</code> 固定です。
+          </p>
+        </div>
+        {feedbackMessage && (
+          <p
+            className={
+              feedbackTone === "error" ? styles.feedbackError : styles.feedbackSuccess
+            }
+          >
+            {feedbackMessage}
+          </p>
+        )}
+      </div>
+
+      <div className={styles.layout}>
+        <section className={styles.sidebarSection}>
+          <div className={styles.sectionHeader}>
+            <div>
+              <h3 className={styles.sectionTitle}>タスク一覧</h3>
+              <p className={styles.sectionHint}>Review 用に使う task を選択・追加できます。</p>
+            </div>
+          </div>
+
+          <form
+            className={styles.panel}
+            onSubmit={(event) => {
+              event.preventDefault();
+              createTaskMutation.mutate();
+            }}
+          >
+            <label className={styles.fieldLabel} htmlFor="new-task-name">
+              新規タスク名
+            </label>
+            <input
+              id="new-task-name"
+              className={styles.fieldInput}
+              value={newTaskForm.name}
+              onChange={(event) =>
+                setNewTaskForm((current) => ({ ...current, name: event.target.value }))
+              }
+              placeholder="例: 回答品質アノテーション"
+            />
+
+            <label className={styles.fieldLabel} htmlFor="new-task-description">
+              説明
+            </label>
+            <textarea
+              id="new-task-description"
+              className={styles.fieldTextarea}
+              value={newTaskForm.description}
+              onChange={(event) =>
+                setNewTaskForm((current) => ({ ...current, description: event.target.value }))
+              }
+              placeholder="任意: この task の目的や判定基準"
+              rows={4}
+            />
+
+            <div className={styles.outputModeBox}>
+              <span className={styles.outputModeLabel}>Output mode</span>
+              <strong className={styles.outputModeValue}>span_label</strong>
+              <p className={styles.outputModeHint}>初期実装では固定です。</p>
+            </div>
+
+            <button type="submit" className={styles.primaryButton} disabled={!canCreateTask}>
+              {createTaskMutation.isPending ? "作成中..." : "タスクを追加"}
+            </button>
+          </form>
+
+          <div className={styles.taskList}>
+            {tasksQuery.isLoading && <p className={styles.stateText}>タスクを読み込み中...</p>}
+            {tasksQuery.isError && (
+              <p className={styles.errorText}>タスク一覧の取得に失敗しました。</p>
+            )}
+            {!tasksQuery.isLoading && (tasksQuery.data?.length ?? 0) === 0 && (
+              <p className={styles.stateText}>まだ task はありません。まず 1 件追加してください。</p>
+            )}
+            {(tasksQuery.data ?? []).map((task) => {
+              const isSelected = task.id === selectedTaskId;
+
+              return (
+                <button
+                  key={task.id}
+                  type="button"
+                  className={isSelected ? styles.taskCardActive : styles.taskCard}
+                  onClick={() => {
+                    setSelectedTaskId(task.id);
+                    setEditingLabelId(null);
+                    setEditingLabelForm(emptyLabelForm);
+                  }}
+                >
+                  <span className={styles.taskCardTitle}>{task.name}</span>
+                  <span className={styles.taskCardMeta}>ID {task.id}</span>
+                  <span className={styles.taskCardMode}>span_label</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className={styles.contentSection}>
+          {selectedTaskId === null ? (
+            <div className={styles.emptyState}>
+              <h3 className={styles.sectionTitle}>タスクを選択してください</h3>
+              <p className={styles.sectionHint}>
+                左側から task を選ぶと、説明や label を編集できます。
+              </p>
+            </div>
+          ) : taskDetailQuery.isLoading ? (
+            <div className={styles.emptyState}>
+              <p className={styles.stateText}>タスク詳細を読み込み中...</p>
+            </div>
+          ) : taskDetailQuery.isError || !taskDetailQuery.data ? (
+            <div className={styles.emptyState}>
+              <p className={styles.errorText}>タスク詳細の取得に失敗しました。</p>
+            </div>
+          ) : (
+            <>
+              <form
+                className={styles.panel}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  updateTaskMutation.mutate();
+                }}
+              >
+                <div className={styles.sectionHeader}>
+                  <div>
+                    <h3 className={styles.sectionTitle}>タスク設定</h3>
+                    <p className={styles.sectionHint}>
+                      Review に使う task 本体の名前と説明を編集します。
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className={styles.dangerButton}
+                    onClick={() => deleteTaskMutation.mutate()}
+                    disabled={deleteTaskMutation.isPending}
+                  >
+                    {deleteTaskMutation.isPending ? "削除中..." : "タスクを削除"}
+                  </button>
+                </div>
+
+                <div className={styles.fieldGrid}>
+                  <div className={styles.fieldGroup}>
+                    <label className={styles.fieldLabel} htmlFor="task-name">
+                      タスク名
+                    </label>
+                    <input
+                      id="task-name"
+                      className={styles.fieldInput}
+                      value={taskForm.name}
+                      onChange={(event) =>
+                        setTaskForm((current) => ({ ...current, name: event.target.value }))
+                      }
+                    />
+                  </div>
+
+                  <div className={styles.fieldGroup}>
+                    <label className={styles.fieldLabel} htmlFor="task-output-mode">
+                      Output mode
+                    </label>
+                    <input
+                      id="task-output-mode"
+                      className={styles.fieldInput}
+                      value="span_label"
+                      disabled
+                    />
+                  </div>
+                </div>
+
+                <div className={styles.fieldGroup}>
+                  <label className={styles.fieldLabel} htmlFor="task-description">
+                    説明
+                  </label>
+                  <textarea
+                    id="task-description"
+                    className={styles.fieldTextarea}
+                    value={taskForm.description}
+                    onChange={(event) =>
+                      setTaskForm((current) => ({ ...current, description: event.target.value }))
+                    }
+                    rows={5}
+                    placeholder="任意: アノテーション方針やラベルの使い分けを記載"
+                  />
+                </div>
+
+                <div className={styles.formFooter}>
+                  <button type="submit" className={styles.primaryButton} disabled={!canUpdateTask}>
+                    {updateTaskMutation.isPending ? "保存中..." : "タスク設定を保存"}
+                  </button>
+                </div>
+              </form>
+
+              <div className={styles.labelSection}>
+                <div className={styles.sectionHeader}>
+                  <div>
+                    <h3 className={styles.sectionTitle}>ラベル設定</h3>
+                    <p className={styles.sectionHint}>
+                      表示名、内部 key、色、表示順を UI から管理できます。
+                    </p>
+                  </div>
+                </div>
+
+                <form
+                  className={styles.panel}
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    createLabelMutation.mutate();
+                  }}
+                >
+                  <div className={styles.fieldGrid}>
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel} htmlFor="new-label-key">
+                        分類ラベル
+                        <span className={styles.requiredMark}>必須</span>
+                      </label>
+                      <input
+                        id="new-label-key"
+                        className={styles.fieldInput}
+                        value={newLabelForm.key}
+                        onChange={(event) =>
+                          setNewLabelForm((current) => ({ ...current, key: event.target.value }))
+                        }
+                        placeholder="例: missing_evidence"
+                      />
+                      <p className={styles.fieldHint}>
+                        未入力なら表示名から自動生成します。
+                      </p>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel} htmlFor="new-label-name">
+                        表示名
+                      </label>
+                      <input
+                        id="new-label-name"
+                        className={styles.fieldInput}
+                        value={newLabelForm.name}
+                        onChange={(event) =>
+                          setNewLabelForm((current) => ({ ...current, name: event.target.value }))
+                        }
+                        placeholder="未入力なら分類ラベルをそのまま使います"
+                      />
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel} htmlFor="new-label-color">
+                        色
+                      </label>
+                      <div className={styles.colorFieldRow}>
+                        <input
+                          id="new-label-color"
+                          className={styles.fieldInput}
+                          value={newLabelForm.color}
+                          onChange={(event) =>
+                            setNewLabelForm((current) => ({
+                              ...current,
+                              color: event.target.value,
+                            }))
+                          }
+                          placeholder="#ff7a59"
+                        />
+                        <span
+                          className={styles.colorChip}
+                          style={{ backgroundColor: buildLabelPreviewColor(newLabelForm) }}
+                          aria-label="色プレビュー"
+                        />
+                      </div>
+                      <p className={styles.fieldHint}>未入力なら自動で設定します。</p>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel} htmlFor="new-label-order">
+                        並び順
+                      </label>
+                      <input
+                        id="new-label-order"
+                        className={styles.fieldInput}
+                        type="number"
+                        value={newLabelForm.displayOrder}
+                        onChange={(event) =>
+                          setNewLabelForm((current) => ({
+                            ...current,
+                            displayOrder: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className={styles.formFooter}>
+                    <button
+                      type="submit"
+                      className={styles.primaryButton}
+                      disabled={!canCreateLabel}
+                    >
+                      {createLabelMutation.isPending ? "追加中..." : "ラベルを追加"}
+                    </button>
+                  </div>
+                </form>
+
+                <div className={styles.labelList}>
+                  {sortedLabels.length === 0 ? (
+                    <div className={styles.emptyState}>
+                      <p className={styles.stateText}>
+                        まだ label はありません。Review で選びたいラベルを追加してください。
+                      </p>
+                    </div>
+                  ) : (
+                    sortedLabels.map((label) => {
+                      const isEditing = label.id === editingLabelId;
+                      const currentForm = isEditing ? editingLabelForm : buildLabelForm(label);
+
+                      return (
+                        <form
+                          key={label.id}
+                          className={styles.labelCard}
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            if (!isEditing) {
+                              setEditingLabelId(label.id);
+                              setEditingLabelForm(buildLabelForm(label));
+                              return;
+                            }
+                            updateLabelMutation.mutate();
+                          }}
+                        >
+                          <div className={styles.labelCardHeader}>
+                            <div>
+                              <h4 className={styles.labelTitle}>{label.name}</h4>
+                              <p className={styles.labelMeta}>
+                                key: <code>{label.key}</code>
+                              </p>
+                            </div>
+                            <div className={styles.labelActions}>
+                              {!isEditing ? (
+                                <button
+                                  type="button"
+                                  className={styles.secondaryButton}
+                                  onClick={() => {
+                                    setEditingLabelId(label.id);
+                                    setEditingLabelForm(buildLabelForm(label));
+                                  }}
+                                >
+                                  編集
+                                </button>
+                              ) : (
+                                <button
+                                  type="submit"
+                                  className={styles.secondaryButton}
+                                  disabled={!canUpdateLabel}
+                                >
+                                  {updateLabelMutation.isPending ? "保存中..." : "保存"}
+                                </button>
+                              )}
+                              <button
+                                type="button"
+                                className={styles.dangerButton}
+                                onClick={() => deleteLabelMutation.mutate(label.id)}
+                                disabled={deleteLabelMutation.isPending}
+                              >
+                                削除
+                              </button>
+                            </div>
+                          </div>
+
+                          <div className={styles.fieldGrid}>
+                            <div className={styles.fieldGroup}>
+                              <label className={styles.fieldLabel}>
+                                分類ラベル
+                                <span className={styles.requiredMark}>必須</span>
+                              </label>
+                              <input
+                                className={styles.fieldInput}
+                                value={currentForm.key}
+                                disabled={!isEditing}
+                                onChange={(event) =>
+                                  setEditingLabelForm((current) => ({
+                                    ...current,
+                                    key: event.target.value,
+                                  }))
+                                }
+                              />
+                              {isEditing && (
+                                <p className={styles.fieldHint}>
+                                  未入力なら表示名から自動生成します。
+                                </p>
+                              )}
+                            </div>
+
+                            <div className={styles.fieldGroup}>
+                              <label className={styles.fieldLabel}>表示名</label>
+                              <input
+                                className={styles.fieldInput}
+                                value={currentForm.name}
+                                disabled={!isEditing}
+                                onChange={(event) =>
+                                  setEditingLabelForm((current) => ({
+                                    ...current,
+                                    name: event.target.value,
+                                  }))
+                                }
+                              />
+                            </div>
+
+                            <div className={styles.fieldGroup}>
+                              <label className={styles.fieldLabel}>色</label>
+                              <div className={styles.colorFieldRow}>
+                                <input
+                                  className={styles.fieldInput}
+                                  value={currentForm.color}
+                                  disabled={!isEditing}
+                                  onChange={(event) =>
+                                    setEditingLabelForm((current) => ({
+                                      ...current,
+                                      color: event.target.value,
+                                    }))
+                                  }
+                                />
+                                <span
+                                  className={styles.colorChip}
+                                  style={{ backgroundColor: buildLabelPreviewColor(currentForm) }}
+                                  aria-label="色プレビュー"
+                                />
+                              </div>
+                              <p className={styles.fieldHint}>未入力なら自動で設定します。</p>
+                            </div>
+
+                            <div className={styles.fieldGroup}>
+                              <label className={styles.fieldLabel}>並び順</label>
+                              <input
+                                className={styles.fieldInput}
+                                type="number"
+                                value={currentForm.displayOrder}
+                                disabled={!isEditing}
+                                onChange={(event) =>
+                                  setEditingLabelForm((current) => ({
+                                    ...current,
+                                    displayOrder: event.target.value,
+                                  }))
+                                }
+                              />
+                            </div>
+                          </div>
+
+                          {isEditing && (
+                            <div className={styles.formFooter}>
+                              <button
+                                type="button"
+                                className={styles.ghostButton}
+                                onClick={() => {
+                                  setEditingLabelId(null);
+                                  setEditingLabelForm(emptyLabelForm);
+                                }}
+                              >
+                                キャンセル
+                              </button>
+                            </div>
+                          )}
+                        </form>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -41,6 +41,7 @@ export function ProjectDetailPage() {
           { to: "prompts", label: "プロンプト管理" },
           { to: "runs", label: "Run 実行・管理" },
           { to: "score", label: "採点" },
+          { to: "annotation-tasks", label: "アノテーション設定" },
           { to: "settings", label: "プロジェクト設定" },
         ].map(({ to, label }) => (
           <Link
@@ -60,6 +61,9 @@ export function ProjectDetailPage() {
           </Link>
         ))}
       </div>
+      <p style={{ marginTop: "16px", color: "#a6adc8", fontSize: "13px" }}>
+        Review 用の task / label 準備は「アノテーション設定」から行えます。
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- annotation task / label を管理するアノテーション設定 UI を追加
- 実装中に見つかった既存不具合として、テストケース管理、LLM 設定保存、Run 実行まわりも同 PR で修正
- ラベル入力 UX を改善し、分類ラベルや色の自動補完に対応

## 変更内容
- プロジェクト詳細から遷移できるアノテーション設定画面を追加
- annotation task の一覧、作成、編集、削除を追加
- label の作成、編集、削除と span_label 固定表示を追加
- テストケース API の呼び先を実在するエンドポイントへ修正
- テストケース作成時に project へ関連付けるようサーバー側を修正
- project settings 保存処理を ON CONFLICT 依存から明示的な insert/update に変更
- Run 実行時に execution profile 未指定なら project settings へフォールバックするよう修正
- ラベルの分類ラベル、表示名、色の入力 UX を改善
- 分類ラベル未入力時は表示名から自動生成するよう変更
- 表示名未入力時は分類ラベルをそのまま使うよう変更
- 色未入力時は自動設定し、色プレビューを入力欄の右側に表示するよう変更

## 確認
- pnpm run test -- packages/server/src/routes/test-cases.test.ts
- pnpm run test -- packages/server/src/routes/project-settings.test.ts
- pnpm run test -- packages/server/src/routes/runs.test.ts
- pnpm --filter @prompt-reviewer/ui typecheck
- pnpm build:local