### PR TITLE
抽出ページのマージン修正とレビュータブのパラメータ保持

### DIFF
--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -2254,6 +2254,41 @@ describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
     ]);
   });
 
+  it("final_answer のパースに失敗しても structured_output があればそちらへフォールバックする", async () => {
+    const insertedValues: Record<string, unknown>[] = [];
+    const runWithInvalidFinalAnswerAndStructuredOutput: MockRun = {
+      ...sampleRunWithStructuredOutput,
+      conversation: JSON.stringify([
+        { role: "user", content: "文章を分析してください" },
+        {
+          role: "assistant",
+          content: "```json\nnot-json\n```",
+        },
+      ]),
+    };
+
+    const db = buildExtractDb({
+      run: runWithInvalidFinalAnswerAndStructuredOutput,
+      insertReturns: [{ id: 6 }],
+      insertedValues,
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1, source_type: "final_answer" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "structured_json",
+        label: "insight",
+      }),
+    ]);
+  });
+
   it("source_type=trace_step と source_step_id を指定すると対象 step から抽出する", async () => {
     const insertedValues: Record<string, unknown>[] = [];
     const db = buildExtractDb({
@@ -2367,6 +2402,96 @@ describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("invalid format");
+  });
+
+  it("final_answer の JSON 文字列内に生改行があっても Candidate を生成できる", async () => {
+    const insertedValues: Record<string, unknown>[] = [];
+    const runWithMultilineQuote: MockRun = {
+      ...sampleRun,
+      structured_output: null,
+      conversation: JSON.stringify([
+        { role: "user", content: "文章を分析してください" },
+        {
+          role: "assistant",
+          content: `\`\`\`json
+{"items":[
+  {"label":"insight","start_line":1568,"end_line":1571,"quote":"「どうすればうまくいくか」を常に慎重に考えている
+- 行動の順番や準備の微調整、体調との兼ね合いなどを常に考えている
+- これが無意識に脳のリソースを使い、疲労感や余裕のなさに繋がる","rationale":"aiが慎重な思考自体が認知負荷になる構造を指摘している"}
+]}
+\`\`\``,
+        },
+      ]),
+    };
+
+    const db = buildExtractDb({
+      run: runWithMultilineQuote,
+      insertReturns: [{ id: 5 }],
+      insertedValues,
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "final_answer",
+        label: "insight",
+        start_line: 1568,
+        end_line: 1571,
+        quote:
+          "「どうすればうまくいくか」を常に慎重に考えている\n- 行動の順番や準備の微調整、体調との兼ね合いなどを常に考えている\n- これが無意識に脳のリソースを使い、疲労感や余裕のなさに繋がる",
+      }),
+    ]);
+  });
+
+  it("final_answer の JSON 文字列内に未エスケープの引用符があっても Candidate を生成できる", async () => {
+    const insertedValues: Record<string, unknown>[] = [];
+    const runWithBareQuotes: MockRun = {
+      ...sampleRun,
+      structured_output: null,
+      conversation: JSON.stringify([
+        { role: "user", content: "文章を分析してください" },
+        {
+          role: "assistant",
+          content: `\`\`\`json
+{"items":[
+  {"label":"insight","start_line":1897,"end_line":1897,"quote":"「無為には過ごしたくないけれど、興味も湧かず、何をすればいいか分からない」という状態は、回復期によくある"エネルギーはまだ低いけど、自己意識は戻りつつある"時期の特徴でもあります。","rationale":"aiが回復プロセスの特徴を指摘している"}
+]}
+\`\`\``,
+        },
+      ]),
+    };
+
+    const db = buildExtractDb({
+      run: runWithBareQuotes,
+      insertReturns: [{ id: 7 }],
+      insertedValues,
+    });
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1, source_type: "final_answer" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        source_type: "final_answer",
+        label: "insight",
+        start_line: 1897,
+        end_line: 1897,
+        quote:
+          '「無為には過ごしたくないけれど、興味も湧かず、何をすればいいか分からない」という状態は、回復期によくある"エネルギーはまだ低いけど、自己意識は戻りつつある"時期の特徴でもあります。',
+      }),
+    ]);
   });
 
   it("重複抽出時に 409 を返す", async () => {

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -182,19 +182,89 @@ function parseStructuredOutput(json: string | null): StructuredOutput | null {
   return JSON.parse(json) as StructuredOutput;
 }
 
+function peekNextNonWhitespace(text: string, startIndex: number): string | null {
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === undefined) {
+      return null;
+    }
+    if (!/\s/.test(char)) {
+      return char;
+    }
+  }
+
+  return null;
+}
+
+function sanitizeLenientJson(text: string): string {
+  let result = "";
+  let inString = false;
+  let escaping = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (escaping) {
+      result += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      result += char;
+      escaping = true;
+      continue;
+    }
+
+    if (char === '"') {
+      if (inString) {
+        const nextNonWhitespace = peekNextNonWhitespace(text, index + 1);
+        if (
+          nextNonWhitespace !== null &&
+          nextNonWhitespace !== "," &&
+          nextNonWhitespace !== "}" &&
+          nextNonWhitespace !== "]" &&
+          nextNonWhitespace !== ":"
+        ) {
+          result += '\\"';
+          continue;
+        }
+      }
+
+      result += char;
+      inString = !inString;
+      continue;
+    }
+
+    if (inString && (char === "\n" || char === "\r")) {
+      if (char === "\r" && text[index + 1] === "\n") {
+        index += 1;
+      }
+      result += "\\n";
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
 function extractJsonFromText(text: string): unknown {
+  const normalizedText = sanitizeLenientJson(text);
+
   // まず直接パースを試みる
   try {
-    return JSON.parse(text);
+    return JSON.parse(normalizedText);
   } catch {
     // ignore
   }
   // テキスト内の最初の { から最後の } を抽出してパース
   // （コードブロック内に ``` が含まれる場合でも対応できる）
-  const firstBrace = text.indexOf("{");
-  const lastBrace = text.lastIndexOf("}");
+  const firstBrace = normalizedText.indexOf("{");
+  const lastBrace = normalizedText.lastIndexOf("}");
   if (firstBrace !== -1 && lastBrace > firstBrace) {
-    return JSON.parse(text.slice(firstBrace, lastBrace + 1));
+    return JSON.parse(normalizedText.slice(firstBrace, lastBrace + 1));
   }
   throw new SyntaxError("Failed to parse as JSON");
 }
@@ -208,6 +278,15 @@ function parseStructuredItems(
   }
 
   return parsed.data.items;
+}
+
+function parseItemsFromStructuredOutput(json: string | null): z.infer<typeof structuredOutputSchema>["items"] | null {
+  const parsedStructuredOutput = parseStructuredOutput(json);
+  if (parsedStructuredOutput === null) {
+    return null;
+  }
+
+  return parseStructuredItems(parsedStructuredOutput);
 }
 
 function addLineNumbers(text: string): string {
@@ -924,20 +1003,15 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     // ソースタイプ決定とアイテム抽出
     let sourceType: CandidateSourceType;
     let resolvedSourceStepId: string | null = null;
-    let items: z.infer<typeof structuredOutputSchema>["items"];
+    let items: z.infer<typeof structuredOutputSchema>["items"] | null = null;
     const requestedSourceType =
       source_type ?? (run.structured_output !== null ? "structured_json" : "final_answer");
 
     if (requestedSourceType === "structured_json") {
       sourceType = "structured_json";
-      const parsedStructuredOutput = parseStructuredOutput(run.structured_output);
-      if (parsedStructuredOutput === null) {
-        return c.json({ error: "structured_output is not available for this run" }, 400);
-      }
-
-      const parsedItems = parseStructuredItems(parsedStructuredOutput);
+      const parsedItems = parseItemsFromStructuredOutput(run.structured_output);
       if (parsedItems === null) {
-        return c.json({ error: "structured_output has invalid format" }, 400);
+        return c.json({ error: "structured_output is not available for this run" }, 400);
       }
       items = parsedItems;
     } else if (requestedSourceType === "final_answer") {
@@ -952,20 +1026,34 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       try {
         parsedFinalAnswer = extractJsonFromText(lastAssistantMessage.content);
       } catch {
-        return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
+        const fallbackItems = parseItemsFromStructuredOutput(run.structured_output);
+        if (fallbackItems !== null) {
+          sourceType = "structured_json";
+          items = fallbackItems;
+        } else {
+          return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
+        }
       }
-
-      const parsedItems = parseStructuredItems(parsedFinalAnswer);
-      if (parsedItems === null) {
-        return c.json(
-          {
-            error:
-              "Assistant message JSON has invalid format (missing items field or invalid schema)",
-          },
-          400,
-        );
+      if (items === null) {
+        const parsedItems = parseStructuredItems(parsedFinalAnswer);
+        if (parsedItems === null) {
+          const fallbackItems = parseItemsFromStructuredOutput(run.structured_output);
+          if (fallbackItems !== null) {
+            sourceType = "structured_json";
+            items = fallbackItems;
+          } else {
+            return c.json(
+              {
+                error:
+                  "Assistant message JSON has invalid format (missing items field or invalid schema)",
+              },
+              400,
+            );
+          }
+        } else {
+          items = parsedItems;
+        }
       }
-      items = parsedItems;
     } else {
       sourceType = "trace_step";
       resolvedSourceStepId = source_step_id ?? null;
@@ -992,6 +1080,10 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
         return c.json({ error: "trace_step output has invalid format" }, 400);
       }
       items = parsedItems;
+    }
+
+    if (items === null) {
+      return c.json({ error: "Failed to resolve annotation candidate items" }, 500);
     }
 
     // label の存在チェック

--- a/packages/ui/src/components/AnnotationSectionTabs.module.css
+++ b/packages/ui/src/components/AnnotationSectionTabs.module.css
@@ -1,9 +1,10 @@
 .tabList {
   display: flex;
   gap: 4px;
-  margin-top: 20px;
+  margin-bottom: 20px;
   border-bottom: 1px solid #45475a;
   padding-bottom: 0;
+  flex-shrink: 0;
 }
 
 .tab {

--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -19,9 +19,15 @@ export function AnnotationSectionTabs() {
   const isReviewPath = location.pathname.endsWith(`/${annotationRoutes.review}`);
   const isSettingsPath = location.pathname.endsWith(`/${annotationRoutes.settings}`);
 
+  const reviewParams = new URLSearchParams({ mode: "review" });
+  const runId = searchParams.get("runId");
+  const taskId = searchParams.get("taskId");
+  if (runId) reviewParams.set("runId", runId);
+  if (taskId) reviewParams.set("taskId", taskId);
+
   const tabs = [
     {
-      to: `/projects/${id}/${annotationRoutes.review}?mode=review`,
+      to: `/projects/${id}/${annotationRoutes.review}?${reviewParams.toString()}`,
       label: "レビュー",
       isActive: isReviewPath && hasRunId,
     },

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -20,7 +20,6 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
     { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
     { to: `/projects/${projectId}/runs`, label: "Run" },
     { to: `/projects/${projectId}/score`, label: "採点" },
-    { to: `/projects/${projectId}/score-progression`, label: "スコア推移" },
     {
       to: `/projects/${projectId}/annotation-review`,
       label: "抽出",

--- a/packages/ui/src/components/ScoreSectionTabs.module.css
+++ b/packages/ui/src/components/ScoreSectionTabs.module.css
@@ -1,0 +1,32 @@
+.tabList {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #45475a;
+  padding-bottom: 0;
+  flex-shrink: 0;
+}
+
+.tab {
+  padding: 8px 20px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+  color: #a6adc8;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: -1px;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.tab:hover {
+  color: #cdd6f4;
+}
+
+.tabActive {
+  color: #cba6f7;
+  border-bottom-color: #cba6f7;
+}

--- a/packages/ui/src/components/ScoreSectionTabs.tsx
+++ b/packages/ui/src/components/ScoreSectionTabs.tsx
@@ -1,0 +1,26 @@
+import { NavLink, useLocation, useParams } from "react-router";
+import styles from "./ScoreSectionTabs.module.css";
+
+export function ScoreSectionTabs() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+
+  if (!id) return null;
+
+  const isProgression = location.pathname.endsWith("/score-progression");
+
+  const tabs = [
+    { to: `/projects/${id}/score`, label: "採点", isActive: !isProgression },
+    { to: `/projects/${id}/score-progression`, label: "スコア推移", isActive: isProgression },
+  ];
+
+  return (
+    <div className={styles.tabList} aria-label="採点ページ切り替え">
+      {tabs.map(({ to, label, isActive }) => (
+        <NavLink key={to} to={to} className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}>
+          {label}
+        </NavLink>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -796,7 +796,7 @@ export function extractAnnotationCandidates(
   runId: number,
   data: {
     annotation_task_id: number;
-    source_type?: "structured_json" | "final_answer" | "workflow_step";
+    source_type?: "structured_json" | "final_answer" | "trace_step";
     source_step_id?: string;
   },
 ): Promise<{ candidates_created: number; annotation_task_id: number }> {

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -25,7 +25,8 @@
 
 /* ==================== Header ==================== */
 .pageHeader {
-  margin-bottom: 8px;
+  composes: pageHeader from '../styles/shared.module.css';
+  margin-bottom: 24px;
   flex-shrink: 0;
 }
 

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -25,9 +25,7 @@
 
 /* ==================== Header ==================== */
 .pageHeader {
-  padding: 0 0 16px;
-  border-bottom: 1px solid var(--c-border);
-  margin-bottom: 16px;
+  margin-bottom: 0;
   flex-shrink: 0;
 }
 

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -25,7 +25,7 @@
 
 /* ==================== Header ==================== */
 .pageHeader {
-  padding: 20px 0 16px;
+  padding: 0 0 16px;
   border-bottom: 1px solid var(--c-border);
   margin-bottom: 16px;
   flex-shrink: 0;

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -21,8 +21,6 @@
   min-height: 0;
   overflow: hidden;
   color: var(--c-text);
-  padding: 0 24px 24px;
-  box-sizing: border-box;
 }
 
 /* ==================== Header ==================== */

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -43,9 +43,8 @@
 }
 
 .pageTitle {
+  composes: pageTitle from '../styles/shared.module.css';
   margin: 0 0 4px;
-  font-size: 22px;
-  color: var(--c-text);
 }
 
 .pageMeta {

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -25,7 +25,7 @@
 
 /* ==================== Header ==================== */
 .pageHeader {
-  margin-bottom: 24px;
+  margin-bottom: 8px;
   flex-shrink: 0;
 }
 

--- a/packages/ui/src/pages/AnnotationReviewPage.module.css
+++ b/packages/ui/src/pages/AnnotationReviewPage.module.css
@@ -25,7 +25,7 @@
 
 /* ==================== Header ==================== */
 .pageHeader {
-  margin-bottom: 0;
+  margin-bottom: 24px;
   flex-shrink: 0;
 }
 

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -345,9 +345,6 @@ export function AnnotationReviewPage() {
         <div className={styles.pageHeader}>
           <div>
             <h2 className={styles.pageTitle}>抽出</h2>
-            <p className={styles.pageMeta}>
-              Run から抽出した候補をレビューするには、対象の Run とタスクを選択してください。
-            </p>
           </div>
         </div>
         <AnnotationSectionTabs />
@@ -483,9 +480,6 @@ export function AnnotationReviewPage() {
             ← Run 一覧に戻る
           </Link>
           <h2 className={styles.pageTitle}>抽出</h2>
-          <p className={styles.pageMeta}>
-            {project?.name} / Run #{run.id} / {annotationTask.name}
-          </p>
         </div>
       </div>
       <AnnotationSectionTabs />
@@ -737,7 +731,6 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
       <div className={styles.pageHeader}>
         <div>
           <h2 className={styles.pageTitle}>抽出</h2>
-          <p className={styles.pageMeta}>Gold Annotation の確認と手動メンテナンスを行います。</p>
         </div>
       </div>
       <AnnotationSectionTabs />

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -348,9 +348,9 @@ export function AnnotationReviewPage() {
             <p className={styles.pageMeta}>
               Run から抽出した候補をレビューするには、対象の Run とタスクを選択してください。
             </p>
-            <AnnotationSectionTabs />
           </div>
         </div>
+        <AnnotationSectionTabs />
         <div className={styles.rightSection}>
           <h3 className={styles.panelTitle}>レビューの開始方法</h3>
           <p className={styles.emptyMsg}>
@@ -486,9 +486,9 @@ export function AnnotationReviewPage() {
           <p className={styles.pageMeta}>
             {project?.name} / Run #{run.id} / {annotationTask.name}
           </p>
-          <AnnotationSectionTabs />
         </div>
       </div>
+      <AnnotationSectionTabs />
 
       {/* 2カラムレイアウト */}
       <div className={styles.layout}>
@@ -738,9 +738,9 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
         <div>
           <h2 className={styles.pageTitle}>抽出</h2>
           <p className={styles.pageMeta}>Gold Annotation の確認と手動メンテナンスを行います。</p>
-          <AnnotationSectionTabs />
         </div>
       </div>
+      <AnnotationSectionTabs />
 
       <div className={styles.layout}>
         {/* 左パネル: 行番号付きテキスト */}

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -250,6 +250,7 @@ function AnnotationExtractPanel({
       if (selectedTaskId === "") throw new Error("タスクを選択してください");
       return extractAnnotationCandidates(projectId, run.id, {
         annotation_task_id: selectedTaskId,
+        source_type: hasStructuredOutput ? "structured_json" : "final_answer",
       });
     },
     onSuccess: (result) => {

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -265,9 +265,7 @@ function AnnotationExtractPanel({
     <div className={styles.annotationPanel}>
       {!canExtract && (
         <p className={styles.annotationWarning}>
-          このRunのアシスタント応答は平文テキストです。抽出にはLLMがJSON形式 （
-          <code>{`{"items":[{"label","start_line","end_line","quote"}]}`}</code>）
-          で出力したRunが必要です。
+          このRunのアシスタント応答がJSON形式と判定できませんでした。抽出を実行しますが、サーバー側でJSONが見つからない場合はエラーになります。
         </p>
       )}
       <div className={styles.annotationPanelRow}>
@@ -294,7 +292,7 @@ function AnnotationExtractPanel({
         <button
           type="button"
           onClick={() => extractMutation.mutate()}
-          disabled={selectedTaskId === "" || extractMutation.isPending || !canExtract}
+          disabled={selectedTaskId === "" || extractMutation.isPending}
           className={styles.btnAnnotationExtract}
         >
           {extractMutation.isPending ? "抽出中..." : "抽出実行"}

--- a/packages/ui/src/pages/ScorePage.tsx
+++ b/packages/ui/src/pages/ScorePage.tsx
@@ -12,6 +12,7 @@ import {
   getScore,
   updateScore,
 } from "../lib/api";
+import { ScoreSectionTabs } from "../components/ScoreSectionTabs";
 import styles from "./ScorePage.module.css";
 
 function formatDate(timestamp: number): string {
@@ -759,6 +760,8 @@ export function ScorePage() {
           {project && <p className={styles.projectName}>{project.name}</p>}
         </div>
       </div>
+
+      <ScoreSectionTabs />
 
       {/* タブ */}
       <div className={styles.tabs}>

--- a/packages/ui/src/pages/ScoreProgressionPage.tsx
+++ b/packages/ui/src/pages/ScoreProgressionPage.tsx
@@ -11,6 +11,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { ScoreSectionTabs } from "../components/ScoreSectionTabs";
 import { type VersionSummary, getProject, getScoreProgression } from "../lib/api";
 import styles from "./ScoreProgressionPage.module.css";
 
@@ -277,7 +278,7 @@ export function ScoreProgressionPage() {
       {/* Page header */}
       <div className={styles.pageHeader}>
         <div>
-          <h2 className={styles.pageTitle}>Score Progression</h2>
+          <h2 className={styles.pageTitle}>採点</h2>
           {project && <p className={styles.projectName}>{project.name}</p>}
         </div>
 
@@ -302,6 +303,7 @@ export function ScoreProgressionPage() {
           </button>
         </div>
       </div>
+      <ScoreSectionTabs />
 
       {isLoading && <p className={styles.loadingMsg}>Loading...</p>}
       {isError && <p className={styles.errorMsg}>Failed to load score data. Please try again.</p>}


### PR DESCRIPTION
Closes #168, #169

## 変更内容

- `AnnotationReviewPage.module.css`: Layout の `<main>` がすでに `padding: 24px` を持っているため、`.root` の重複 `padding: 0 24px 24px` を削除
- `AnnotationSectionTabs.tsx`: レビュータブのリンクに現在の `runId`/`taskId` を引き継ぐよう修正し、他タブ遷移後に戻れるように改善