### PR TITLE
[codex] 旧 runs / score-progression API を互換レイヤ化

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -95,7 +95,7 @@ app.route("/api/projects/:projectId/test-cases", createProjectTestCasesRouter(db
 app.route("/api/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
-app.route("/api/runs", createRunsRouter(db));
+app.route("/api/runs", createRunsRouter(db, { enableCandidateExtractRoute: false }));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
 app.route("/api/score-progression", createScoreProgressionRouter(db));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -95,8 +95,10 @@ app.route("/api/projects/:projectId/test-cases", createProjectTestCasesRouter(db
 app.route("/api/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
+app.route("/api/runs", createRunsRouter(db));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
+app.route("/api/score-progression", createScoreProgressionRouter(db));
 app.route("/api/projects/:projectId/score-progression", createScoreProgressionRouter(db));
 app.route("/api/projects/:projectId/settings", createProjectSettingsRouter(db));
 app.get("*", async (c) => {

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -49,6 +49,7 @@ type MockRun = {
 
 function buildApp(db: unknown) {
   const app = new Hono();
+  app.route("/api/runs", createRunsRouter(db as DB));
   app.route("/api/projects/:projectId/runs", createRunsRouter(db as DB));
   return app;
 }
@@ -103,6 +104,62 @@ const sampleStructuredOutput = {
 // ---- テスト ----
 
 describe("GET /api/projects/:projectId/runs", () => {
+  it("新APIでは project_id を含めずに Run 一覧を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([sampleRun]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([sampleRun]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/runs?project_id=1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body.at(0)).not.toHaveProperty("project_id");
+  });
+
+  it("legacy path は project_id を補完して返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ prompt_version_id: 1 }]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () => Promise.resolve([sampleRun]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<MockRun & { conversation: MockConversationMessage[] }>;
+    expect(body.at(0)).toHaveProperty("project_id", 1);
+  });
+
   it("prompt_version_projects 基準でフィルタしてRun一覧を200で返す", async () => {
     const runs = [sampleRun, { ...sampleRun, id: 2 }];
 

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -49,7 +49,7 @@ type MockRun = {
 
 function buildApp(db: unknown) {
   const app = new Hono();
-  app.route("/api/runs", createRunsRouter(db as DB));
+  app.route("/api/runs", createRunsRouter(db as DB, { enableCandidateExtractRoute: false }));
   app.route("/api/projects/:projectId/runs", createRunsRouter(db as DB));
   return app;
 }
@@ -516,12 +516,31 @@ describe("POST /api/projects/:projectId/runs", () => {
   it("execution_profile_idをRun作成時に保存できる", async () => {
     const created = { ...sampleRun, execution_profile_id: 1 };
 
+    let selectCallCount = 0;
     const db = {
-      select: () => ({
-        from: () => ({
-          where: () => Promise.resolve([{ prompt_version_id: 1, project_id: 1, created_at: 0 }]),
-        }),
-      }),
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([{ prompt_version_id: 1, project_id: 1, created_at: 0 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () => ({
+            where: () =>
+              Promise.resolve([
+                {
+                  ...sampleProfile,
+                  max_tokens: null,
+                },
+              ]),
+          }),
+        };
+      },
       insert: () => ({
         values: (values: { execution_profile_id: number | null }) => ({
           returning: () => {
@@ -550,6 +569,47 @@ describe("POST /api/projects/:projectId/runs", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as MockRun;
     expect(body.execution_profile_id).toBe(1);
+  });
+
+  it("legacy create で存在しない execution_profile_id を指定した場合は 404 を返す", async () => {
+    let selectCallCount = 0;
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([{ prompt_version_id: 1, project_id: 1, created_at: 0 }]),
+            }),
+          };
+        }
+
+        return {
+          from: () => ({
+            where: () => Promise.resolve([]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/projects/1/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        conversation: sampleConversation,
+        execution_profile_id: 999,
+        model: "claude-sonnet-4-6",
+        temperature: 0.7,
+        api_provider: "anthropic",
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Execution profile not found" });
   });
 
   it("structured_output を保存してレスポンスでは JSON として返す", async () => {
@@ -2217,6 +2277,17 @@ function buildExtractDb(params: {
 }
 
 describe("POST /api/projects/:projectId/runs/:id/candidates/extract", () => {
+  it("新APIでは candidates/extract を公開しない", async () => {
+    const app = buildApp({});
+    const res = await app.request("/api/runs/1/candidates/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ annotation_task_id: 1 }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
   it("structured_output から Candidate を生成して 201 を返す", async () => {
     const insertedValues: Record<string, unknown>[] = [];
     const db = buildExtractDb({ insertReturns: [{ id: 1 }], insertedValues });

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -124,6 +124,7 @@ type RunExecutionClientFactoryInput = {
 
 type RunsRouterOptions = {
   llmClientFactory?: (input: RunExecutionClientFactoryInput) => LLMClient | null;
+  enableCandidateExtractRoute?: boolean;
 };
 
 type StoredPromptVersion = {
@@ -603,6 +604,7 @@ async function fetchTestCaseIdsByProject(db: DB, projectId: number): Promise<num
 export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   const router = new Hono();
   const llmClientFactory = options.llmClientFactory ?? defaultLLMClientFactory;
+  const enableCandidateExtractRoute = options.enableCandidateExtractRoute ?? true;
 
   // GET /api/runs - 新 Runs API
   // GET /api/projects/:projectId/runs - 旧API互換レイヤ
@@ -700,29 +702,41 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     if (body.temperature !== undefined) legacySnapshot.temperature = body.temperature;
     if (body.api_provider !== undefined) legacySnapshot.api_provider = body.api_provider;
 
-    const resolvedSettings =
-      legacyProjectId !== undefined &&
-      body.execution_profile_id !== undefined &&
-      legacySnapshot.model !== undefined &&
-      legacySnapshot.temperature !== undefined &&
-      legacySnapshot.api_provider !== undefined
-        ? {
-            ok: true as const,
-            settings: {
-              model: legacySnapshot.model,
-              temperature: legacySnapshot.temperature,
-              api_provider: legacySnapshot.api_provider,
-              max_tokens: null,
-            },
-            executionProfileId: body.execution_profile_id,
-          }
-        : await fetchExecutionSettings(db, {
-            ...(body.execution_profile_id !== undefined
-              ? { executionProfileId: body.execution_profile_id }
-              : {}),
-            ...(legacyProjectId !== undefined ? { legacyProjectId } : {}),
-            ...(Object.keys(legacySnapshot).length > 0 ? { legacySnapshot } : {}),
-          });
+    const resolvedSettings = await (async () => {
+      if (
+        legacyProjectId !== undefined &&
+        body.execution_profile_id !== undefined &&
+        legacySnapshot.model !== undefined &&
+        legacySnapshot.temperature !== undefined &&
+        legacySnapshot.api_provider !== undefined
+      ) {
+        const profileValidation = await fetchExecutionSettings(db, {
+          executionProfileId: body.execution_profile_id,
+        });
+        if (!profileValidation.ok) {
+          return profileValidation;
+        }
+
+        return {
+          ok: true as const,
+          settings: {
+            model: legacySnapshot.model,
+            temperature: legacySnapshot.temperature,
+            api_provider: legacySnapshot.api_provider,
+            max_tokens: null,
+          },
+          executionProfileId: profileValidation.executionProfileId,
+        };
+      }
+
+      return fetchExecutionSettings(db, {
+        ...(body.execution_profile_id !== undefined
+          ? { executionProfileId: body.execution_profile_id }
+          : {}),
+        ...(legacyProjectId !== undefined ? { legacyProjectId } : {}),
+        ...(Object.keys(legacySnapshot).length > 0 ? { legacySnapshot } : {}),
+      });
+    })();
 
     if (!resolvedSettings.ok) {
       return c.json({ error: resolvedSettings.error }, resolvedSettings.status);
@@ -1148,226 +1162,233 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   });
 
   // POST /api/projects/:projectId/runs/:id/candidates/extract - annotation_candidates を抽出して保存
-  router.post("/:id/candidates/extract", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
-    const id = parseIntParam(c.req.param("id"));
+  if (enableCandidateExtractRoute) {
+    router.post("/:id/candidates/extract", async (c) => {
+      const projectId = parseIntParam(c.req.param("projectId"));
+      const id = parseIntParam(c.req.param("id"));
 
-    if (projectId === null || id === null) {
-      return c.json({ error: "Invalid ID" }, 400);
-    }
-
-    let body: z.infer<typeof extractCandidatesSchema>;
-    try {
-      body = (await c.req.json()) as z.infer<typeof extractCandidatesSchema>;
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-
-    const parsedBody = extractCandidatesSchema.safeParse(body);
-    if (!parsedBody.success) {
-      return c.json({ error: parsedBody.error.issues[0]?.message ?? "Invalid request body" }, 400);
-    }
-    const { annotation_task_id, source_type, source_step_id } = parsedBody.data;
-
-    // run が存在し、該当プロジェクトに属することを確認
-    const versionIds = await fetchVersionIdsByProject(db, projectId);
-    if (versionIds.length === 0) {
-      return c.json({ error: "Run not found" }, 404);
-    }
-
-    const [run] = await db
-      .select()
-      .from(runs)
-      .where(
-        and(
-          eq(runs.id, id),
-          eq(runs.project_id, projectId),
-          inArray(runs.prompt_version_id, versionIds),
-        ),
-      );
-
-    if (!run) {
-      return c.json({ error: "Run not found" }, 404);
-    }
-
-    // annotation_task が存在することを確認
-    const [task] = await db
-      .select()
-      .from(annotation_tasks)
-      .where(eq(annotation_tasks.id, annotation_task_id));
-
-    if (!task) {
-      return c.json({ error: "Annotation task not found" }, 404);
-    }
-
-    // annotation_task に紐づく有効な label keys を取得
-    const labels = await db
-      .select({ key: annotation_labels.key })
-      .from(annotation_labels)
-      .where(eq(annotation_labels.annotation_task_id, annotation_task_id));
-    const validLabelKeys = new Set(labels.map((l) => l.key));
-
-    // ソースタイプ決定とアイテム抽出
-    let sourceType: CandidateSourceType;
-    let resolvedSourceStepId: string | null = null;
-    let items: z.infer<typeof structuredOutputSchema>["items"] | null = null;
-    const requestedSourceType =
-      source_type ?? (run.structured_output !== null ? "structured_json" : "final_answer");
-
-    if (requestedSourceType === "structured_json") {
-      sourceType = "structured_json";
-      const parsedItems = parseItemsFromStructuredOutput(run.structured_output);
-      if (parsedItems === null) {
-        return c.json({ error: "structured_output is not available for this run" }, 400);
-      }
-      items = parsedItems;
-    } else if (requestedSourceType === "final_answer") {
-      sourceType = "final_answer";
-      const conversation = parseConversation(run.conversation);
-      const lastAssistantMessage = [...conversation].reverse().find((m) => m.role === "assistant");
-      if (!lastAssistantMessage) {
-        return c.json({ error: "No assistant message found in conversation" }, 400);
+      if (projectId === null || id === null) {
+        return c.json({ error: "Invalid ID" }, 400);
       }
 
-      let parsedFinalAnswer: unknown;
+      let body: z.infer<typeof extractCandidatesSchema>;
       try {
-        parsedFinalAnswer = extractJsonFromText(lastAssistantMessage.content);
+        body = (await c.req.json()) as z.infer<typeof extractCandidatesSchema>;
       } catch {
-        const fallbackItems = parseItemsFromStructuredOutput(run.structured_output);
-        if (fallbackItems !== null) {
-          sourceType = "structured_json";
-          items = fallbackItems;
-        } else {
-          return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
-        }
+        return c.json({ error: "Invalid JSON body" }, 400);
       }
-      if (items === null) {
-        const parsedItems = parseStructuredItems(parsedFinalAnswer);
+
+      const parsedBody = extractCandidatesSchema.safeParse(body);
+      if (!parsedBody.success) {
+        return c.json(
+          { error: parsedBody.error.issues[0]?.message ?? "Invalid request body" },
+          400,
+        );
+      }
+      const { annotation_task_id, source_type, source_step_id } = parsedBody.data;
+
+      // run が存在し、該当プロジェクトに属することを確認
+      const versionIds = await fetchVersionIdsByProject(db, projectId);
+      if (versionIds.length === 0) {
+        return c.json({ error: "Run not found" }, 404);
+      }
+
+      const [run] = await db
+        .select()
+        .from(runs)
+        .where(
+          and(
+            eq(runs.id, id),
+            eq(runs.project_id, projectId),
+            inArray(runs.prompt_version_id, versionIds),
+          ),
+        );
+
+      if (!run) {
+        return c.json({ error: "Run not found" }, 404);
+      }
+
+      // annotation_task が存在することを確認
+      const [task] = await db
+        .select()
+        .from(annotation_tasks)
+        .where(eq(annotation_tasks.id, annotation_task_id));
+
+      if (!task) {
+        return c.json({ error: "Annotation task not found" }, 404);
+      }
+
+      // annotation_task に紐づく有効な label keys を取得
+      const labels = await db
+        .select({ key: annotation_labels.key })
+        .from(annotation_labels)
+        .where(eq(annotation_labels.annotation_task_id, annotation_task_id));
+      const validLabelKeys = new Set(labels.map((l) => l.key));
+
+      // ソースタイプ決定とアイテム抽出
+      let sourceType: CandidateSourceType;
+      let resolvedSourceStepId: string | null = null;
+      let items: z.infer<typeof structuredOutputSchema>["items"] | null = null;
+      const requestedSourceType =
+        source_type ?? (run.structured_output !== null ? "structured_json" : "final_answer");
+
+      if (requestedSourceType === "structured_json") {
+        sourceType = "structured_json";
+        const parsedItems = parseItemsFromStructuredOutput(run.structured_output);
         if (parsedItems === null) {
+          return c.json({ error: "structured_output is not available for this run" }, 400);
+        }
+        items = parsedItems;
+      } else if (requestedSourceType === "final_answer") {
+        sourceType = "final_answer";
+        const conversation = parseConversation(run.conversation);
+        const lastAssistantMessage = [...conversation]
+          .reverse()
+          .find((m) => m.role === "assistant");
+        if (!lastAssistantMessage) {
+          return c.json({ error: "No assistant message found in conversation" }, 400);
+        }
+
+        let parsedFinalAnswer: unknown;
+        try {
+          parsedFinalAnswer = extractJsonFromText(lastAssistantMessage.content);
+        } catch {
           const fallbackItems = parseItemsFromStructuredOutput(run.structured_output);
           if (fallbackItems !== null) {
             sourceType = "structured_json";
             items = fallbackItems;
           } else {
-            return c.json(
-              {
-                error:
-                  "Assistant message JSON has invalid format (missing items field or invalid schema)",
-              },
-              400,
-            );
+            return c.json({ error: "Failed to parse assistant message as JSON" }, 400);
           }
-        } else {
-          items = parsedItems;
+        }
+        if (items === null) {
+          const parsedItems = parseStructuredItems(parsedFinalAnswer);
+          if (parsedItems === null) {
+            const fallbackItems = parseItemsFromStructuredOutput(run.structured_output);
+            if (fallbackItems !== null) {
+              sourceType = "structured_json";
+              items = fallbackItems;
+            } else {
+              return c.json(
+                {
+                  error:
+                    "Assistant message JSON has invalid format (missing items field or invalid schema)",
+                },
+                400,
+              );
+            }
+          } else {
+            items = parsedItems;
+          }
+        }
+      } else {
+        sourceType = "trace_step";
+        resolvedSourceStepId = source_step_id ?? null;
+
+        const executionTrace = parseExecutionTrace(run.execution_trace);
+        if (executionTrace === null) {
+          return c.json({ error: "execution_trace is not available for this run" }, 400);
+        }
+
+        const traceStep = executionTrace.find((step) => step.id === source_step_id);
+        if (!traceStep) {
+          return c.json({ error: `Trace step "${source_step_id}" not found` }, 400);
+        }
+
+        let parsedTraceStepOutput: unknown;
+        try {
+          parsedTraceStepOutput = JSON.parse(traceStep.output);
+        } catch {
+          return c.json({ error: "Failed to parse trace_step output as JSON" }, 400);
+        }
+
+        const parsedItems = parseStructuredItems(parsedTraceStepOutput);
+        if (parsedItems === null) {
+          return c.json({ error: "trace_step output has invalid format" }, 400);
+        }
+        items = parsedItems;
+      }
+
+      if (items === null) {
+        return c.json({ error: "Failed to resolve annotation candidate items" }, 500);
+      }
+
+      // label の存在チェック
+      for (const item of items) {
+        if (!validLabelKeys.has(item.label)) {
+          return c.json(
+            { error: `Label "${item.label}" is not valid for this annotation task` },
+            400,
+          );
         }
       }
-    } else {
-      sourceType = "trace_step";
-      resolvedSourceStepId = source_step_id ?? null;
 
-      const executionTrace = parseExecutionTrace(run.execution_trace);
-      if (executionTrace === null) {
-        return c.json({ error: "execution_trace is not available for this run" }, 400);
+      // line range チェック
+      for (const item of items) {
+        if (item.start_line > item.end_line) {
+          return c.json(
+            {
+              error: `start_line (${item.start_line}) must not be greater than end_line (${item.end_line})`,
+            },
+            400,
+          );
+        }
       }
 
-      const traceStep = executionTrace.find((step) => step.id === source_step_id);
-      if (!traceStep) {
-        return c.json({ error: `Trace step "${source_step_id}" not found` }, 400);
-      }
+      // 重複チェック: 同一 run / task / source からの重複取り込みを防ぐ
+      const [existing] = await db
+        .select({ id: annotation_candidates.id })
+        .from(annotation_candidates)
+        .where(
+          and(
+            eq(annotation_candidates.run_id, id),
+            eq(annotation_candidates.annotation_task_id, annotation_task_id),
+            eq(annotation_candidates.source_type, sourceType),
+          ),
+        );
 
-      let parsedTraceStepOutput: unknown;
-      try {
-        parsedTraceStepOutput = JSON.parse(traceStep.output);
-      } catch {
-        return c.json({ error: "Failed to parse trace_step output as JSON" }, 400);
-      }
-
-      const parsedItems = parseStructuredItems(parsedTraceStepOutput);
-      if (parsedItems === null) {
-        return c.json({ error: "trace_step output has invalid format" }, 400);
-      }
-      items = parsedItems;
-    }
-
-    if (items === null) {
-      return c.json({ error: "Failed to resolve annotation candidate items" }, 500);
-    }
-
-    // label の存在チェック
-    for (const item of items) {
-      if (!validLabelKeys.has(item.label)) {
+      if (existing) {
         return c.json(
-          { error: `Label "${item.label}" is not valid for this annotation task` },
-          400,
+          { error: "Candidates already extracted for this run/task/source combination" },
+          409,
         );
       }
-    }
 
-    // line range チェック
-    for (const item of items) {
-      if (item.start_line > item.end_line) {
-        return c.json(
-          {
-            error: `start_line (${item.start_line}) must not be greater than end_line (${item.end_line})`,
-          },
-          400,
-        );
-      }
-    }
+      const targetTextRef = `test_case:${run.test_case_id}`;
+      const now = Date.now();
 
-    // 重複チェック: 同一 run / task / source からの重複取り込みを防ぐ
-    const [existing] = await db
-      .select({ id: annotation_candidates.id })
-      .from(annotation_candidates)
-      .where(
-        and(
-          eq(annotation_candidates.run_id, id),
-          eq(annotation_candidates.annotation_task_id, annotation_task_id),
-          eq(annotation_candidates.source_type, sourceType),
-        ),
-      );
+      const inserted = await db
+        .insert(annotation_candidates)
+        .values(
+          items.map((item) => ({
+            run_id: id,
+            annotation_task_id,
+            target_text_ref: targetTextRef,
+            source_type: sourceType,
+            source_step_id: resolvedSourceStepId,
+            label: item.label,
+            start_line: item.start_line,
+            end_line: item.end_line,
+            quote: item.quote,
+            rationale: item.rationale ?? null,
+            status: "pending" as const,
+            note: null,
+            created_at: now,
+            updated_at: now,
+          })),
+        )
+        .returning();
 
-    if (existing) {
       return c.json(
-        { error: "Candidates already extracted for this run/task/source combination" },
-        409,
-      );
-    }
-
-    const targetTextRef = `test_case:${run.test_case_id}`;
-    const now = Date.now();
-
-    const inserted = await db
-      .insert(annotation_candidates)
-      .values(
-        items.map((item) => ({
+        {
+          candidates_created: inserted.length,
           run_id: id,
           annotation_task_id,
-          target_text_ref: targetTextRef,
-          source_type: sourceType,
-          source_step_id: resolvedSourceStepId,
-          label: item.label,
-          start_line: item.start_line,
-          end_line: item.end_line,
-          quote: item.quote,
-          rationale: item.rationale ?? null,
-          status: "pending" as const,
-          note: null,
-          created_at: now,
-          updated_at: now,
-        })),
-      )
-      .returning();
-
-    return c.json(
-      {
-        candidates_created: inserted.length,
-        run_id: id,
-        annotation_task_id,
-      },
-      201,
-    );
-  });
+        },
+        201,
+      );
+    });
+  }
 
   // PATCH /api/runs/:id/discard - 新 Runs API
   // PATCH /api/projects/:projectId/runs/:id/discard - 旧API互換レイヤ

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -80,6 +80,16 @@ const executeRunSchema = z.object({
     .optional(),
 });
 
+const legacyCreateRunSchema = createRunSchema.extend({
+  model: z.string().min(1, "modelは1文字以上必要です").optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  api_provider: z.string().min(1, "api_providerは1文字以上必要です").optional(),
+});
+
+const legacyExecuteRunSchema = executeRunSchema.extend({
+  api_key: z.string().min(1, "api_keyは1文字以上必要です"),
+});
+
 type ExecuteRunBody = z.infer<typeof executeRunSchema>;
 type CandidateSourceType = "structured_json" | "final_answer" | "trace_step";
 
@@ -405,18 +415,147 @@ function buildExecutionRequest(params: {
 
 function serializeRun(run: typeof runs.$inferSelect): Omit<
   typeof run,
-  "conversation" | "execution_trace" | "structured_output"
+  "project_id" | "conversation" | "execution_trace" | "structured_output"
 > & {
   conversation: ConversationMessage[];
   execution_trace: ExecutionTraceStep[] | null;
   structured_output: StructuredOutput | null;
 } {
   return {
-    ...run,
+    id: run.id,
+    prompt_version_id: run.prompt_version_id,
+    test_case_id: run.test_case_id,
     conversation: parseConversation(run.conversation),
     execution_trace: parseExecutionTrace(run.execution_trace),
     structured_output: parseStructuredOutput(run.structured_output),
+    is_best: run.is_best,
+    is_discarded: run.is_discarded,
+    model: run.model,
+    temperature: run.temperature,
+    api_provider: run.api_provider,
+    execution_profile_id: run.execution_profile_id,
+    created_at: run.created_at,
   };
+}
+
+function serializeRunWithProjectId(run: typeof runs.$inferSelect, projectId: number) {
+  return {
+    ...serializeRun(run),
+    project_id: projectId,
+  };
+}
+
+function parseOptionalBooleanParam(value: string | undefined): boolean | null {
+  if (value === undefined) return null;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function parseProjectIdParam(c: {
+  req: {
+    param: (name: string) => string;
+    query: (name: string) => string | undefined;
+  };
+}): number | null | undefined {
+  const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
+  if (legacyProjectId !== null) {
+    return legacyProjectId;
+  }
+
+  if (c.req.param("projectId") !== undefined) {
+    return null;
+  }
+
+  return parseIntParam(c.req.query("project_id"));
+}
+
+function parseLegacyProjectId(value: string | undefined): number | null | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  return parseIntParam(value);
+}
+
+async function fetchRunById(db: DB, id: number): Promise<typeof runs.$inferSelect | null> {
+  const [run] = await db.select().from(runs).where(eq(runs.id, id));
+  return run ?? null;
+}
+
+async function fetchExecutionSettings(
+  db: DB,
+  params: {
+    executionProfileId?: number;
+    legacyProjectId?: number;
+    legacySnapshot?: Partial<Pick<ExecutionSettings, "model" | "temperature" | "api_provider">>;
+  },
+): Promise<
+  | { ok: true; settings: ExecutionSettings; executionProfileId: number | null }
+  | { ok: false; status: 400 | 404; error: string }
+> {
+  if (params.executionProfileId !== undefined) {
+    const [profile] = await db
+      .select()
+      .from(execution_profiles)
+      .where(eq(execution_profiles.id, params.executionProfileId));
+
+    if (!profile) {
+      return { ok: false, status: 404, error: "Execution profile not found" };
+    }
+
+    return {
+      ok: true,
+      settings: {
+        model: profile.model,
+        temperature: profile.temperature,
+        api_provider: profile.api_provider,
+        max_tokens: profile.max_tokens,
+      },
+      executionProfileId: profile.id,
+    };
+  }
+
+  if (
+    params.legacySnapshot?.model !== undefined &&
+    params.legacySnapshot.temperature !== undefined &&
+    params.legacySnapshot.api_provider !== undefined
+  ) {
+    return {
+      ok: true,
+      settings: {
+        model: params.legacySnapshot.model,
+        temperature: params.legacySnapshot.temperature,
+        api_provider: params.legacySnapshot.api_provider,
+        max_tokens: null,
+      },
+      executionProfileId: null,
+    };
+  }
+
+  if (params.legacyProjectId !== undefined) {
+    const [projectSettings] = await db
+      .select()
+      .from(project_settings)
+      .where(eq(project_settings.project_id, params.legacyProjectId));
+
+    if (!projectSettings) {
+      return { ok: false, status: 404, error: "Project settings not found" };
+    }
+
+    return {
+      ok: true,
+      settings: {
+        model: projectSettings.model,
+        temperature: projectSettings.temperature,
+        api_provider: projectSettings.api_provider,
+        max_tokens: projectSettings.max_tokens,
+      },
+      executionProfileId: null,
+    };
+  }
+
+  return { ok: false, status: 400, error: "execution_profile_id is required" };
 }
 
 function encodeSse(event: string, data: unknown): Uint8Array {
@@ -465,30 +604,38 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   const router = new Hono();
   const llmClientFactory = options.llmClientFactory ?? defaultLLMClientFactory;
 
-  // GET /api/projects/:projectId/runs - Run一覧取得（prompt_version_id / test_case_id でフィルタ可能）
-  // project_id フィルタは prompt_version_projects 基準で実装
+  // GET /api/runs - 新 Runs API
+  // GET /api/projects/:projectId/runs - 旧API互換レイヤ
   router.get("/", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
+    const queryProjectIdRaw = c.req.query("project_id");
+    const queryProjectId = parseIntParam(queryProjectIdRaw);
 
-    if (projectId === null) {
+    if (legacyProjectId === null || (queryProjectIdRaw !== undefined && queryProjectId === null)) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
+    const filterProjectId = legacyProjectId ?? queryProjectId ?? undefined;
 
     const promptVersionIdParam = c.req.query("prompt_version_id");
     const testCaseIdParam = c.req.query("test_case_id");
-
-    // prompt_version_projects 経由でプロジェクトに紐づくバージョンIDを取得
-    const versionIds = await fetchVersionIdsByProject(db, projectId);
-
-    if (versionIds.length === 0) {
-      return c.json([]);
+    const includeDiscardedParam = c.req.query("include_discarded");
+    const includeDiscarded = parseOptionalBooleanParam(includeDiscardedParam);
+    if (includeDiscarded === null && includeDiscardedParam !== undefined) {
+      return c.json({ error: "Invalid include_discarded" }, 400);
     }
 
     const conditions = [
-      eq(runs.project_id, projectId),
-      inArray(runs.prompt_version_id, versionIds),
-      eq(runs.is_discarded, false),
+      ...(includeDiscarded === true ? [] : [eq(runs.is_discarded, false)]),
     ];
+
+    if (filterProjectId !== undefined) {
+      const versionIds = await fetchVersionIdsByProject(db, filterProjectId);
+      if (versionIds.length === 0) {
+        return c.json([]);
+      }
+
+      conditions.push(inArray(runs.prompt_version_id, versionIds));
+    }
 
     if (promptVersionIdParam !== undefined) {
       const promptVersionId = parseIntParam(promptVersionIdParam);
@@ -511,38 +658,80 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       .from(runs)
       .where(and(...conditions));
 
-    return c.json(result.map(serializeRun));
+    return c.json(
+      result.map((run) =>
+        legacyProjectId !== undefined
+          ? serializeRunWithProjectId(run, legacyProjectId)
+          : serializeRun(run),
+      ),
+    );
   });
 
-  // POST /api/projects/:projectId/runs - 新規Run作成
-  router.post("/", zValidator("json", createRunSchema), async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
+  // POST /api/runs - 新 Runs API
+  // POST /api/projects/:projectId/runs - 旧API互換レイヤ
+  router.post("/", zValidator("json", legacyCreateRunSchema), async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
 
-    if (projectId === null) {
+    if (legacyProjectId === null) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
     const body = c.req.valid("json");
 
-    // prompt_version_projects でプロジェクトへの紐づきを確認
-    const [versionLink] = await db
-      .select()
-      .from(prompt_version_projects)
-      .where(
-        and(
-          eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
-          eq(prompt_version_projects.project_id, projectId),
-        ),
-      );
+    if (legacyProjectId !== undefined) {
+      const [versionLink] = await db
+        .select()
+        .from(prompt_version_projects)
+        .where(
+          and(
+            eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
+            eq(prompt_version_projects.project_id, legacyProjectId),
+          ),
+        );
 
-    if (!versionLink) {
-      return c.json({ error: "Prompt version not found in this project" }, 404);
+      if (!versionLink) {
+        return c.json({ error: "Prompt version not found in this project" }, 404);
+      }
+    }
+
+    const legacySnapshot: Partial<Pick<ExecutionSettings, "model" | "temperature" | "api_provider">> =
+      {};
+    if (body.model !== undefined) legacySnapshot.model = body.model;
+    if (body.temperature !== undefined) legacySnapshot.temperature = body.temperature;
+    if (body.api_provider !== undefined) legacySnapshot.api_provider = body.api_provider;
+
+    const resolvedSettings =
+      legacyProjectId !== undefined &&
+      body.execution_profile_id !== undefined &&
+      legacySnapshot.model !== undefined &&
+      legacySnapshot.temperature !== undefined &&
+      legacySnapshot.api_provider !== undefined
+        ? {
+            ok: true as const,
+            settings: {
+              model: legacySnapshot.model,
+              temperature: legacySnapshot.temperature,
+              api_provider: legacySnapshot.api_provider,
+              max_tokens: null,
+            },
+            executionProfileId: body.execution_profile_id,
+          }
+        : await fetchExecutionSettings(db, {
+            ...(body.execution_profile_id !== undefined
+              ? { executionProfileId: body.execution_profile_id }
+              : {}),
+            ...(legacyProjectId !== undefined ? { legacyProjectId } : {}),
+            ...(Object.keys(legacySnapshot).length > 0 ? { legacySnapshot } : {}),
+          });
+
+    if (!resolvedSettings.ok) {
+      return c.json({ error: resolvedSettings.error }, resolvedSettings.status);
     }
 
     const result = await db
       .insert(runs)
       .values({
-        project_id: projectId,
+        project_id: legacyProjectId ?? 0,
         prompt_version_id: body.prompt_version_id,
         test_case_id: body.test_case_id,
         conversation: JSON.stringify(body.conversation),
@@ -551,10 +740,10 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
           body.structured_output === undefined ? null : JSON.stringify(body.structured_output),
         is_best: false,
         is_discarded: false,
-        model: body.model,
-        temperature: body.temperature,
-        api_provider: body.api_provider,
-        execution_profile_id: body.execution_profile_id ?? null,
+        model: resolvedSettings.settings.model,
+        temperature: resolvedSettings.settings.temperature,
+        api_provider: resolvedSettings.settings.api_provider,
+        execution_profile_id: resolvedSettings.executionProfileId,
         created_at: Date.now(),
       })
       .returning();
@@ -564,48 +753,53 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Failed to create Run" }, 500);
     }
 
-    return c.json(serializeRun(created), 201);
+    return c.json(
+      legacyProjectId !== undefined
+        ? serializeRunWithProjectId(created, legacyProjectId)
+        : serializeRun(created),
+      201,
+    );
   });
 
-  // POST /api/projects/:projectId/runs/execute - LLMに接続してRunを実行・保存
-  // execution_profile_id が指定された場合はそこから実行設定を取得する
-  router.post("/execute", zValidator("json", executeRunSchema), async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
+  // POST /api/runs/execute - 新 Runs API
+  // POST /api/projects/:projectId/runs/execute - 旧API互換レイヤ
+  router.post("/execute", zValidator("json", legacyExecuteRunSchema), async (c) => {
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
 
-    if (projectId === null) {
+    if (legacyProjectId === null) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
     const body: ExecuteRunBody = c.req.valid("json");
 
-    // prompt_version_projects 経由でバージョンの所属を確認
-    const [versionLink] = await db
-      .select()
-      .from(prompt_version_projects)
-      .where(
-        and(
-          eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
-          eq(prompt_version_projects.project_id, projectId),
-        ),
-      );
+    if (legacyProjectId !== undefined) {
+      const [versionLink] = await db
+        .select()
+        .from(prompt_version_projects)
+        .where(
+          and(
+            eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
+            eq(prompt_version_projects.project_id, legacyProjectId),
+          ),
+        );
 
-    if (!versionLink) {
-      return c.json({ error: "Prompt version not found" }, 404);
-    }
+      if (!versionLink) {
+        return c.json({ error: "Prompt version not found" }, 404);
+      }
 
-    // test_case_projects 経由でテストケースの所属を確認
-    const [testCaseLink] = await db
-      .select()
-      .from(test_case_projects)
-      .where(
-        and(
-          eq(test_case_projects.test_case_id, body.test_case_id),
-          eq(test_case_projects.project_id, projectId),
-        ),
-      );
+      const [testCaseLink] = await db
+        .select()
+        .from(test_case_projects)
+        .where(
+          and(
+            eq(test_case_projects.test_case_id, body.test_case_id),
+            eq(test_case_projects.project_id, legacyProjectId),
+          ),
+        );
 
-    if (!testCaseLink) {
-      return c.json({ error: "Test case not found" }, 404);
+      if (!testCaseLink) {
+        return c.json({ error: "Test case not found" }, 404);
+      }
     }
 
     const [[version], [testCase]] = await Promise.all([
@@ -621,45 +815,19 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Test case not found" }, 404);
     }
 
-    // execution_profile_id が指定された場合はそこから設定を取得（snapshotとして保存）
-    // 未指定の場合はプロジェクト設定にフォールバック
-    let settings: ExecutionSettings;
-    let resolvedExecutionProfileId: number | null = null;
+    const resolvedSettings = await fetchExecutionSettings(db, {
+      ...(body.execution_profile_id !== undefined
+        ? { executionProfileId: body.execution_profile_id }
+        : {}),
+      ...(legacyProjectId !== undefined ? { legacyProjectId } : {}),
+    });
 
-    if (body.execution_profile_id !== undefined) {
-      const [profile] = await db
-        .select()
-        .from(execution_profiles)
-        .where(eq(execution_profiles.id, body.execution_profile_id));
-
-      if (!profile) {
-        return c.json({ error: "Execution profile not found" }, 404);
-      }
-
-      settings = {
-        model: profile.model,
-        temperature: profile.temperature,
-        api_provider: profile.api_provider,
-        max_tokens: profile.max_tokens,
-      };
-      resolvedExecutionProfileId = profile.id;
-    } else {
-      const [projectSettings] = await db
-        .select()
-        .from(project_settings)
-        .where(eq(project_settings.project_id, projectId));
-
-      if (!projectSettings) {
-        return c.json({ error: "Project settings not found" }, 404);
-      }
-
-      settings = {
-        model: projectSettings.model,
-        temperature: projectSettings.temperature,
-        api_provider: projectSettings.api_provider,
-        max_tokens: projectSettings.max_tokens,
-      };
+    if (!resolvedSettings.ok) {
+      return c.json({ error: resolvedSettings.error }, resolvedSettings.status);
     }
+
+    const settings = resolvedSettings.settings;
+    const resolvedExecutionProfileId = resolvedSettings.executionProfileId;
 
     const client = llmClientFactory({
       apiProvider: settings.api_provider,
@@ -793,7 +961,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
             const [created] = await db
               .insert(runs)
               .values({
-                project_id: projectId,
+                project_id: legacyProjectId ?? 0,
                 prompt_version_id: body.prompt_version_id,
                 test_case_id: body.test_case_id,
                 conversation: JSON.stringify(conversation),
@@ -820,7 +988,14 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
               return;
             }
 
-            controller.enqueue(encodeSse("run", serializeRun(created)));
+            controller.enqueue(
+              encodeSse(
+                "run",
+                legacyProjectId !== undefined
+                  ? serializeRunWithProjectId(created, legacyProjectId)
+                  : serializeRun(created),
+              ),
+            );
           } catch (error) {
             controller.enqueue(encodeSse("error", normalizeExecuteError(error)));
           } finally {
@@ -838,62 +1013,76 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     );
   });
 
-  // GET /api/projects/:projectId/runs/:id - 特定Run取得
+  // GET /api/runs/:id - 新 Runs API
+  // GET /api/projects/:projectId/runs/:id - 旧API互換レイヤ
   router.get("/:id", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
     const id = parseIntParam(c.req.param("id"));
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
 
-    if (projectId === null || id === null) {
+    if (legacyProjectId === null || id === null) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    // prompt_version_projects 経由でプロジェクトに紐づくバージョンIDを取得
-    const versionIds = await fetchVersionIdsByProject(db, projectId);
-
-    if (versionIds.length === 0) {
-      return c.json({ error: "Run not found" }, 404);
-    }
-
-    const [run] = await db
-      .select()
-      .from(runs)
-      .where(
-        and(
-          eq(runs.id, id),
-          eq(runs.project_id, projectId),
-          inArray(runs.prompt_version_id, versionIds),
-        ),
-      );
+    const run =
+      legacyProjectId !== undefined
+        ? await (async () => {
+            const versionIds = await fetchVersionIdsByProject(db, legacyProjectId);
+            if (versionIds.length === 0) return null;
+            return (
+              await db
+                .select()
+                .from(runs)
+                .where(
+                  and(
+                    eq(runs.id, id),
+                    eq(runs.project_id, legacyProjectId),
+                    inArray(runs.prompt_version_id, versionIds),
+                  ),
+                )
+            )[0] ?? null;
+          })()
+        : await fetchRunById(db, id);
 
     if (!run) {
       return c.json({ error: "Run not found" }, 404);
     }
 
-    return c.json(serializeRun(run));
+    return c.json(
+      legacyProjectId !== undefined
+        ? serializeRunWithProjectId(run, legacyProjectId)
+        : serializeRun(run),
+    );
   });
 
-  // PATCH /api/projects/:projectId/runs/:id/best - ベスト回答フラグ更新
+  // PATCH /api/runs/:id/best - 新 Runs API
+  // PATCH /api/projects/:projectId/runs/:id/best - 旧API互換レイヤ
   // バージョン×テストケースごとに1件のみ設定できる（既存フラグは自動解除）
   // { unset: true } を渡すと解除のみ行う
   router.patch("/:id/best", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
     const id = parseIntParam(c.req.param("id"));
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
 
-    if (projectId === null || id === null) {
+    if (legacyProjectId === null || id === null) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    // prompt_version_projects 経由でプロジェクトに紐づくバージョンIDを取得
-    const versionIds = await fetchVersionIdsByProject(db, projectId);
+    const versionIds =
+      legacyProjectId !== undefined ? await fetchVersionIdsByProject(db, legacyProjectId) : null;
 
-    if (versionIds.length === 0) {
+    if (legacyProjectId !== undefined && versionIds !== null && versionIds.length === 0) {
       return c.json({ error: "Run not found" }, 404);
     }
 
     const [existing] = await db
       .select()
       .from(runs)
-      .where(and(eq(runs.id, id), inArray(runs.prompt_version_id, versionIds)));
+      .where(
+        and(
+          eq(runs.id, id),
+          ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
+          ...(versionIds !== null ? [inArray(runs.prompt_version_id, versionIds)] : []),
+        ),
+      );
 
     if (!existing) {
       return c.json({ error: "Run not found" }, 404);
@@ -906,11 +1095,20 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       const updateResult = await db
         .update(runs)
         .set({ is_best: false })
-        .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
+        .where(
+          and(
+            eq(runs.id, id),
+            ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
+          ),
+        )
         .returning();
       const updated = updateResult[0];
       if (!updated) return c.json({ error: "Failed to update Run" }, 500);
-      return c.json(serializeRun(updated));
+      return c.json(
+        legacyProjectId !== undefined
+          ? serializeRunWithProjectId(updated, legacyProjectId)
+          : serializeRun(updated),
+      );
     }
 
     // 同一 prompt_version_id × test_case_id の既存フラグを解除
@@ -919,9 +1117,9 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       .set({ is_best: false })
       .where(
         and(
-          eq(runs.project_id, projectId),
           eq(runs.prompt_version_id, existing.prompt_version_id),
           eq(runs.test_case_id, existing.test_case_id),
+          ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
         ),
       );
 
@@ -929,7 +1127,12 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const updateResult = await db
       .update(runs)
       .set({ is_best: true })
-      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
+      .where(
+        and(
+          eq(runs.id, id),
+          ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
+        ),
+      )
       .returning();
 
     const updated = updateResult[0];
@@ -937,7 +1140,11 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Failed to update Run" }, 500);
     }
 
-    return c.json(serializeRun(updated));
+    return c.json(
+      legacyProjectId !== undefined
+        ? serializeRunWithProjectId(updated, legacyProjectId)
+        : serializeRun(updated),
+    );
   });
 
   // POST /api/projects/:projectId/runs/:id/candidates/extract - annotation_candidates を抽出して保存
@@ -1162,26 +1369,33 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     );
   });
 
-  // PATCH /api/projects/:projectId/runs/:id/discard - Run破棄
+  // PATCH /api/runs/:id/discard - 新 Runs API
+  // PATCH /api/projects/:projectId/runs/:id/discard - 旧API互換レイヤ
   router.patch("/:id/discard", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
     const id = parseIntParam(c.req.param("id"));
+    const legacyProjectId = parseLegacyProjectId(c.req.param("projectId"));
 
-    if (projectId === null || id === null) {
+    if (legacyProjectId === null || id === null) {
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    // prompt_version_projects 経由でプロジェクトに紐づくバージョンIDを取得
-    const versionIds = await fetchVersionIdsByProject(db, projectId);
+    const versionIds =
+      legacyProjectId !== undefined ? await fetchVersionIdsByProject(db, legacyProjectId) : null;
 
-    if (versionIds.length === 0) {
+    if (legacyProjectId !== undefined && versionIds !== null && versionIds.length === 0) {
       return c.json({ error: "Run not found" }, 404);
     }
 
     const [existing] = await db
       .select()
       .from(runs)
-      .where(and(eq(runs.id, id), inArray(runs.prompt_version_id, versionIds)));
+      .where(
+        and(
+          eq(runs.id, id),
+          ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
+          ...(versionIds !== null ? [inArray(runs.prompt_version_id, versionIds)] : []),
+        ),
+      );
 
     if (!existing) {
       return c.json({ error: "Run not found" }, 404);
@@ -1190,7 +1404,12 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const updateResult = await db
       .update(runs)
       .set({ is_discarded: true })
-      .where(and(eq(runs.id, id), eq(runs.project_id, projectId)))
+      .where(
+        and(
+          eq(runs.id, id),
+          ...(legacyProjectId !== undefined ? [eq(runs.project_id, legacyProjectId)] : []),
+        ),
+      )
       .returning();
 
     const updated = updateResult[0];
@@ -1198,7 +1417,11 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Failed to update Run" }, 500);
     }
 
-    return c.json(serializeRun(updated));
+    return c.json(
+      legacyProjectId !== undefined
+        ? serializeRunWithProjectId(updated, legacyProjectId)
+        : serializeRun(updated),
+    );
   });
 
   return router;

--- a/packages/server/src/routes/score-progression.test.ts
+++ b/packages/server/src/routes/score-progression.test.ts
@@ -5,11 +5,131 @@ import { createScoreProgressionRouter } from "./score-progression.js";
 
 function buildApp(db: unknown) {
   const app = new Hono();
+  app.route("/api/score-progression", createScoreProgressionRouter(db as DB));
   app.route("/api/projects/:projectId/score-progression", createScoreProgressionRouter(db as DB));
   return app;
 }
 
 describe("GET /api/projects/:projectId/score-progression", () => {
+  it("新APIでも project_id クエリで同じ集計結果を返す", async () => {
+    let selectCallCount = 0;
+
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ prompt_version_id: 1 }]),
+            }),
+          };
+        }
+        if (selectCallCount === 2) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([
+                  {
+                    id: 1,
+                    project_id: null,
+                    version: 1,
+                    name: "v1",
+                    content: "prompt",
+                    workflow_definition: null,
+                    created_at: 1,
+                    updated_at: 1,
+                  },
+                ]),
+            }),
+          };
+        }
+        if (selectCallCount === 3) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([
+                  {
+                    id: 10,
+                    project_id: 1,
+                    prompt_version_id: 1,
+                    test_case_id: 1,
+                    conversation: "[]",
+                    execution_trace: null,
+                    is_best: true,
+                    is_discarded: false,
+                    created_at: 100,
+                    model: "claude-sonnet-4-6",
+                    temperature: 0.4,
+                    api_provider: "anthropic",
+                    execution_profile_id: 1,
+                  },
+                ]),
+            }),
+          };
+        }
+        if (selectCallCount === 4) {
+          return {
+            from: () => ({
+              where: () =>
+                Promise.resolve([
+                  {
+                    id: 100,
+                    run_id: 10,
+                    human_score: 0.8,
+                    judge_score: 0.7,
+                    comment: null,
+                    is_discarded: false,
+                    created_at: 101,
+                    updated_at: 101,
+                  },
+                ]),
+            }),
+          };
+        }
+        if (selectCallCount === 5) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ test_case_id: 1 }]),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: () =>
+              Promise.resolve([
+                {
+                  id: 1,
+                  title: "ケース1",
+                  turns: "[]",
+                  context_content: "",
+                  expected_description: null,
+                  display_order: 0,
+                  created_at: 1,
+                  updated_at: 1,
+                },
+              ]),
+          }),
+        };
+      },
+    };
+
+    const app = buildApp(db);
+    const res = await app.request("/api/score-progression?project_id=1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      versionSummaries: Array<{ versionId: number; runCount: number; scoredCount: number }>;
+    };
+
+    expect(body.versionSummaries).toEqual([
+      expect.objectContaining({
+        versionId: 1,
+        runCount: 1,
+        scoredCount: 1,
+      }),
+    ]);
+  });
+
   it("共有ラベルがあっても対象プロジェクトのRunだけを集計する", async () => {
     let selectCallCount = 0;
 

--- a/packages/server/src/routes/score-progression.ts
+++ b/packages/server/src/routes/score-progression.ts
@@ -17,6 +17,24 @@ function parseIntParam(value: string | undefined): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+function resolveProjectId(c: {
+  req: {
+    param: (name: string) => string;
+    query: (name: string) => string | undefined;
+  };
+}): number | null | undefined {
+  const legacyProjectId = parseIntParam(c.req.param("projectId"));
+  if (legacyProjectId !== null) {
+    return legacyProjectId;
+  }
+
+  if (c.req.param("projectId") !== undefined) {
+    return null;
+  }
+
+  return parseIntParam(c.req.query("project_id"));
+}
+
 export type VersionSummary = {
   versionId: number;
   versionNumber: number;
@@ -59,21 +77,23 @@ export function createScoreProgressionRouter(db: DB) {
   const router = new Hono();
 
   router.get("/", async (c) => {
-    const projectId = parseIntParam(c.req.param("projectId"));
+    const projectId = resolveProjectId(c);
 
     if (projectId === null) {
       return c.json({ error: "Invalid projectId" }, 400);
     }
 
-    // prompt_version_projects 経由でプロジェクトに紐づくバージョンIDを取得
-    const versionLinks = await db
-      .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
-      .from(prompt_version_projects)
-      .where(eq(prompt_version_projects.project_id, projectId));
+    const versionIds =
+      projectId !== undefined
+        ? (
+            await db
+              .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+              .from(prompt_version_projects)
+              .where(eq(prompt_version_projects.project_id, projectId))
+          ).map((l) => l.prompt_version_id)
+        : [];
 
-    const versionIds = versionLinks.map((l) => l.prompt_version_id);
-
-    if (versionIds.length === 0) {
+    if (projectId !== undefined && versionIds.length === 0) {
       return c.json({
         versionSummaries: [],
         testCaseBreakdown: [],
@@ -81,10 +101,10 @@ export function createScoreProgressionRouter(db: DB) {
     }
 
     // バージョン詳細を取得
-    const versions = await db
-      .select()
-      .from(prompt_versions)
-      .where(inArray(prompt_versions.id, versionIds));
+    const versions =
+      projectId !== undefined
+        ? await db.select().from(prompt_versions).where(inArray(prompt_versions.id, versionIds))
+        : await db.select().from(prompt_versions);
 
     if (versions.length === 0) {
       return c.json({
@@ -94,10 +114,10 @@ export function createScoreProgressionRouter(db: DB) {
     }
 
     // prompt_version_projects 基準でRunを取得
-    const allRuns = await db
-      .select()
-      .from(runs)
-      .where(and(eq(runs.project_id, projectId), inArray(runs.prompt_version_id, versionIds)));
+    const allRuns =
+      projectId !== undefined
+        ? await db.select().from(runs).where(inArray(runs.prompt_version_id, versionIds))
+        : await db.select().from(runs);
 
     if (allRuns.length === 0) {
       const emptySummaries: VersionSummary[] = versions.map((v) => ({
@@ -164,12 +184,15 @@ export function createScoreProgressionRouter(db: DB) {
       });
 
     // test_case_projects 経由でプロジェクトに紐づくテストケースIDを取得
-    const testCaseLinks = await db
-      .select({ test_case_id: test_case_projects.test_case_id })
-      .from(test_case_projects)
-      .where(eq(test_case_projects.project_id, projectId));
-
-    const testCaseIds = testCaseLinks.map((l) => l.test_case_id);
+    const testCaseIds =
+      projectId !== undefined
+        ? (
+            await db
+              .select({ test_case_id: test_case_projects.test_case_id })
+              .from(test_case_projects)
+              .where(eq(test_case_projects.project_id, projectId))
+          ).map((l) => l.test_case_id)
+        : [...new Set(allRuns.map((run) => run.test_case_id))];
 
     if (testCaseIds.length === 0) {
       return c.json({


### PR DESCRIPTION
## 概要
- 旧 `/api/projects/:projectId/runs` と `/api/projects/:projectId/score-progression` を互換レイヤとして整理
- 新 `/api/runs` と `/api/score-progression` を追加し、legacy path と共通ロジックで運用可能に変更
- legacy path の `project_id` 補完と、新旧 API の互換テストを追加

## 変更理由
- 既存 Runs / Score / Progression 画面を壊さずに、新しい runs / score-progression モデルへ段階的に移行できるようにするため

## 検証
- `pnpm --filter @prompt-reviewer/server exec tsc --noEmit`
- `pnpm run test -- packages/server/src/routes/runs.test.ts packages/server/src/routes/score-progression.test.ts`
