### PR TITLE
抽出ページのレビュー復帰とタブ遷移を修正

### DIFF
--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -1,4 +1,11 @@
+import { useEffect } from "react";
 import { NavLink, useLocation, useParams } from "react-router";
+import {
+  buildAnnotationReviewPath,
+  getAnnotationReviewContextFromSearch,
+  loadLastAnnotationReviewContext,
+  saveLastAnnotationReviewContext,
+} from "../lib/annotationReviewNavigation";
 import styles from "./AnnotationSectionTabs.module.css";
 
 const annotationRoutes = {
@@ -15,19 +22,22 @@ export function AnnotationSectionTabs() {
   }
 
   const searchParams = new URLSearchParams(location.search);
+  const reviewContextFromSearch = getAnnotationReviewContextFromSearch(location.search);
+  const persistedReviewContext = loadLastAnnotationReviewContext(id);
+  const reviewContext = reviewContextFromSearch ?? persistedReviewContext;
   const hasRunId = searchParams.get("runId") !== null;
   const isReviewPath = location.pathname.endsWith(`/${annotationRoutes.review}`);
   const isSettingsPath = location.pathname.endsWith(`/${annotationRoutes.settings}`);
 
-  const reviewParams = new URLSearchParams({ mode: "review" });
-  const runId = searchParams.get("runId");
-  const taskId = searchParams.get("taskId");
-  if (runId) reviewParams.set("runId", runId);
-  if (taskId) reviewParams.set("taskId", taskId);
+  useEffect(() => {
+    if (reviewContextFromSearch) {
+      saveLastAnnotationReviewContext(id, reviewContextFromSearch);
+    }
+  }, [id, reviewContextFromSearch]);
 
   const tabs = [
     {
-      to: `/projects/${id}/${annotationRoutes.review}?${reviewParams.toString()}`,
+      to: buildAnnotationReviewPath(id, reviewContext),
       label: "レビュー",
       isActive: isReviewPath && hasRunId,
     },

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -1,4 +1,9 @@
 import { NavLink, Outlet, useLocation, useParams } from "react-router";
+import {
+  buildAnnotationReviewPath,
+  getAnnotationReviewContextFromSearch,
+  loadLastAnnotationReviewContext,
+} from "../lib/annotationReviewNavigation";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
@@ -13,6 +18,12 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
 });
 
 function ProjectSubNav({ projectId }: { projectId: string }) {
+  const location = useLocation();
+  const reviewContext =
+    getAnnotationReviewContextFromSearch(location.search) ??
+    loadLastAnnotationReviewContext(projectId);
+  const annotationReviewPath = buildAnnotationReviewPath(projectId, reviewContext);
+
   const subNavItems = [
     { to: `/projects/${projectId}`, label: "ホーム", end: true },
     { to: `/projects/${projectId}/context-files`, label: "コンテキスト" },
@@ -21,7 +32,7 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
     { to: `/projects/${projectId}/runs`, label: "Run" },
     { to: `/projects/${projectId}/score`, label: "採点" },
     {
-      to: `/projects/${projectId}/annotation-review`,
+      to: annotationReviewPath,
       label: "抽出",
       matchPaths: [
         `/projects/${projectId}/annotation-review`,
@@ -30,7 +41,6 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
     },
     { to: `/projects/${projectId}/settings`, label: "設定" },
   ];
-  const location = useLocation();
 
   return (
     <div style={{ marginTop: "8px" }}>

--- a/packages/ui/src/lib/annotationReviewNavigation.test.ts
+++ b/packages/ui/src/lib/annotationReviewNavigation.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildAnnotationReviewPath,
+  getAnnotationReviewContextFromSearch,
+  loadLastAnnotationReviewContext,
+  saveLastAnnotationReviewContext,
+} from "./annotationReviewNavigation";
+
+describe("annotationReviewNavigation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("runId と taskId がある検索文字列からレビュー文脈を取り出す", () => {
+    expect(getAnnotationReviewContextFromSearch("?mode=review&runId=12&taskId=34")).toEqual({
+      runId: "12",
+      taskId: "34",
+    });
+  });
+
+  it("runId または taskId が欠けているときは null を返す", () => {
+    expect(getAnnotationReviewContextFromSearch("?mode=review&runId=12")).toBeNull();
+    expect(getAnnotationReviewContextFromSearch("?taskId=34")).toBeNull();
+  });
+
+  it("レビュー文脈があると mode=review 付きの抽出 URL を組み立てる", () => {
+    expect(
+      buildAnnotationReviewPath(7, {
+        runId: "12",
+        taskId: "34",
+      }),
+    ).toBe("/projects/7/annotation-review?mode=review&runId=12&taskId=34");
+  });
+
+  it("レビュー文脈がないときは抽出トップ URL を返す", () => {
+    expect(buildAnnotationReviewPath(7, null)).toBe("/projects/7/annotation-review");
+  });
+
+  it("保存したレビュー文脈を project ごとに復元できる", () => {
+    const storage = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      },
+    });
+
+    saveLastAnnotationReviewContext(7, { runId: "12", taskId: "34" });
+
+    expect(loadLastAnnotationReviewContext(7)).toEqual({
+      runId: "12",
+      taskId: "34",
+    });
+    expect(loadLastAnnotationReviewContext(8)).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/annotationReviewNavigation.ts
+++ b/packages/ui/src/lib/annotationReviewNavigation.ts
@@ -1,0 +1,81 @@
+export type AnnotationReviewContext = {
+  runId: string;
+  taskId: string;
+};
+
+function storageKey(projectId: string | number): string {
+  return `prompt-reviewer:annotation-review:${projectId}`;
+}
+
+function isValidContext(value: Partial<AnnotationReviewContext>): value is AnnotationReviewContext {
+  return (
+    typeof value.runId === "string" &&
+    value.runId !== "" &&
+    typeof value.taskId === "string" &&
+    value.taskId !== ""
+  );
+}
+
+export function getAnnotationReviewContextFromSearch(
+  search: string,
+): AnnotationReviewContext | null {
+  const searchParams = new URLSearchParams(search);
+  const runId = searchParams.get("runId");
+  const taskId = searchParams.get("taskId");
+
+  if (!runId || !taskId) {
+    return null;
+  }
+
+  return { runId, taskId };
+}
+
+export function loadLastAnnotationReviewContext(
+  projectId: string | number,
+): AnnotationReviewContext | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(storageKey(projectId));
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<AnnotationReviewContext>;
+    return isValidContext(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastAnnotationReviewContext(
+  projectId: string | number,
+  context: AnnotationReviewContext,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(storageKey(projectId), JSON.stringify(context));
+}
+
+export function buildAnnotationReviewPath(
+  projectId: string | number,
+  context?: AnnotationReviewContext | null,
+): string {
+  const basePath = `/projects/${projectId}/annotation-review`;
+
+  if (!context) {
+    return basePath;
+  }
+
+  const searchParams = new URLSearchParams({
+    mode: "review",
+    runId: context.runId,
+    taskId: context.taskId,
+  });
+
+  return `${basePath}?${searchParams.toString()}`;
+}

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -13,7 +13,6 @@ import {
   getAnnotationTask,
   getAnnotationTasks,
   getGoldAnnotations,
-  getProject,
   getRun,
   getTestCase,
   getTestCases,
@@ -35,11 +34,11 @@ function statusLabel(status: CandidateStatus): string {
 function statusClassName(status: CandidateStatus, s: typeof styles): string {
   switch (status) {
     case "pending":
-      return s.badgePending;
+      return s.badgePending ?? "";
     case "accepted":
-      return s.badgeAccepted;
+      return s.badgeAccepted ?? "";
     case "rejected":
-      return s.badgeRejected;
+      return s.badgeRejected ?? "";
   }
 }
 
@@ -79,6 +78,7 @@ function LineNumberedText({
     );
     if (matching.length === 0) return null;
     const first = matching[0];
+    if (!first) return null;
     const label = labels.find((l) => l.key === first.label);
     return labelColorRgba(label?.color, first.status === "accepted" ? 0.35 : 0.15);
   }
@@ -330,52 +330,42 @@ function CandidateCard({
   );
 }
 
-export function AnnotationReviewPage() {
-  const { id } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
-  const projectId = Number(id);
-  const runIdParam = searchParams.get("runId");
-  const mode = searchParams.get("mode");
-  const runId = Number(runIdParam);
-  const taskId = Number(searchParams.get("taskId"));
-
-  if (mode === "review" && !runIdParam) {
-    return (
-      <div className={styles.root}>
-        <div className={styles.pageHeader}>
-          <div>
-            <h2 className={styles.pageTitle}>抽出</h2>
-          </div>
-        </div>
-        <AnnotationSectionTabs />
-        <div className={styles.rightSection}>
-          <h3 className={styles.panelTitle}>レビューの開始方法</h3>
-          <p className={styles.emptyMsg}>
-            Run ページで候補抽出を実行するか、既存の候補レビューリンクからこの画面を開いてください。
-          </p>
-          <div style={{ padding: "0 16px 16px" }}>
-            <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
-              ← Run に戻る
-            </Link>
-          </div>
+function AnnotationReviewStartPage({ projectId }: { projectId: number }) {
+  return (
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <div>
+          <h2 className={styles.pageTitle}>抽出</h2>
         </div>
       </div>
-    );
-  }
+      <AnnotationSectionTabs />
+      <div className={styles.rightSection}>
+        <h3 className={styles.panelTitle}>レビューの開始方法</h3>
+        <p className={styles.emptyMsg}>
+          Run ページで候補抽出を実行するか、既存の候補レビューリンクからこの画面を開いてください。
+        </p>
+        <div style={{ padding: "0 16px 16px" }}>
+          <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+            ← Run に戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-  // runId が指定されていない場合は Gold Annotation ブラウズモード
-  if (!runIdParam) {
-    return <GoldAnnotationBrowse projectId={projectId} />;
-  }
+function AnnotationReviewContent({
+  projectId,
+  runId,
+  taskId,
+}: {
+  projectId: number;
+  runId: number;
+  taskId: number;
+}) {
   const queryClient = useQueryClient();
 
   const [activeRange, setActiveRange] = useState<{ start: number; end: number } | null>(null);
-
-  const { data: project } = useQuery({
-    queryKey: ["projects", projectId],
-    queryFn: () => getProject(projectId),
-    enabled: !Number.isNaN(projectId),
-  });
 
   const { data: run, isLoading: isRunLoading } = useQuery({
     queryKey: ["runs", projectId, runId],
@@ -559,6 +549,26 @@ export function AnnotationReviewPage() {
       </div>
     </div>
   );
+}
+
+export function AnnotationReviewPage() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const projectId = Number(id);
+  const runIdParam = searchParams.get("runId");
+  const mode = searchParams.get("mode");
+  const runId = Number(runIdParam);
+  const taskId = Number(searchParams.get("taskId"));
+
+  if (mode === "review" && !runIdParam) {
+    return <AnnotationReviewStartPage projectId={projectId} />;
+  }
+
+  if (!runIdParam) {
+    return <GoldAnnotationBrowse projectId={projectId} />;
+  }
+
+  return <AnnotationReviewContent projectId={projectId} runId={runId} taskId={taskId} />;
 }
 
 function GoldAnnotationCard({


### PR DESCRIPTION
## 概要
- 抽出ページで最後に見ていたレビューの runId/taskId を保持し、サイドバーやタブ遷移でもレビュー画面に復帰できるようにしました
- ゴールドアノテーションタブへ移動した際に Hooks の数が崩れて落ちる問題を、ページ分岐の構造を見直して解消しました
- レビュー文脈保持ロジックの単体テストを追加しました

## 確認
- pnpm --filter @prompt-reviewer/ui typecheck
- pnpm test -- packages/ui/src/lib/annotationReviewNavigation.test.ts

Closes #169