### PR TITLE
抽出設定・レビューページのUIを改善する

### DIFF
--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -17,23 +17,23 @@ export function AnnotationSectionTabs() {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
 
-  if (!id) {
-    return null;
-  }
-
   const searchParams = new URLSearchParams(location.search);
   const reviewContextFromSearch = getAnnotationReviewContextFromSearch(location.search);
-  const persistedReviewContext = loadLastAnnotationReviewContext(id);
+  const persistedReviewContext = id ? loadLastAnnotationReviewContext(id) : null;
   const reviewContext = reviewContextFromSearch ?? persistedReviewContext;
   const hasRunId = searchParams.get("runId") !== null;
   const isReviewPath = location.pathname.endsWith(`/${annotationRoutes.review}`);
   const isSettingsPath = location.pathname.endsWith(`/${annotationRoutes.settings}`);
 
   useEffect(() => {
-    if (reviewContextFromSearch) {
+    if (id && reviewContextFromSearch) {
       saveLastAnnotationReviewContext(id, reviewContextFromSearch);
     }
   }, [id, reviewContextFromSearch]);
+
+  if (!id) {
+    return null;
+  }
 
   const tabs = [
     {

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -453,10 +453,16 @@ function AnnotationReviewContent({
   if (!run || !annotationTask) {
     return (
       <div className={styles.root}>
+        <div className={styles.pageHeader}>
+          <div>
+            <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+              ← Run 一覧に戻る
+            </Link>
+            <h2 className={styles.pageTitle}>抽出</h2>
+          </div>
+        </div>
+        <AnnotationSectionTabs />
         <p className={styles.errorMsg}>Run またはアノテーションタスクが見つかりません。</p>
-        <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
-          ← Run 一覧に戻る
-        </Link>
       </div>
     );
   }
@@ -505,7 +511,7 @@ function AnnotationReviewContent({
               <p className={styles.emptyMsg}>候補がありません。Run ページから抽出してください。</p>
             ) : (
               <div className={styles.candidateList}>
-                {candidates.map((c) => (
+                {[...candidates].sort((a, b) => a.start_line - b.start_line).map((c) => (
                   <CandidateCard
                     key={c.id}
                     candidate={c}
@@ -534,7 +540,7 @@ function AnnotationReviewContent({
               <p className={styles.emptyMsg}>まだ Gold Annotation がありません</p>
             ) : (
               <div className={styles.goldList}>
-                {goldAnnotations.map((g) => (
+                {[...goldAnnotations].sort((a, b) => a.start_line - b.start_line).map((g) => (
                   <GoldAnnotationCard
                     key={g.id}
                     gold={g}
@@ -824,7 +830,7 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
                 <p className={styles.emptyMsg}>Gold Annotation がありません</p>
               ) : (
                 <div className={styles.goldList}>
-                  {goldAnnotations.map((g) => (
+                  {[...goldAnnotations].sort((a, b) => a.start_line - b.start_line).map((g) => (
                     <GoldAnnotationCard
                       key={g.id}
                       gold={g}

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
@@ -51,20 +51,34 @@
   align-items: start;
 }
 
-.sidebarSection,
+.sidebarSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 60vh;
+}
+
 .contentSection,
 .labelSection,
-.taskList,
 .labelList {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
+.taskList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+  overflow-y: auto;
+}
+
 .createTaskSection {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  margin-top: auto;
 }
 
 .inlineForm,

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -124,6 +124,7 @@ export function AnnotationTaskSettingsPage() {
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
   const [feedbackTone, setFeedbackTone] = useState<"success" | "error" | null>(null);
   const [taskFormMode, setTaskFormMode] = useState<"create" | "edit" | null>(null);
+  const [labelCreateOpen, setLabelCreateOpen] = useState(false);
 
   const { data: project } = useQuery({
     queryKey: ["project", projectId],
@@ -166,20 +167,22 @@ export function AnnotationTaskSettingsPage() {
   });
 
   useEffect(() => {
-    if (taskDetailQuery.data) {
-      setTaskForm(buildTaskForm(taskDetailQuery.data));
-
-      if (editingLabelId !== null) {
-        const nextLabel = taskDetailQuery.data.labels.find((label) => label.id === editingLabelId);
+    if (!taskDetailQuery.data) return;
+    setTaskForm(buildTaskForm(taskDetailQuery.data));
+    const labels = taskDetailQuery.data.labels;
+    setEditingLabelId((currentId) => {
+      if (currentId !== null) {
+        const nextLabel = labels.find((l) => l.id === currentId);
         if (nextLabel) {
           setEditingLabelForm(buildLabelForm(nextLabel));
         } else {
-          setEditingLabelId(null);
           setEditingLabelForm(emptyLabelForm);
+          return null;
         }
       }
-    }
-  }, [editingLabelId, taskDetailQuery.data]);
+      return currentId;
+    });
+  }, [taskDetailQuery.data]);
 
   const sortedLabels = useMemo(
     () => taskDetailQuery.data?.labels ?? [],
@@ -259,6 +262,7 @@ export function AnnotationTaskSettingsPage() {
         await refreshTaskData(selectedTaskId);
       }
       setNewLabelForm(emptyLabelForm);
+      setLabelCreateOpen(false);
       showFeedback("ラベルを追加しました。", "success");
     },
     onError: (error) => {
@@ -424,78 +428,6 @@ export function AnnotationTaskSettingsPage() {
             })}
           </div>
 
-          <div className={styles.createTaskSection}>
-            {taskFormMode === "create" && (
-              <form
-                className={styles.panel}
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  createTaskMutation.mutate();
-                }}
-              >
-                <label className={styles.fieldLabel} htmlFor="new-task-name">
-                  新規タスク名
-                </label>
-                <input
-                  id="new-task-name"
-                  className={styles.fieldInput}
-                  value={newTaskForm.name}
-                  onChange={(event) =>
-                    setNewTaskForm((current) => ({ ...current, name: event.target.value }))
-                  }
-                  placeholder="例: 回答品質アノテーション"
-                />
-
-                <label className={styles.fieldLabel} htmlFor="new-task-description">
-                  説明
-                </label>
-                <textarea
-                  id="new-task-description"
-                  className={styles.fieldTextarea}
-                  value={newTaskForm.description}
-                  onChange={(event) =>
-                    setNewTaskForm((current) => ({ ...current, description: event.target.value }))
-                  }
-                  placeholder="任意: この task の目的や判定基準"
-                  rows={4}
-                />
-
-                <div className={styles.outputModeBox}>
-                  <span className={styles.outputModeLabel}>Output mode</span>
-                  <strong className={styles.outputModeValue}>span_label</strong>
-                  <p className={styles.outputModeHint}>初期実装では固定です。</p>
-                </div>
-
-                <div className={styles.formFooter}>
-                  <button type="submit" className={styles.primaryButton} disabled={!canCreateTask}>
-                    {createTaskMutation.isPending ? "作成中..." : "タスクを追加"}
-                  </button>
-                  <button
-                    type="button"
-                    className={styles.ghostButton}
-                    onClick={() => setTaskFormMode(null)}
-                    disabled={createTaskMutation.isPending}
-                  >
-                    キャンセル
-                  </button>
-                </div>
-              </form>
-            )}
-
-            <div className={styles.leftAlignedAction}>
-              <button
-                type="button"
-                className={styles.secondaryButton}
-                onClick={() =>
-                  setTaskFormMode((current) => (current === "create" ? null : "create"))
-                }
-                aria-expanded={taskFormMode === "create"}
-              >
-                {taskFormMode === "create" ? "新規タスク作成を閉じる" : "新規タスクを作成"}
-              </button>
-            </div>
-          </div>
-
           {selectedTaskId !== null &&
             !taskDetailQuery.isLoading &&
             !taskDetailQuery.isError &&
@@ -626,6 +558,78 @@ export function AnnotationTaskSettingsPage() {
                 </div>
               </section>
             )}
+
+          <div className={styles.createTaskSection}>
+            {taskFormMode === "create" && (
+              <form
+                className={styles.panel}
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  createTaskMutation.mutate();
+                }}
+              >
+                <label className={styles.fieldLabel} htmlFor="new-task-name">
+                  新規タスク名
+                </label>
+                <input
+                  id="new-task-name"
+                  className={styles.fieldInput}
+                  value={newTaskForm.name}
+                  onChange={(event) =>
+                    setNewTaskForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                  placeholder="例: 回答品質アノテーション"
+                />
+
+                <label className={styles.fieldLabel} htmlFor="new-task-description">
+                  説明
+                </label>
+                <textarea
+                  id="new-task-description"
+                  className={styles.fieldTextarea}
+                  value={newTaskForm.description}
+                  onChange={(event) =>
+                    setNewTaskForm((current) => ({ ...current, description: event.target.value }))
+                  }
+                  placeholder="任意: この task の目的や判定基準"
+                  rows={4}
+                />
+
+                <div className={styles.outputModeBox}>
+                  <span className={styles.outputModeLabel}>Output mode</span>
+                  <strong className={styles.outputModeValue}>span_label</strong>
+                  <p className={styles.outputModeHint}>初期実装では固定です。</p>
+                </div>
+
+                <div className={styles.formFooter}>
+                  <button type="submit" className={styles.primaryButton} disabled={!canCreateTask}>
+                    {createTaskMutation.isPending ? "作成中..." : "タスクを追加"}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.ghostButton}
+                    onClick={() => setTaskFormMode(null)}
+                    disabled={createTaskMutation.isPending}
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </form>
+            )}
+
+            <div className={styles.leftAlignedAction}>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() =>
+                  setTaskFormMode((current) => (current === "create" ? null : "create"))
+                }
+                aria-expanded={taskFormMode === "create"}
+              >
+                {taskFormMode === "create" ? "新規タスク作成を閉じる" : "新規タスクを作成"}
+              </button>
+            </div>
+          </div>
         </section>
 
         <section className={styles.contentSection}>
@@ -650,102 +654,10 @@ export function AnnotationTaskSettingsPage() {
                 <div>
                   <h3 className={styles.sectionTitle}>ラベル設定</h3>
                   <p className={styles.sectionHint}>
-                    表示名、内部 key、色、表示順を UI から管理できます。
+                    カテゴリキー・カテゴリ名・色・表示順を UI から管理できます。
                   </p>
                 </div>
               </div>
-
-              <form
-                className={styles.panel}
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  createLabelMutation.mutate();
-                }}
-              >
-                <div className={styles.fieldGrid}>
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="new-label-key">
-                      分類ラベル
-                      <span className={styles.requiredMark}>必須</span>
-                    </label>
-                    <input
-                      id="new-label-key"
-                      className={styles.fieldInput}
-                      value={newLabelForm.key}
-                      onChange={(event) =>
-                        setNewLabelForm((current) => ({ ...current, key: event.target.value }))
-                      }
-                      placeholder="例: missing_evidence"
-                    />
-                    <p className={styles.fieldHint}>未入力なら表示名から自動生成します。</p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="new-label-name">
-                      表示名
-                    </label>
-                    <input
-                      id="new-label-name"
-                      className={styles.fieldInput}
-                      value={newLabelForm.name}
-                      onChange={(event) =>
-                        setNewLabelForm((current) => ({ ...current, name: event.target.value }))
-                      }
-                      placeholder="未入力なら分類ラベルをそのまま使います"
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="new-label-color">
-                      色
-                    </label>
-                    <div className={styles.colorFieldRow}>
-                      <input
-                        id="new-label-color"
-                        className={styles.fieldInput}
-                        value={newLabelForm.color}
-                        onChange={(event) =>
-                          setNewLabelForm((current) => ({
-                            ...current,
-                            color: event.target.value,
-                          }))
-                        }
-                        placeholder="#ff7a59"
-                      />
-                      <span
-                        className={styles.colorChip}
-                        style={{ backgroundColor: buildLabelPreviewColor(newLabelForm) }}
-                        aria-label="色プレビュー"
-                      />
-                    </div>
-                    <p className={styles.fieldHint}>未入力なら自動で設定します。</p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel} htmlFor="new-label-order">
-                      並び順
-                    </label>
-                    <input
-                      id="new-label-order"
-                      className={styles.fieldInput}
-                      type="number"
-                      value={newLabelForm.displayOrder}
-                      onChange={(event) =>
-                        setNewLabelForm((current) => ({
-                          ...current,
-                          displayOrder: event.target.value,
-                        }))
-                      }
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.formFooter}>
-                  <button type="submit" className={styles.primaryButton} disabled={!canCreateLabel}>
-                    {createLabelMutation.isPending ? "追加中..." : "ラベルを追加"}
-                  </button>
-                </div>
-              </form>
 
               <div className={styles.labelList}>
                 {sortedLabels.length === 0 ? (
@@ -760,18 +672,9 @@ export function AnnotationTaskSettingsPage() {
                     const currentForm = isEditing ? editingLabelForm : buildLabelForm(label);
 
                     return (
-                      <form
+                      <div
                         key={label.id}
                         className={styles.labelCard}
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          if (!isEditing) {
-                            setEditingLabelId(label.id);
-                            setEditingLabelForm(buildLabelForm(label));
-                            return;
-                          }
-                          updateLabelMutation.mutate();
-                        }}
                       >
                         <div className={styles.labelCardHeader}>
                           <div>
@@ -794,9 +697,10 @@ export function AnnotationTaskSettingsPage() {
                               </button>
                             ) : (
                               <button
-                                type="submit"
+                                type="button"
                                 className={styles.secondaryButton}
                                 disabled={!canUpdateLabel}
+                                onClick={() => updateLabelMutation.mutate()}
                               >
                                 {updateLabelMutation.isPending ? "保存中..." : "保存"}
                               </button>
@@ -815,7 +719,7 @@ export function AnnotationTaskSettingsPage() {
                         <div className={styles.fieldGrid}>
                           <div className={styles.fieldGroup}>
                             <label htmlFor="label-key-input" className={styles.fieldLabel}>
-                              分類ラベル
+                              分類ラベル/カテゴリキー
                               <span className={styles.requiredMark}>必須</span>
                             </label>
                             <input
@@ -832,14 +736,14 @@ export function AnnotationTaskSettingsPage() {
                             />
                             {isEditing && (
                               <p className={styles.fieldHint}>
-                                未入力なら表示名から自動生成します。
+                                未入力ならカテゴリ名から自動生成します。
                               </p>
                             )}
                           </div>
 
                           <div className={styles.fieldGroup}>
                             <label htmlFor="label-name-input" className={styles.fieldLabel}>
-                              表示名
+                              カテゴリ名
                             </label>
                             <input
                               id="label-name-input"
@@ -915,10 +819,128 @@ export function AnnotationTaskSettingsPage() {
                             </button>
                           </div>
                         )}
-                      </form>
+                      </div>
                     );
                   })
                 )}
+              </div>
+
+              <div className={styles.createTaskSection}>
+                {labelCreateOpen && (
+                  <form
+                    className={styles.panel}
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      createLabelMutation.mutate();
+                    }}
+                  >
+                    <div className={styles.fieldGrid}>
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="new-label-key">
+                          分類ラベル/カテゴリキー
+                          <span className={styles.requiredMark}>必須</span>
+                        </label>
+                        <input
+                          id="new-label-key"
+                          className={styles.fieldInput}
+                          value={newLabelForm.key}
+                          onChange={(event) =>
+                            setNewLabelForm((current) => ({ ...current, key: event.target.value }))
+                          }
+                          placeholder="例: missing_evidence"
+                        />
+                        <p className={styles.fieldHint}>未入力ならカテゴリ名から自動生成します。</p>
+                      </div>
+
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="new-label-name">
+                          カテゴリ名
+                        </label>
+                        <input
+                          id="new-label-name"
+                          className={styles.fieldInput}
+                          value={newLabelForm.name}
+                          onChange={(event) =>
+                            setNewLabelForm((current) => ({ ...current, name: event.target.value }))
+                          }
+                          placeholder="未入力ならカテゴリキーをそのまま使います"
+                        />
+                      </div>
+
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="new-label-color">
+                          色
+                        </label>
+                        <div className={styles.colorFieldRow}>
+                          <input
+                            id="new-label-color"
+                            className={styles.fieldInput}
+                            value={newLabelForm.color}
+                            onChange={(event) =>
+                              setNewLabelForm((current) => ({
+                                ...current,
+                                color: event.target.value,
+                              }))
+                            }
+                            placeholder="#ff7a59"
+                          />
+                          <span
+                            className={styles.colorChip}
+                            style={{ backgroundColor: buildLabelPreviewColor(newLabelForm) }}
+                            aria-label="色プレビュー"
+                          />
+                        </div>
+                        <p className={styles.fieldHint}>未入力なら自動で設定します。</p>
+                      </div>
+
+                      <div className={styles.fieldGroup}>
+                        <label className={styles.fieldLabel} htmlFor="new-label-order">
+                          並び順
+                        </label>
+                        <input
+                          id="new-label-order"
+                          className={styles.fieldInput}
+                          type="number"
+                          value={newLabelForm.displayOrder}
+                          onChange={(event) =>
+                            setNewLabelForm((current) => ({
+                              ...current,
+                              displayOrder: event.target.value,
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div className={styles.formFooter}>
+                      <button type="submit" className={styles.primaryButton} disabled={!canCreateLabel}>
+                        {createLabelMutation.isPending ? "追加中..." : "ラベルを追加"}
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.ghostButton}
+                        onClick={() => {
+                          setLabelCreateOpen(false);
+                          setNewLabelForm(emptyLabelForm);
+                        }}
+                        disabled={createLabelMutation.isPending}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </form>
+                )}
+
+                <div className={styles.leftAlignedAction}>
+                  <button
+                    type="button"
+                    className={styles.secondaryButton}
+                    onClick={() => setLabelCreateOpen((prev) => !prev)}
+                    aria-expanded={labelCreateOpen}
+                  >
+                    {labelCreateOpen ? "新規ラベル追加を閉じる" : "新規ラベルを追加"}
+                  </button>
+                </div>
               </div>
 
               {/* プロンプト生成パネル */}


### PR DESCRIPTION
## Summary

- 抽出設定: 新規タスク作成ボタンをサイドバー左下に固定配置（`margin-top: auto`）
- 抽出設定: ラベル追加フォームをトグル式に変更し下部に配置（タスク側と統一）
- 抽出設定: ラベルカードを `<form>` から `<div>` に変更し、編集ボタン押下時に保存が即時実行される問題を修正
- 抽出設定: ラベル項目のテキストを「分類ラベル/カテゴリキー」「カテゴリ名」に変更
- 抽出設定: `useEffect` の依存配列から `editingLabelId` を除去し編集状態のリセットを防止
- 抽出レビュー: `AnnotationSectionTabs` の Rules of Hooks 違反を修正（`useEffect` を early return より前に移動）
- 抽出レビュー: エラー状態（Run・タスク未発見）でもタブを表示するよう修正
- 抽出レビュー: 候補一覧・Gold Annotation を `start_line` 昇順で表示

## Test plan

- [ ] 抽出設定ページで新規タスク作成ボタンがサイドバー下部に表示される
- [ ] ラベル追加フォームがトグルボタンで開閉できる
- [ ] ラベルの編集ボタンを押しても即保存されない（編集モードが開く）
- [ ] 抽出レビューページでタブが正常に表示される
- [ ] Run・タスクが見つからないエラー状態でもタブが表示される
- [ ] 候補・Gold Annotation が行番号順に並ぶ

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)