### PR TITLE
[codex] 旧 context-files API を context_assets 互換レイヤー化

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -88,7 +88,7 @@ app.route("/api/context-assets", createContextAssetsRouter(db));
 app.route("/api/projects", createProjectsRouter(db));
 app.route("/api/execution-profiles", createExecutionProfilesRouter(db));
 app.route("/api/prompt-families", createPromptFamiliesRouter(db));
-app.route("/api/projects/:projectId/context-files", createContextFilesRouter());
+app.route("/api/projects/:projectId/context-files", createContextFilesRouter(db));
 app.route("/api/test-cases", createTestCasesRouter(db));
 app.route("/api/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));

--- a/packages/server/src/routes/context-files.test.ts
+++ b/packages/server/src/routes/context-files.test.ts
@@ -1,55 +1,122 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockReturnValue({}),
+  };
+});
+
+import type { DB } from "@prompt-reviewer/core";
 import { Hono } from "hono";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createContextFilesRouter } from "./context-files.js";
 
-async function createTempDir(): Promise<string> {
-  return mkdtemp(path.join(os.tmpdir(), "prompt-reviewer-context-files-"));
-}
+type MockContextAsset = {
+  id: number;
+  name: string;
+  path: string;
+  content: string;
+  mime_type: string;
+  content_hash: string | null;
+  created_at: number;
+  updated_at: number;
+};
 
-function buildApp(baseDir: string) {
+function buildApp(db: unknown) {
   const app = new Hono();
-  app.route("/api/projects/:projectId/context-files", createContextFilesRouter({ baseDir }));
+  app.route("/api/projects/:projectId/context-files", createContextFilesRouter(db as DB));
   return app;
 }
 
-const cleanupTargets: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    cleanupTargets.splice(0).map((target) => rm(target, { recursive: true, force: true })),
-  );
-});
+const sampleAsset: MockContextAsset = {
+  id: 1,
+  name: "guide.md",
+  path: "docs/guide.md",
+  content: "# guide",
+  mime_type: "text/markdown",
+  content_hash: "sha256:guide",
+  created_at: 1000000,
+  updated_at: 1000100,
+};
 
 describe("context files router", () => {
-  it("GET /api/projects/:projectId/context-files returns uploaded files", async () => {
-    const baseDir = await createTempDir();
-    cleanupTargets.push(baseDir);
-    const projectDir = path.join(baseDir, "12");
-    await mkdir(path.join(projectDir, "docs"), { recursive: true });
-    await writeFile(path.join(projectDir, "docs", "guide.md"), "# guide", {
-      encoding: "utf8",
-      flag: "w",
+  it("GET /api/projects/:projectId/context-files は project ラベル付き素材だけ返す", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ context_asset_id: 1 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () =>
+            Promise.resolve([
+              sampleAsset,
+              {
+                ...sampleAsset,
+                id: 2,
+                name: "other.md",
+                path: "docs/other.md",
+              },
+            ]),
+        };
+      },
     });
 
-    const app = buildApp(baseDir);
     const res = await app.request("/api/projects/12/context-files");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as Array<{ path: string; name: string }>;
-    expect(body).toHaveLength(1);
-    expect(body[0]?.path).toBe("docs/guide.md");
-    expect(body[0]?.name).toBe("guide.md");
+    await expect(res.json()).resolves.toEqual([
+      {
+        name: "guide.md",
+        path: "docs/guide.md",
+        mime_type: "text/markdown",
+        size: Buffer.byteLength("# guide", "utf8"),
+        updated_at: 1000100,
+      },
+    ]);
   });
 
-  it("POST /api/projects/:projectId/context-files creates a file under the project directory", async () => {
-    const baseDir = await createTempDir();
-    cleanupTargets.push(baseDir);
-    const app = buildApp(baseDir);
+  it("POST /api/projects/:projectId/context-files は context asset を作成して project に紐付ける", async () => {
+    const created = {
+      ...sampleAsset,
+      id: 10,
+      name: "policy.txt",
+      path: "snapshots/policy.txt",
+      content: "refund within 30 days",
+      mime_type: "text/plain",
+    };
+    let insertCallCount = 0;
+    let capturedAssetValues: Record<string, unknown> = {};
+    let capturedLinkValues: Record<string, unknown> = {};
 
-    const res = await app.request("/api/projects/3/context-files", {
+    const db = {
+      insert: () => {
+        insertCallCount++;
+        if (insertCallCount === 1) {
+          return {
+            values: (values: Record<string, unknown>) => {
+              capturedAssetValues = values;
+              return {
+                returning: () => Promise.resolve([created]),
+              };
+            },
+          };
+        }
+
+        return {
+          values: (values: Record<string, unknown>) => {
+            capturedLinkValues = values;
+            return Promise.resolve();
+          },
+        };
+      },
+    };
+
+    const res = await buildApp(db).request("/api/projects/3/context-files", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -59,51 +126,156 @@ describe("context files router", () => {
     });
 
     expect(res.status).toBe(201);
-    const saved = await readFile(path.join(baseDir, "3", "snapshots", "policy.txt"), "utf8");
-    expect(saved).toBe("refund within 30 days");
+    expect(capturedAssetValues.name).toBe("policy.txt");
+    expect(capturedAssetValues.path).toBe("snapshots/policy.txt");
+    expect(capturedAssetValues.mime_type).toBe("text/plain");
+    expect(typeof capturedAssetValues.content_hash).toBe("string");
+    expect(capturedLinkValues.context_asset_id).toBe(10);
+    expect(capturedLinkValues.project_id).toBe(3);
   });
 
-  it("GET /content returns file content", async () => {
-    const baseDir = await createTempDir();
-    cleanupTargets.push(baseDir);
-    const targetPath = path.join(baseDir, "7", "context.md");
-    await mkdir(path.dirname(targetPath), { recursive: true });
-    await writeFile(targetPath, "hello context", { encoding: "utf8", flag: "w" });
+  it("GET /content は project に紐付いた同一 path の素材を返す", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ context_asset_id: 2 }]),
+            }),
+          };
+        }
 
-    const app = buildApp(baseDir);
-    const res = await app.request("/api/projects/7/context-files/content?path=context.md");
+        return {
+          from: () =>
+            Promise.resolve([
+              sampleAsset,
+              {
+                ...sampleAsset,
+                id: 2,
+                content: "project specific",
+              },
+            ]),
+        };
+      },
+    });
+
+    const res = await app.request("/api/projects/7/context-files/content?path=docs/guide.md");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { content: string; path: string };
-    expect(body.content).toBe("hello context");
-    expect(body.path).toBe("context.md");
+    await expect(res.json()).resolves.toEqual({
+      name: "guide.md",
+      path: "docs/guide.md",
+      mime_type: "text/markdown",
+      size: Buffer.byteLength("project specific", "utf8"),
+      updated_at: 1000100,
+      content: "project specific",
+    });
   });
 
-  it("PUT /content updates an existing file", async () => {
-    const baseDir = await createTempDir();
-    cleanupTargets.push(baseDir);
-    const targetPath = path.join(baseDir, "9", "drafts", "memo.md");
-    await mkdir(path.dirname(targetPath), { recursive: true });
-    await writeFile(targetPath, "before", { encoding: "utf8", flag: "w" });
+  it("PUT /content は path から解決した asset を更新する", async () => {
+    let selectCallCount = 0;
+    let capturedUpdateValues: Record<string, unknown> = {};
+    const updated = {
+      ...sampleAsset,
+      id: 2,
+      content: "after",
+      updated_at: 2000000,
+    };
 
-    const app = buildApp(baseDir);
-    const res = await app.request("/api/projects/9/context-files/content?path=drafts/memo.md", {
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ context_asset_id: 2 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () =>
+            Promise.resolve([
+              sampleAsset,
+              {
+                ...sampleAsset,
+                id: 2,
+                content: "before",
+              },
+            ]),
+        };
+      },
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          capturedUpdateValues = values;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+    });
+
+    const res = await app.request("/api/projects/9/context-files/content?path=docs/guide.md", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content: "after" }),
     });
 
     expect(res.status).toBe(200);
-    const saved = await readFile(targetPath, "utf8");
-    expect(saved).toBe("after");
+    expect(capturedUpdateValues.content).toBe("after");
+    expect(typeof capturedUpdateValues.content_hash).toBe("string");
     const body = (await res.json()) as { content: string };
     expect(body.content).toBe("after");
   });
 
-  it("rejects traversal paths", async () => {
-    const baseDir = await createTempDir();
-    cleanupTargets.push(baseDir);
-    const app = buildApp(baseDir);
+  it("project フィルタ外の素材は一覧に含めない", async () => {
+    let selectCallCount = 0;
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ context_asset_id: 2 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () =>
+            Promise.resolve([
+              sampleAsset,
+              {
+                ...sampleAsset,
+                id: 2,
+                name: "selected.md",
+                path: "docs/selected.md",
+              },
+            ]),
+        };
+      },
+    });
+
+    const res = await app.request("/api/projects/4/context-files");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([
+      {
+        name: "selected.md",
+        path: "docs/selected.md",
+        mime_type: "text/markdown",
+        size: Buffer.byteLength("# guide", "utf8"),
+        updated_at: 1000100,
+      },
+    ]);
+  });
+
+  it("不正な path を拒否する", async () => {
+    const app = buildApp({});
 
     const res = await app.request("/api/projects/4/context-files", {
       method: "POST",
@@ -115,5 +287,15 @@ describe("context files router", () => {
     });
 
     expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid file_name" });
+  });
+
+  it("GET /content の不正な path は 400 を返す", async () => {
+    const app = buildApp({});
+
+    const res = await app.request("/api/projects/4/context-files/content?path=../escape.txt");
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid path" });
   });
 });

--- a/packages/server/src/routes/context-files.test.ts
+++ b/packages/server/src/routes/context-files.test.ts
@@ -94,6 +94,11 @@ describe("context files router", () => {
     let capturedLinkValues: Record<string, unknown> = {};
 
     const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
       insert: () => {
         insertCallCount++;
         if (insertCallCount === 1) {
@@ -132,6 +137,69 @@ describe("context files router", () => {
     expect(typeof capturedAssetValues.content_hash).toBe("string");
     expect(capturedLinkValues.context_asset_id).toBe(10);
     expect(capturedLinkValues.project_id).toBe(3);
+  });
+
+  it("同じ path を再投稿した場合は新規作成せず既存 asset を更新する", async () => {
+    let selectCallCount = 0;
+    let updateCalled = false;
+    let insertCalled = false;
+    let capturedUpdateValues: Record<string, unknown> = {};
+    const updated = {
+      ...sampleAsset,
+      content: "updated content",
+      updated_at: 2000000,
+    };
+
+    const app = buildApp({
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ context_asset_id: 1 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () => Promise.resolve([sampleAsset]),
+        };
+      },
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updateCalled = true;
+          capturedUpdateValues = values;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([updated]),
+            }),
+          };
+        },
+      }),
+      insert: () => {
+        insertCalled = true;
+        return {
+          values: () => Promise.resolve(),
+        };
+      },
+    });
+
+    const res = await app.request("/api/projects/3/context-files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        file_name: "docs/guide.md",
+        content: "updated content",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(updateCalled).toBe(true);
+    expect(insertCalled).toBe(false);
+    expect(capturedUpdateValues.content).toBe("updated content");
+    expect(capturedUpdateValues.path).toBe("docs/guide.md");
+    expect(capturedUpdateValues.name).toBe("guide.md");
+    expect(capturedUpdateValues.mime_type).toBe("text/markdown");
   });
 
   it("GET /content は project に紐付いた同一 path の素材を返す", async () => {

--- a/packages/server/src/routes/context-files.ts
+++ b/packages/server/src/routes/context-files.ts
@@ -144,6 +144,29 @@ export function createContextFilesRouter(db: DB) {
 
     const now = Date.now();
     const mimeType = body.mime_type ?? inferMimeType(safePath);
+    const existing = await findProjectContextAssetByPath(db, projectId, safePath);
+
+    if (existing) {
+      const [updated] = await db
+        .update(context_assets)
+        .set({
+          name: path.basename(safePath),
+          path: safePath,
+          content: body.content,
+          mime_type: mimeType,
+          content_hash: buildContentHash(body.content),
+          updated_at: now,
+        })
+        .where(eq(context_assets.id, existing.id))
+        .returning();
+
+      if (!updated) {
+        return c.json({ error: "Failed to update context file" }, 500);
+      }
+
+      return c.json(toSummary(updated), 201);
+    }
+
     const [created] = await db
       .insert(context_assets)
       .values({

--- a/packages/server/src/routes/context-files.ts
+++ b/packages/server/src/routes/context-files.ts
@@ -1,7 +1,9 @@
-import type { Dirent } from "node:fs";
-import { access, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { zValidator } from "@hono/zod-validator";
+import type { DB } from "@prompt-reviewer/core";
+import { context_asset_projects, context_assets } from "@prompt-reviewer/core";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
@@ -27,9 +29,7 @@ export type ContextFileDetail = ContextFileSummary & {
   content: string;
 };
 
-type ContextFilesRouterOptions = {
-  baseDir?: string;
-};
+type ContextAssetRecord = typeof context_assets.$inferSelect;
 
 const textMimeTypes: Record<string, string> = {
   ".css": "text/css",
@@ -46,14 +46,6 @@ const textMimeTypes: Record<string, string> = {
   ".yaml": "application/yaml",
   ".yml": "application/yaml",
 };
-
-function getBaseDir(options: ContextFilesRouterOptions): string {
-  const configured =
-    options.baseDir ??
-    process.env.CONTEXT_FILES_DIR ??
-    path.resolve(process.cwd(), "data/context-files");
-  return path.resolve(configured);
-}
 
 function parseProjectId(value: string | undefined): number | null {
   if (value === undefined) return null;
@@ -77,64 +69,56 @@ function sanitizeRelativePath(input: string): string | null {
   return parts.join("/");
 }
 
-function resolveProjectRoot(baseDir: string, projectId: number): string {
-  return path.join(baseDir, String(projectId));
+function buildContentHash(content: string): string {
+  return `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
 }
 
-function resolveProjectFilePath(projectRoot: string, relativePath: string): string | null {
-  const safeRelativePath = sanitizeRelativePath(relativePath);
-  if (!safeRelativePath) return null;
-
-  const resolvedPath = path.resolve(projectRoot, safeRelativePath);
-  const relativeToRoot = path.relative(projectRoot, resolvedPath);
-  if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
-    return null;
-  }
-
-  return resolvedPath;
+function toSummary(asset: ContextAssetRecord): ContextFileSummary {
+  return {
+    name: asset.name,
+    path: asset.path,
+    mime_type: asset.mime_type,
+    size: Buffer.byteLength(asset.content, "utf8"),
+    updated_at: asset.updated_at,
+  };
 }
 
-async function listProjectFiles(
-  projectRoot: string,
-  currentDir = projectRoot,
-): Promise<ContextFileSummary[]> {
-  let entries: Dirent[];
-  try {
-    entries = await readdir(currentDir, { withFileTypes: true });
-  } catch {
+function toDetail(asset: ContextAssetRecord): ContextFileDetail {
+  return {
+    ...toSummary(asset),
+    content: asset.content,
+  };
+}
+
+async function listProjectContextAssets(db: DB, projectId: number): Promise<ContextAssetRecord[]> {
+  const links = await db
+    .select({ context_asset_id: context_asset_projects.context_asset_id })
+    .from(context_asset_projects)
+    .where(eq(context_asset_projects.project_id, projectId));
+
+  if (links.length === 0) {
     return [];
   }
 
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const fullPath = path.join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        return listProjectFiles(projectRoot, fullPath);
-      }
-      if (!entry.isFile()) {
-        return [];
-      }
+  const linkedIds = new Set(links.map((link) => link.context_asset_id));
+  const assets = await db.select().from(context_assets);
 
-      const fileStat = await stat(fullPath);
-      const relativePath = path.relative(projectRoot, fullPath).replace(/\\/g, "/");
-      return [
-        {
-          name: entry.name,
-          path: relativePath,
-          mime_type: inferMimeType(entry.name),
-          size: fileStat.size,
-          updated_at: fileStat.mtimeMs,
-        } satisfies ContextFileSummary,
-      ];
-    }),
-  );
-
-  return files.flat().sort((a, b) => a.path.localeCompare(b.path, "ja"));
+  return assets
+    .filter((asset) => linkedIds.has(asset.id))
+    .sort((a, b) => a.path.localeCompare(b.path, "ja"));
 }
 
-export function createContextFilesRouter(options: ContextFilesRouterOptions = {}) {
+async function findProjectContextAssetByPath(
+  db: DB,
+  projectId: number,
+  safePath: string,
+): Promise<ContextAssetRecord | null> {
+  const assets = await listProjectContextAssets(db, projectId);
+  return assets.find((asset) => asset.path === safePath) ?? null;
+}
+
+export function createContextFilesRouter(db: DB) {
   const router = new Hono();
-  const baseDir = getBaseDir(options);
 
   router.get("/", async (c) => {
     const projectId = parseProjectId(c.req.param("projectId"));
@@ -142,9 +126,8 @@ export function createContextFilesRouter(options: ContextFilesRouterOptions = {}
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
-    const projectRoot = resolveProjectRoot(baseDir, projectId);
-    const files = await listProjectFiles(projectRoot);
-    return c.json(files);
+    const assets = await listProjectContextAssets(db, projectId);
+    return c.json(assets.map(toSummary));
   });
 
   router.post("/", zValidator("json", createContextFileSchema), async (c) => {
@@ -154,26 +137,37 @@ export function createContextFilesRouter(options: ContextFilesRouterOptions = {}
     }
 
     const body = c.req.valid("json");
-    const projectRoot = resolveProjectRoot(baseDir, projectId);
-    const targetPath = resolveProjectFilePath(projectRoot, body.file_name);
-    if (!targetPath) {
+    const safePath = sanitizeRelativePath(body.file_name);
+    if (!safePath) {
       return c.json({ error: "Invalid file_name" }, 400);
     }
 
-    await mkdir(path.dirname(targetPath), { recursive: true });
-    await writeFile(targetPath, body.content, "utf8");
+    const now = Date.now();
+    const mimeType = body.mime_type ?? inferMimeType(safePath);
+    const [created] = await db
+      .insert(context_assets)
+      .values({
+        name: path.basename(safePath),
+        path: safePath,
+        content: body.content,
+        mime_type: mimeType,
+        content_hash: buildContentHash(body.content),
+        created_at: now,
+        updated_at: now,
+      })
+      .returning();
 
-    const fileStat = await stat(targetPath);
-    return c.json(
-      {
-        name: path.basename(targetPath),
-        path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
-        mime_type: body.mime_type ?? inferMimeType(targetPath),
-        size: fileStat.size,
-        updated_at: fileStat.mtimeMs,
-      } satisfies ContextFileSummary,
-      201,
-    );
+    if (!created) {
+      return c.json({ error: "Failed to create context file" }, 500);
+    }
+
+    await db.insert(context_asset_projects).values({
+      context_asset_id: created.id,
+      project_id: projectId,
+      created_at: now,
+    });
+
+    return c.json(toSummary(created), 201);
   });
 
   router.get("/content", async (c) => {
@@ -187,27 +181,17 @@ export function createContextFilesRouter(options: ContextFilesRouterOptions = {}
       return c.json({ error: "Missing path" }, 400);
     }
 
-    const projectRoot = resolveProjectRoot(baseDir, projectId);
-    const targetPath = resolveProjectFilePath(projectRoot, requestedPath);
-    if (!targetPath) {
+    const safePath = sanitizeRelativePath(requestedPath);
+    if (!safePath) {
       return c.json({ error: "Invalid path" }, 400);
     }
 
-    try {
-      await access(targetPath);
-    } catch {
+    const asset = await findProjectContextAssetByPath(db, projectId, safePath);
+    if (!asset) {
       return c.json({ error: "Context file not found" }, 404);
     }
 
-    const [content, fileStat] = await Promise.all([readFile(targetPath, "utf8"), stat(targetPath)]);
-    return c.json({
-      name: path.basename(targetPath),
-      path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
-      mime_type: inferMimeType(targetPath),
-      size: fileStat.size,
-      updated_at: fileStat.mtimeMs,
-      content,
-    } satisfies ContextFileDetail);
+    return c.json(toDetail(asset));
   });
 
   router.put("/content", zValidator("json", updateContextFileSchema), async (c) => {
@@ -221,30 +205,32 @@ export function createContextFilesRouter(options: ContextFilesRouterOptions = {}
       return c.json({ error: "Missing path" }, 400);
     }
 
-    const projectRoot = resolveProjectRoot(baseDir, projectId);
-    const targetPath = resolveProjectFilePath(projectRoot, requestedPath);
-    if (!targetPath) {
+    const safePath = sanitizeRelativePath(requestedPath);
+    if (!safePath) {
       return c.json({ error: "Invalid path" }, 400);
     }
 
-    try {
-      await access(targetPath);
-    } catch {
+    const asset = await findProjectContextAssetByPath(db, projectId, safePath);
+    if (!asset) {
       return c.json({ error: "Context file not found" }, 404);
     }
 
     const body = c.req.valid("json");
-    await writeFile(targetPath, body.content, "utf8");
+    const [updated] = await db
+      .update(context_assets)
+      .set({
+        content: body.content,
+        content_hash: buildContentHash(body.content),
+        updated_at: Date.now(),
+      })
+      .where(eq(context_assets.id, asset.id))
+      .returning();
 
-    const fileStat = await stat(targetPath);
-    return c.json({
-      name: path.basename(targetPath),
-      path: path.relative(projectRoot, targetPath).replace(/\\/g, "/"),
-      mime_type: inferMimeType(targetPath),
-      size: fileStat.size,
-      updated_at: fileStat.mtimeMs,
-      content: body.content,
-    } satisfies ContextFileDetail);
+    if (!updated) {
+      return c.json({ error: "Failed to update context file" }, 500);
+    }
+
+    return c.json(toDetail(updated));
   });
 
   return router;


### PR DESCRIPTION
## 概要
- 旧 \\context-files\\ ルートをファイルシステム依存から外し、\\context_assets\\ と project ラベル参照の互換レイヤーへ置換
- \\POST /context-files\\ で context asset 作成と project 紐付けを同時に行うよう変更
- path 指定の \\/content\\ 取得・更新を project ラベル付き asset 解決に差し替え

## 変更内容
- \\createContextFilesRouter\\ を DB 依存に変更し、一覧・作成・取得・更新を \\context_assets\\ ベースで実装
- 旧 API 互換のレスポンス形式を維持しつつ、\\size\\ は content 長から算出
- \\context-files\\ テストを DB モックベースへ更新し、project フィルタ互換と不正 path の検証を追加

## 確認
- \\pnpm exec tsc --noEmit\\
- \\pnpm run test -- packages/server/src/routes/context-files.test.ts\\
- \\pnpm run check -- packages/server/src/index.ts packages/server/src/routes/context-files.ts packages/server/src/routes/context-files.test.ts\\

## 補足
- draft PR として作成しています。