### PR TITLE
fix: 抽出UIを整理して行番号付き抽出を復元

### DIFF
--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -920,7 +920,7 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
     expect(capturedRequests[0]).toMatchObject({
       model: sampleProfile.model,
       temperature: sampleProfile.temperature,
-      systemPrompt: "あなたは親切なアシスタントです。\n\n入力文: 今日は晴れです。",
+      systemPrompt: "あなたは親切なアシスタントです。\n\n1: 入力文: 今日は晴れです。",
     });
   });
 
@@ -1164,7 +1164,7 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
       created_at: 0,
       updated_at: 0,
     };
-    const promptMessage = "次のルールで回答してください。\n\n入力文: 今日は晴れです。";
+    const promptMessage = "次のルールで回答してください。\n\n1: 入力文: 今日は晴れです。";
     const created = {
       ...sampleRun,
       conversation: JSON.stringify([
@@ -1617,7 +1617,7 @@ describe("POST /api/projects/:projectId/runs/execute", () => {
     expect(capturedRequests).toHaveLength(2);
     expect(JSON.parse(capturedInsertValues[0]?.execution_trace ?? "[]")).toHaveLength(2);
     expect(capturedRequests[0]).toMatchObject({
-      systemPrompt: "判定してください\n\n元の相談コンテキスト",
+      systemPrompt: "判定してください\n\n1: 元の相談コンテキスト",
     });
     expect(capturedRequests[1]).toMatchObject({
       messages: [{ role: "user", content: "長い相談ログ" }],

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -209,16 +209,24 @@ function parseStructuredItems(
   return parsed.data.items;
 }
 
+function addLineNumbers(text: string): string {
+  const lines = text.split("\n");
+  const width = String(lines.length).length;
+  return lines.map((line, index) => `${String(index + 1).padStart(width, " ")}: ${line}`).join("\n");
+}
+
 function buildSystemPrompt(version: StoredPromptVersion, testCase: StoredTestCase): string {
   if (!testCase.context_content) {
     return version.content;
   }
 
+  const numberedContext = addLineNumbers(testCase.context_content);
+
   if (version.content.includes("{{context}}")) {
-    return version.content.replace("{{context}}", testCase.context_content);
+    return version.content.replace("{{context}}", numberedContext);
   }
 
-  return `${version.content}\n\n${testCase.context_content}`;
+  return `${version.content}\n\n${numberedContext}`;
 }
 
 function buildWorkflowConversation(messages: ConversationMessage[]): ConversationMessage[] {
@@ -255,7 +263,8 @@ function renderWorkflowPrompt(params: {
     .map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${message.content}`)
     .join("\n\n");
   const rawContext = params.testCase.context_content ?? "";
-  const effectiveContext = params.previousOutput ?? rawContext;
+  const numberedContext = rawContext ? addLineNumbers(rawContext) : "";
+  const effectiveContext = params.previousOutput ?? numberedContext;
 
   let rendered = params.step.prompt
     .replaceAll("{{prompt}}", params.version.content)

--- a/packages/ui/src/components/AnnotationSectionTabs.module.css
+++ b/packages/ui/src/components/AnnotationSectionTabs.module.css
@@ -1,0 +1,31 @@
+.tabList {
+  display: flex;
+  gap: 4px;
+  margin-top: 20px;
+  border-bottom: 1px solid #45475a;
+  padding-bottom: 0;
+}
+
+.tab {
+  padding: 8px 20px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+  color: #a6adc8;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: -1px;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.tab:hover {
+  color: #cdd6f4;
+}
+
+.tabActive {
+  color: #cba6f7;
+  border-bottom-color: #cba6f7;
+}

--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -1,0 +1,53 @@
+import { NavLink, useLocation, useParams } from "react-router";
+import styles from "./AnnotationSectionTabs.module.css";
+
+const annotationRoutes = {
+  review: "annotation-review",
+  settings: "annotation-tasks",
+} as const;
+
+export function AnnotationSectionTabs() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+
+  if (!id) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams(location.search);
+  const hasRunId = searchParams.get("runId") !== null;
+  const isReviewPath = location.pathname.endsWith(`/${annotationRoutes.review}`);
+  const isSettingsPath = location.pathname.endsWith(`/${annotationRoutes.settings}`);
+
+  const tabs = [
+    {
+      to: `/projects/${id}/${annotationRoutes.review}?mode=review`,
+      label: "レビュー",
+      isActive: isReviewPath && hasRunId,
+    },
+    {
+      to: `/projects/${id}/${annotationRoutes.review}`,
+      label: "ゴールドアノテーション",
+      isActive: isReviewPath && !hasRunId,
+    },
+    {
+      to: `/projects/${id}/${annotationRoutes.settings}`,
+      label: "設定",
+      isActive: isSettingsPath,
+    },
+  ];
+
+  return (
+    <div className={styles.tabList} aria-label="抽出ページ切り替え">
+      {tabs.map(({ to, label, isActive }) => (
+        <NavLink
+          key={to}
+          to={to}
+          className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
+        >
+          {label}
+        </NavLink>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useParams } from "react-router";
+import { NavLink, Outlet, useLocation, useParams } from "react-router";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
@@ -14,17 +14,24 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
 
 function ProjectSubNav({ projectId }: { projectId: string }) {
   const subNavItems = [
-    { to: `/projects/${projectId}`, label: "概要", end: true },
+    { to: `/projects/${projectId}`, label: "ホーム", end: true },
     { to: `/projects/${projectId}/context-files`, label: "コンテキスト" },
     { to: `/projects/${projectId}/test-cases`, label: "テストケース" },
     { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
-    { to: `/projects/${projectId}/runs`, label: "Run 一覧" },
+    { to: `/projects/${projectId}/runs`, label: "Run" },
     { to: `/projects/${projectId}/score`, label: "採点" },
     { to: `/projects/${projectId}/score-progression`, label: "スコア推移" },
-    { to: `/projects/${projectId}/annotation-tasks`, label: "アノテーション設定" },
-    { to: `/projects/${projectId}/annotation-review`, label: "アノテーション" },
+    {
+      to: `/projects/${projectId}/annotation-review`,
+      label: "抽出",
+      matchPaths: [
+        `/projects/${projectId}/annotation-review`,
+        `/projects/${projectId}/annotation-tasks`,
+      ],
+    },
     { to: `/projects/${projectId}/settings`, label: "設定" },
   ];
+  const location = useLocation();
 
   return (
     <div style={{ marginTop: "8px" }}>
@@ -40,8 +47,19 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
       >
         プロジェクト
       </div>
-      {subNavItems.map(({ to, label, end }) => (
-        <NavLink key={to} to={to} end={end} style={navLinkStyle}>
+      {subNavItems.map(({ to, label, end, matchPaths }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={end}
+          style={
+            matchPaths
+              ? navLinkStyle({
+                  isActive: matchPaths.some((path) => location.pathname.startsWith(path)),
+                })
+              : navLinkStyle
+          }
+        >
           {label}
         </NavLink>
       ))}

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -18,6 +18,7 @@ import {
   getTestCases,
   updateAnnotationCandidate,
 } from "../lib/api";
+import { AnnotationSectionTabs } from "../components/AnnotationSectionTabs";
 import styles from "./AnnotationReviewPage.module.css";
 
 function statusLabel(status: CandidateStatus): string {
@@ -334,8 +335,36 @@ export function AnnotationReviewPage() {
   const [searchParams] = useSearchParams();
   const projectId = Number(id);
   const runIdParam = searchParams.get("runId");
+  const mode = searchParams.get("mode");
   const runId = Number(runIdParam);
   const taskId = Number(searchParams.get("taskId"));
+
+  if (mode === "review" && !runIdParam) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.pageHeader}>
+          <div>
+            <h2 className={styles.pageTitle}>抽出</h2>
+            <p className={styles.pageMeta}>
+              Run から抽出した候補をレビューするには、対象の Run とタスクを選択してください。
+            </p>
+            <AnnotationSectionTabs />
+          </div>
+        </div>
+        <div className={styles.rightSection}>
+          <h3 className={styles.panelTitle}>レビューの開始方法</h3>
+          <p className={styles.emptyMsg}>
+            Run ページで候補抽出を実行するか、既存の候補レビューリンクからこの画面を開いてください。
+          </p>
+          <div style={{ padding: "0 16px 16px" }}>
+            <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+              ← Run に戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // runId が指定されていない場合は Gold Annotation ブラウズモード
   if (!runIdParam) {
@@ -453,10 +482,11 @@ export function AnnotationReviewPage() {
           <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
             ← Run 一覧に戻る
           </Link>
-          <h2 className={styles.pageTitle}>Annotation レビュー</h2>
+          <h2 className={styles.pageTitle}>抽出</h2>
           <p className={styles.pageMeta}>
             {project?.name} / Run #{run.id} / {annotationTask.name}
           </p>
+          <AnnotationSectionTabs />
         </div>
       </div>
 
@@ -705,7 +735,11 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
   return (
     <div className={styles.root}>
       <div className={styles.pageHeader}>
-        <h2 className={styles.pageTitle}>Gold Annotation 一覧</h2>
+        <div>
+          <h2 className={styles.pageTitle}>抽出</h2>
+          <p className={styles.pageMeta}>Gold Annotation の確認と手動メンテナンスを行います。</p>
+          <AnnotationSectionTabs />
+        </div>
       </div>
 
       <div className={styles.layout}>

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
@@ -61,6 +61,50 @@
   gap: 16px;
 }
 
+.createTaskSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.inlineForm,
+.taskSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.leftAlignedAction {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.summaryList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 0;
+}
+
+.summaryRow {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.summaryLabel {
+  color: var(--c-muted);
+  font-size: 13px;
+}
+
+.summaryValue {
+  margin: 0;
+  color: var(--c-text);
+  line-height: 1.6;
+  word-break: break-word;
+}
+
 .sectionHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
+import { AnnotationSectionTabs } from "../components/AnnotationSectionTabs";
 import { generateAnnotationPrompt } from "../lib/annotationPrompt";
 import {
   type AnnotationLabel,
@@ -122,6 +123,7 @@ export function AnnotationTaskSettingsPage() {
   const [editingLabelForm, setEditingLabelForm] = useState<LabelFormState>(emptyLabelForm);
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
   const [feedbackTone, setFeedbackTone] = useState<"success" | "error" | null>(null);
+  const [taskFormMode, setTaskFormMode] = useState<"create" | "edit" | null>(null);
 
   const { data: project } = useQuery({
     queryKey: ["project", projectId],
@@ -135,10 +137,15 @@ export function AnnotationTaskSettingsPage() {
   });
 
   useEffect(() => {
+    if (tasksQuery.isLoading) {
+      return;
+    }
+
     const tasks = tasksQuery.data ?? [];
 
     if (tasks.length === 0) {
       setSelectedTaskId(null);
+      setTaskFormMode("create");
       return;
     }
 
@@ -150,7 +157,7 @@ export function AnnotationTaskSettingsPage() {
     if (selectedTaskId === null || !tasks.some((task) => task.id === selectedTaskId)) {
       setSelectedTaskId(firstTask.id);
     }
-  }, [selectedTaskId, tasksQuery.data]);
+  }, [selectedTaskId, tasksQuery.data, tasksQuery.isLoading]);
 
   const taskDetailQuery = useQuery({
     queryKey: ["annotation-task", selectedTaskId],
@@ -202,6 +209,7 @@ export function AnnotationTaskSettingsPage() {
       await refreshTaskData(createdTask.id);
       setSelectedTaskId(createdTask.id);
       setNewTaskForm(emptyTaskForm);
+      setTaskFormMode(null);
       showFeedback("アノテーションタスクを作成しました。", "success");
     },
     onError: () => {
@@ -361,11 +369,12 @@ export function AnnotationTaskSettingsPage() {
       <div className={styles.pageHeader}>
         <div>
           <p className={styles.eyebrow}>Annotation Task Settings</p>
-          <h2 className={styles.pageTitle}>アノテーション設定</h2>
+          <h2 className={styles.pageTitle}>抽出</h2>
           <p className={styles.pageDescription}>
             {project?.name ?? "プロジェクト"} で使う annotation task と label を準備します。
             現在の初期実装では output mode は <code>span_label</code> 固定です。
           </p>
+          <AnnotationSectionTabs />
         </div>
         {feedbackMessage && (
           <p className={feedbackTone === "error" ? styles.feedbackError : styles.feedbackSuccess}>
@@ -379,54 +388,9 @@ export function AnnotationTaskSettingsPage() {
           <div className={styles.sectionHeader}>
             <div>
               <h3 className={styles.sectionTitle}>タスク一覧</h3>
-              <p className={styles.sectionHint}>Review 用に使う task を選択・追加できます。</p>
+              <p className={styles.sectionHint}>Review 用に使う task を選択できます。</p>
             </div>
           </div>
-
-          <form
-            className={styles.panel}
-            onSubmit={(event) => {
-              event.preventDefault();
-              createTaskMutation.mutate();
-            }}
-          >
-            <label className={styles.fieldLabel} htmlFor="new-task-name">
-              新規タスク名
-            </label>
-            <input
-              id="new-task-name"
-              className={styles.fieldInput}
-              value={newTaskForm.name}
-              onChange={(event) =>
-                setNewTaskForm((current) => ({ ...current, name: event.target.value }))
-              }
-              placeholder="例: 回答品質アノテーション"
-            />
-
-            <label className={styles.fieldLabel} htmlFor="new-task-description">
-              説明
-            </label>
-            <textarea
-              id="new-task-description"
-              className={styles.fieldTextarea}
-              value={newTaskForm.description}
-              onChange={(event) =>
-                setNewTaskForm((current) => ({ ...current, description: event.target.value }))
-              }
-              placeholder="任意: この task の目的や判定基準"
-              rows={4}
-            />
-
-            <div className={styles.outputModeBox}>
-              <span className={styles.outputModeLabel}>Output mode</span>
-              <strong className={styles.outputModeValue}>span_label</strong>
-              <p className={styles.outputModeHint}>初期実装では固定です。</p>
-            </div>
-
-            <button type="submit" className={styles.primaryButton} disabled={!canCreateTask}>
-              {createTaskMutation.isPending ? "作成中..." : "タスクを追加"}
-            </button>
-          </form>
 
           <div className={styles.taskList}>
             {tasksQuery.isLoading && <p className={styles.stateText}>タスクを読み込み中...</p>}
@@ -459,6 +423,202 @@ export function AnnotationTaskSettingsPage() {
               );
             })}
           </div>
+
+          <div className={styles.createTaskSection}>
+            {taskFormMode === "create" && (
+              <form
+                className={styles.panel}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  createTaskMutation.mutate();
+                }}
+              >
+                <label className={styles.fieldLabel} htmlFor="new-task-name">
+                  新規タスク名
+                </label>
+                <input
+                  id="new-task-name"
+                  className={styles.fieldInput}
+                  value={newTaskForm.name}
+                  onChange={(event) =>
+                    setNewTaskForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                  placeholder="例: 回答品質アノテーション"
+                />
+
+                <label className={styles.fieldLabel} htmlFor="new-task-description">
+                  説明
+                </label>
+                <textarea
+                  id="new-task-description"
+                  className={styles.fieldTextarea}
+                  value={newTaskForm.description}
+                  onChange={(event) =>
+                    setNewTaskForm((current) => ({ ...current, description: event.target.value }))
+                  }
+                  placeholder="任意: この task の目的や判定基準"
+                  rows={4}
+                />
+
+                <div className={styles.outputModeBox}>
+                  <span className={styles.outputModeLabel}>Output mode</span>
+                  <strong className={styles.outputModeValue}>span_label</strong>
+                  <p className={styles.outputModeHint}>初期実装では固定です。</p>
+                </div>
+
+                <div className={styles.formFooter}>
+                  <button type="submit" className={styles.primaryButton} disabled={!canCreateTask}>
+                    {createTaskMutation.isPending ? "作成中..." : "タスクを追加"}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.ghostButton}
+                    onClick={() => setTaskFormMode(null)}
+                    disabled={createTaskMutation.isPending}
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </form>
+            )}
+
+            <div className={styles.leftAlignedAction}>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => setTaskFormMode((current) => (current === "create" ? null : "create"))}
+                aria-expanded={taskFormMode === "create"}
+              >
+                {taskFormMode === "create" ? "新規タスク作成を閉じる" : "新規タスクを作成"}
+              </button>
+            </div>
+          </div>
+
+          {selectedTaskId !== null &&
+            !taskDetailQuery.isLoading &&
+            !taskDetailQuery.isError &&
+            taskDetailQuery.data && (
+              <section className={styles.panel}>
+                <div className={styles.sectionHeader}>
+                  <div>
+                    <h3 className={styles.sectionTitle}>タスク設定</h3>
+                    <p className={styles.sectionHint}>
+                      Review に使う task 本体の名前と説明を編集します。
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className={styles.dangerButton}
+                    onClick={() => deleteTaskMutation.mutate()}
+                    disabled={deleteTaskMutation.isPending}
+                  >
+                    {deleteTaskMutation.isPending ? "削除中..." : "タスクを削除"}
+                  </button>
+                </div>
+
+                {taskFormMode === "edit" ? (
+                  <form
+                    className={styles.inlineForm}
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      updateTaskMutation.mutate();
+                    }}
+                  >
+                    <div className={styles.fieldGrid}>
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="task-name">
+                          タスク名
+                        </label>
+                        <input
+                          id="task-name"
+                          className={styles.fieldInput}
+                          value={taskForm.name}
+                          onChange={(event) =>
+                            setTaskForm((current) => ({ ...current, name: event.target.value }))
+                          }
+                        />
+                      </div>
+
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="task-output-mode">
+                          Output mode
+                        </label>
+                        <input
+                          id="task-output-mode"
+                          className={styles.fieldInput}
+                          value="span_label"
+                          disabled
+                        />
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel} htmlFor="task-description">
+                        説明
+                      </label>
+                      <textarea
+                        id="task-description"
+                        className={styles.fieldTextarea}
+                        value={taskForm.description}
+                        onChange={(event) =>
+                          setTaskForm((current) => ({ ...current, description: event.target.value }))
+                        }
+                        rows={5}
+                        placeholder="任意: アノテーション方針やラベルの使い分けを記載"
+                      />
+                    </div>
+
+                    <div className={styles.formFooter}>
+                      <button
+                        type="submit"
+                        className={styles.primaryButton}
+                        disabled={!canUpdateTask}
+                      >
+                        {updateTaskMutation.isPending ? "保存中..." : "タスク設定を保存"}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.ghostButton}
+                        onClick={() => setTaskFormMode(null)}
+                        disabled={updateTaskMutation.isPending}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <div className={styles.taskSummary}>
+                    <dl className={styles.summaryList}>
+                      <div className={styles.summaryRow}>
+                        <dt className={styles.summaryLabel}>タスク名</dt>
+                        <dd className={styles.summaryValue}>{taskDetailQuery.data.name}</dd>
+                      </div>
+                      <div className={styles.summaryRow}>
+                        <dt className={styles.summaryLabel}>Output mode</dt>
+                        <dd className={styles.summaryValue}>span_label</dd>
+                      </div>
+                      <div className={styles.summaryRow}>
+                        <dt className={styles.summaryLabel}>説明</dt>
+                        <dd className={styles.summaryValue}>
+                          {taskDetailQuery.data.description?.trim() || "未設定"}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+                )}
+
+                <div className={styles.leftAlignedAction}>
+                  <button
+                    type="button"
+                    className={styles.secondaryButton}
+                    onClick={() => setTaskFormMode((current) => (current === "edit" ? null : "edit"))}
+                    aria-expanded={taskFormMode === "edit"}
+                  >
+                    {taskFormMode === "edit" ? "タスク編集を閉じる" : "タスクを編集"}
+                  </button>
+                </div>
+              </section>
+            )}
         </section>
 
         <section className={styles.contentSection}>
@@ -478,99 +638,23 @@ export function AnnotationTaskSettingsPage() {
               <p className={styles.errorText}>タスク詳細の取得に失敗しました。</p>
             </div>
           ) : (
-            <>
+            <div className={styles.labelSection}>
+              <div className={styles.sectionHeader}>
+                <div>
+                  <h3 className={styles.sectionTitle}>ラベル設定</h3>
+                  <p className={styles.sectionHint}>
+                    表示名、内部 key、色、表示順を UI から管理できます。
+                  </p>
+                </div>
+              </div>
+
               <form
                 className={styles.panel}
                 onSubmit={(event) => {
                   event.preventDefault();
-                  updateTaskMutation.mutate();
+                  createLabelMutation.mutate();
                 }}
               >
-                <div className={styles.sectionHeader}>
-                  <div>
-                    <h3 className={styles.sectionTitle}>タスク設定</h3>
-                    <p className={styles.sectionHint}>
-                      Review に使う task 本体の名前と説明を編集します。
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.dangerButton}
-                    onClick={() => deleteTaskMutation.mutate()}
-                    disabled={deleteTaskMutation.isPending}
-                  >
-                    {deleteTaskMutation.isPending ? "削除中..." : "タスクを削除"}
-                  </button>
-                </div>
-
-                <div className={styles.fieldGrid}>
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="task-name">
-                      タスク名
-                    </label>
-                    <input
-                      id="task-name"
-                      className={styles.fieldInput}
-                      value={taskForm.name}
-                      onChange={(event) =>
-                        setTaskForm((current) => ({ ...current, name: event.target.value }))
-                      }
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="task-output-mode">
-                      Output mode
-                    </label>
-                    <input
-                      id="task-output-mode"
-                      className={styles.fieldInput}
-                      value="span_label"
-                      disabled
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.fieldGroup}>
-                  <label className={styles.fieldLabel} htmlFor="task-description">
-                    説明
-                  </label>
-                  <textarea
-                    id="task-description"
-                    className={styles.fieldTextarea}
-                    value={taskForm.description}
-                    onChange={(event) =>
-                      setTaskForm((current) => ({ ...current, description: event.target.value }))
-                    }
-                    rows={5}
-                    placeholder="任意: アノテーション方針やラベルの使い分けを記載"
-                  />
-                </div>
-
-                <div className={styles.formFooter}>
-                  <button type="submit" className={styles.primaryButton} disabled={!canUpdateTask}>
-                    {updateTaskMutation.isPending ? "保存中..." : "タスク設定を保存"}
-                  </button>
-                </div>
-              </form>
-
-              <div className={styles.labelSection}>
-                <div className={styles.sectionHeader}>
-                  <div>
-                    <h3 className={styles.sectionTitle}>ラベル設定</h3>
-                    <p className={styles.sectionHint}>
-                      表示名、内部 key、色、表示順を UI から管理できます。
-                    </p>
-                  </div>
-                </div>
-
-                <form
-                  className={styles.panel}
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    createLabelMutation.mutate();
-                  }}
-                >
                   <div className={styles.fieldGrid}>
                     <div className={styles.fieldGroup}>
                       <label className={styles.fieldLabel} htmlFor="new-label-key">
@@ -658,34 +742,34 @@ export function AnnotationTaskSettingsPage() {
                       {createLabelMutation.isPending ? "追加中..." : "ラベルを追加"}
                     </button>
                   </div>
-                </form>
+              </form>
 
-                <div className={styles.labelList}>
-                  {sortedLabels.length === 0 ? (
-                    <div className={styles.emptyState}>
-                      <p className={styles.stateText}>
-                        まだ label はありません。Review で選びたいラベルを追加してください。
-                      </p>
-                    </div>
-                  ) : (
-                    sortedLabels.map((label) => {
-                      const isEditing = label.id === editingLabelId;
-                      const currentForm = isEditing ? editingLabelForm : buildLabelForm(label);
+              <div className={styles.labelList}>
+                {sortedLabels.length === 0 ? (
+                  <div className={styles.emptyState}>
+                    <p className={styles.stateText}>
+                      まだ label はありません。Review で選びたいラベルを追加してください。
+                    </p>
+                  </div>
+                ) : (
+                  sortedLabels.map((label) => {
+                    const isEditing = label.id === editingLabelId;
+                    const currentForm = isEditing ? editingLabelForm : buildLabelForm(label);
 
-                      return (
-                        <form
-                          key={label.id}
-                          className={styles.labelCard}
-                          onSubmit={(event) => {
-                            event.preventDefault();
-                            if (!isEditing) {
-                              setEditingLabelId(label.id);
-                              setEditingLabelForm(buildLabelForm(label));
-                              return;
-                            }
-                            updateLabelMutation.mutate();
-                          }}
-                        >
+                    return (
+                      <form
+                        key={label.id}
+                        className={styles.labelCard}
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          if (!isEditing) {
+                            setEditingLabelId(label.id);
+                            setEditingLabelForm(buildLabelForm(label));
+                            return;
+                          }
+                          updateLabelMutation.mutate();
+                        }}
+                      >
                           <div className={styles.labelCardHeader}>
                             <div>
                               <h4 className={styles.labelTitle}>{label.name}</h4>
@@ -828,11 +912,10 @@ export function AnnotationTaskSettingsPage() {
                               </button>
                             </div>
                           )}
-                        </form>
-                      );
-                    })
-                  )}
-                </div>
+                      </form>
+                    );
+                  })
+                )}
               </div>
 
               {/* プロンプト生成パネル */}
@@ -937,7 +1020,7 @@ export function AnnotationTaskSettingsPage() {
                   </div>
                 )}
               </div>
-            </>
+            </div>
           )}
         </section>
       </div>


### PR DESCRIPTION
## 概要
- サイドバーの抽出導線を整理し、抽出関連ページをタブで切り替えられるように変更
- 抽出設定タブのレイアウトを見直し、タスク一覧・新規作成・タスク設定の導線を整理
- 抽出時の context への行番号付与を復元し、レビュー画面との行番号ずれを再度防止

## 変更内容
- サイドバー文言を見直し、アノテーション関連を 抽出 に集約
- レビュー / ゴールドアノテーション / 設定 の共通タブを追加
- 抽出設定画面で新規作成フォームとタスク編集フォームを開閉式に変更
- タスク設定カードを左カラム下部へ移動して配置を整理
- Run 実行時と workflow 実行時の両方で context に行番号を付与するよう修正
- 行番号付与に合わせて runs テストの期待値を更新

## 確認
- pnpm exec vitest run packages/server/src/routes/runs.test.ts
- pnpm run typecheck

Closes #161