### PR TITLE
feat: max_tokensをexecution profileとproject settingsに追加

### DIFF
--- a/packages/core/drizzle/0016_max_tokens.sql
+++ b/packages/core/drizzle/0016_max_tokens.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `execution_profiles` ADD `max_tokens` integer;
+--> statement-breakpoint
+ALTER TABLE `project_settings` ADD `max_tokens` integer;

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1776658349002,
       "tag": "0015_noisy_gauntlet",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1745193600000,
+      "tag": "0016_max_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/schema/execution-profiles.ts
+++ b/packages/core/src/schema/execution-profiles.ts
@@ -13,6 +13,7 @@ export const execution_profiles = sqliteTable("execution_profiles", {
   api_provider: text("api_provider", { enum: ["anthropic", "openai"] })
     .notNull()
     .default("anthropic"),
+  max_tokens: integer("max_tokens"),
   created_at: integer("created_at").notNull(),
   updated_at: integer("updated_at").notNull(),
 });

--- a/packages/core/src/schema/projects.ts
+++ b/packages/core/src/schema/projects.ts
@@ -27,6 +27,7 @@ export const project_settings = sqliteTable("project_settings", {
   api_provider: text("api_provider", { enum: ["anthropic", "openai"] })
     .notNull()
     .default("anthropic"),
+  max_tokens: integer("max_tokens"),
   created_at: integer("created_at").notNull(),
   updated_at: integer("updated_at").notNull(),
 });

--- a/packages/server/src/routes/execution-profiles.ts
+++ b/packages/server/src/routes/execution-profiles.ts
@@ -22,6 +22,12 @@ const createExecutionProfileSchema = z.object({
   api_provider: z.enum(["anthropic", "openai"], {
     error: 'api_providerは "anthropic" または "openai" である必要があります',
   }),
+  max_tokens: z
+    .number()
+    .int("max_tokensは整数が必要です")
+    .min(1, "max_tokensは1以上が必要です")
+    .nullable()
+    .optional(),
 });
 
 const updateExecutionProfileSchema = z
@@ -38,6 +44,12 @@ const updateExecutionProfileSchema = z
       .enum(["anthropic", "openai"], {
         error: 'api_providerは "anthropic" または "openai" である必要があります',
       })
+      .optional(),
+    max_tokens: z
+      .number()
+      .int("max_tokensは整数が必要です")
+      .min(1, "max_tokensは1以上が必要です")
+      .nullable()
       .optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
@@ -160,6 +172,7 @@ function buildCreateValues(body: CreateExecutionProfileBody, now: number) {
     model: body.model,
     temperature: body.temperature,
     api_provider: body.api_provider,
+    max_tokens: body.max_tokens ?? null,
     created_at: now,
     updated_at: now,
   };
@@ -172,6 +185,7 @@ function buildUpdateValues(body: UpdateExecutionProfileBody, now: number) {
     ...(body.model !== undefined ? { model: body.model } : {}),
     ...(body.temperature !== undefined ? { temperature: body.temperature } : {}),
     ...(body.api_provider !== undefined ? { api_provider: body.api_provider } : {}),
+    ...(body.max_tokens !== undefined ? { max_tokens: body.max_tokens } : {}),
     updated_at: now,
   };
 }

--- a/packages/server/src/routes/project-settings.ts
+++ b/packages/server/src/routes/project-settings.ts
@@ -20,6 +20,12 @@ const upsertSettingsSchema = z.object({
   api_provider: z.enum(["anthropic", "openai"], {
     error: 'api_providerは "anthropic" または "openai" である必要があります',
   }),
+  max_tokens: z
+    .number()
+    .int("max_tokensは整数が必要です")
+    .min(1, "max_tokensは1以上が必要です")
+    .nullable()
+    .optional(),
 });
 
 type UpsertBody = z.infer<typeof upsertSettingsSchema>;
@@ -63,6 +69,7 @@ function upsertDefaultExecutionProfile(
         model: body.model,
         temperature: body.temperature,
         api_provider: body.api_provider,
+        max_tokens: body.max_tokens ?? null,
         updated_at: now,
       })
       .where(eq(execution_profiles.id, existing.id))
@@ -77,6 +84,7 @@ function upsertDefaultExecutionProfile(
       model: body.model,
       temperature: body.temperature,
       api_provider: body.api_provider,
+      max_tokens: body.max_tokens ?? null,
       created_at: now,
       updated_at: now,
     })
@@ -141,6 +149,7 @@ export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRout
             model: body.model,
             temperature: body.temperature,
             api_provider: body.api_provider,
+            max_tokens: body.max_tokens ?? null,
             updated_at: now,
           })
           .where(eq(project_settings.project_id, projectId))
@@ -163,6 +172,7 @@ export function createProjectSettingsRouter(db: DB, options: ProjectSettingsRout
           model: body.model,
           temperature: body.temperature,
           api_provider: body.api_provider,
+          max_tokens: body.max_tokens ?? null,
           created_at: now,
           updated_at: now,
         })

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -133,6 +133,7 @@ type ExecutionSettings = {
   model: string;
   temperature: number;
   api_provider: string;
+  max_tokens: number | null;
 };
 
 const encoder = new TextEncoder();
@@ -212,7 +213,9 @@ function parseStructuredItems(
 function addLineNumbers(text: string): string {
   const lines = text.split("\n");
   const width = String(lines.length).length;
-  return lines.map((line, index) => `${String(index + 1).padStart(width, " ")}: ${line}`).join("\n");
+  return lines
+    .map((line, index) => `${String(index + 1).padStart(width, " ")}: ${line}`)
+    .join("\n");
 }
 
 function buildSystemPrompt(version: StoredPromptVersion, testCase: StoredTestCase): string {
@@ -288,7 +291,9 @@ function buildExecutionRequest(params: {
   messages: ConversationMessage[];
   systemPrompt: string;
   temperature: number;
+  maxTokens: number | null;
 }): { request: LLMRequest; conversationBase: ConversationMessage[] } | null {
+  const maxTokens = params.maxTokens ?? undefined;
   if (params.messages.length > 0) {
     return {
       request: {
@@ -296,6 +301,7 @@ function buildExecutionRequest(params: {
         messages: params.messages,
         systemPrompt: params.systemPrompt,
         temperature: params.temperature,
+        ...(maxTokens !== undefined ? { maxTokens } : {}),
       },
       conversationBase: params.messages,
     };
@@ -312,6 +318,7 @@ function buildExecutionRequest(params: {
       model: params.model,
       messages: fallbackMessages,
       temperature: params.temperature,
+      ...(maxTokens !== undefined ? { maxTokens } : {}),
     },
     conversationBase: fallbackMessages,
   };
@@ -554,6 +561,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         model: profile.model,
         temperature: profile.temperature,
         api_provider: profile.api_provider,
+        max_tokens: profile.max_tokens,
       };
       resolvedExecutionProfileId = profile.id;
     } else {
@@ -570,6 +578,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         model: projectSettings.model,
         temperature: projectSettings.temperature,
         api_provider: projectSettings.api_provider,
+        max_tokens: projectSettings.max_tokens,
       };
     }
 
@@ -593,6 +602,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       messages: parseConversation(storedTestCase.turns),
       systemPrompt: buildSystemPrompt(version, storedTestCase),
       temperature: settings.temperature,
+      maxTokens: settings.max_tokens,
     });
     const workflow = parseWorkflowDefinition(version.workflow_definition);
     const workflowSteps = buildWorkflowSteps(version, workflow);
@@ -630,6 +640,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
                   messages: inputConversation,
                   systemPrompt: renderedPrompt,
                   temperature: settings.temperature,
+                  maxTokens: settings.max_tokens,
                 });
 
                 if (!stepExecution) {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -650,6 +650,7 @@ export type ProjectSettings = {
   model: string;
   temperature: number;
   api_provider: "anthropic" | "openai";
+  max_tokens: number | null;
   created_at: number;
   updated_at: number;
 };
@@ -668,7 +669,12 @@ export function getProjectSettings(projectId: number): Promise<ProjectSettings> 
 
 export function upsertProjectSettings(
   projectId: number,
-  data: { model: string; temperature: number; api_provider: ApiProvider },
+  data: {
+    model: string;
+    temperature: number;
+    api_provider: ApiProvider;
+    max_tokens: number | null;
+  },
 ): Promise<ProjectSettings> {
   return api.put<ProjectSettings>(`/projects/${projectId}/settings`, data);
 }

--- a/packages/ui/src/pages/ProjectSettingsPage.tsx
+++ b/packages/ui/src/pages/ProjectSettingsPage.tsx
@@ -22,6 +22,7 @@ export function ProjectSettingsPage() {
   const [model, setModel] = useState("");
   const [temperature, setTemperature] = useState(0.7);
   const [apiProvider, setApiProvider] = useState<ApiProvider>("anthropic");
+  const [maxTokens, setMaxTokens] = useState<number | null>(null);
   const [initialized, setInitialized] = useState(false);
 
   const [saveFeedback, setSaveFeedback] = useState<"success" | "error" | null>(null);
@@ -63,6 +64,7 @@ export function ProjectSettingsPage() {
       setModel(settingsData.model);
       setTemperature(settingsData.temperature);
       setApiProvider(settingsData.api_provider);
+      setMaxTokens(settingsData.max_tokens);
       setInitialized(true);
     }
   }, [settingsData, initialized]);
@@ -86,6 +88,7 @@ export function ProjectSettingsPage() {
         model,
         temperature,
         api_provider: apiProvider,
+        max_tokens: maxTokens,
       }),
     onSuccess: () => {
       setSaveFeedback("success");
@@ -227,6 +230,27 @@ export function ProjectSettingsPage() {
               <span className={styles.sliderValue}>{temperature.toFixed(1)}</span>
             </div>
             <p className={styles.fieldHint}>0.0（より決定論的）〜 2.0（よりランダム）</p>
+          </div>
+
+          {/* Max Tokens */}
+          <div className={styles.fieldGroup}>
+            <label htmlFor="settings-max-tokens" className={styles.fieldLabel}>
+              Max Tokens
+            </label>
+            <input
+              id="settings-max-tokens"
+              type="number"
+              min={1}
+              step={1}
+              value={maxTokens ?? ""}
+              onChange={(e) => setMaxTokens(e.target.value === "" ? null : Number(e.target.value))}
+              placeholder="デフォルト (4096)"
+              className={styles.fieldInput}
+            />
+            <p className={styles.fieldHint}>
+              LLM の出力トークン上限。長い出力が途中で切れる場合は増やしてください（例:
+              16000）。空欄でデフォルト値 (4096) を使用。
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- `execution_profiles`と`project_settings`テーブルに`max_tokens`カラム（nullable integer）を追加
- マイグレーション`0016_max_tokens.sql`を追加
- `buildExecutionRequest`が`maxTokens`を`LLMRequest`に渡すよう修正
- プロジェクト設定画面（ProjectSettingsPage）に Max Tokens 入力フィールドを追加
- 未設定（null）の場合はAnthropicクライアントのデフォルト値（4096）を使用

## 背景

長い会話コンテキストに対してJSONアノテーションを生成するRunが`DEFAULT_MAX_TOKENS = 4096`の上限に達してJSON出力が途中で切れる問題があった。この修正によりプロジェクト設定でmax_tokensを16000など大きな値に変更できるようになる。

## Test plan

- [ ] プロジェクト設定画面でMax Tokensフィールドが表示される
- [ ] 値を入力して保存するとDBに反映される
- [ ] 空欄のまま保存するとnull（デフォルト4096）が使われる
- [ ] Run実行時にmax_tokensがAnthropicAPIへ渡される
- [ ] 全テスト通過（417 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)