### PR TITLE
[codex] Execution Profiles画面を追加

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,13 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { Layout } from "./components/Layout";
 import { AnnotationReviewPage } from "./pages/AnnotationReviewPage";
 import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
 import { ContextFilesPage } from "./pages/ContextFilesPage";
+import { ExecutionProfilesPage } from "./pages/ExecutionProfilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { ProjectDetailPage } from "./pages/ProjectDetailPage";
-import { ProjectSettingsPage } from "./pages/ProjectSettingsPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
 import { PromptsPage } from "./pages/PromptsPage";
 import { RunsPage } from "./pages/RunsPage";
@@ -42,7 +42,11 @@ export function App() {
             <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
             <Route path="projects/:id/annotation-tasks" element={<AnnotationTaskSettingsPage />} />
             <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
-            <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
+            <Route
+              path="projects/:id/settings"
+              element={<Navigate to="/execution-profiles" replace />}
+            />
+            <Route path="execution-profiles" element={<ExecutionProfilesPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />
             {/* 404 */}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -39,7 +39,7 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
         `/projects/${projectId}/annotation-tasks`,
       ],
     },
-    { to: `/projects/${projectId}/settings`, label: "設定" },
+    { to: "/execution-profiles", label: "実行設定" },
   ];
 
   return (
@@ -81,6 +81,7 @@ function SidebarNav() {
 
   const topNavItems = [
     { to: "/", label: "プロジェクト一覧", end: true },
+    { to: "/execution-profiles", label: "実行設定", end: false },
     { to: "/health", label: "ヘルスチェック", end: false },
   ];
 

--- a/packages/ui/src/hooks/useApiKey.ts
+++ b/packages/ui/src/hooks/useApiKey.ts
@@ -1,30 +1,60 @@
 import { useCallback, useEffect, useState } from "react";
 
-export function useApiKey(projectId: number): {
+const SHARED_API_KEY_STORAGE_KEY = "api_key_shared";
+
+function resolveStorageKey(scope: number | string): string {
+  if (scope === "shared") {
+    return SHARED_API_KEY_STORAGE_KEY;
+  }
+
+  return `api_key_${scope}`;
+}
+
+function readApiKey(scope: number | string): string {
+  const storageKey = resolveStorageKey(scope);
+  const scopedKey = localStorage.getItem(storageKey);
+  if (scopedKey) {
+    return scopedKey;
+  }
+
+  if (typeof scope === "number") {
+    return localStorage.getItem(SHARED_API_KEY_STORAGE_KEY) ?? "";
+  }
+
+  return "";
+}
+
+export function useApiKey(scope: number | string): {
   apiKey: string;
   hasApiKey: boolean;
   setApiKey: (key: string) => void;
 } {
-  const storageKey = `api_key_${projectId}`;
+  const storageKey = resolveStorageKey(scope);
 
   const [apiKey, setApiKeyState] = useState<string>(() => {
-    return localStorage.getItem(storageKey) ?? "";
+    return readApiKey(scope);
   });
 
   useEffect(() => {
-    setApiKeyState(localStorage.getItem(storageKey) ?? "");
-  }, [storageKey]);
+    setApiKeyState(readApiKey(scope));
+  }, [scope]);
 
   const setApiKey = useCallback(
     (key: string) => {
       if (key) {
         localStorage.setItem(storageKey, key);
+        if (typeof scope === "number") {
+          localStorage.setItem(SHARED_API_KEY_STORAGE_KEY, key);
+        }
       } else {
         localStorage.removeItem(storageKey);
+        if (typeof scope === "number") {
+          localStorage.removeItem(SHARED_API_KEY_STORAGE_KEY);
+        }
       }
       setApiKeyState(key);
     },
-    [storageKey],
+    [scope, storageKey],
   );
 
   return {

--- a/packages/ui/src/pages/ExecutionProfilesPage.module.css
+++ b/packages/ui/src/pages/ExecutionProfilesPage.module.css
@@ -1,0 +1,367 @@
+.root {
+  --bg: #111827;
+  --surface: #182235;
+  --surface-strong: #21314d;
+  --surface-soft: #0f1726;
+  --border: #30415f;
+  --text: #eff6ff;
+  --subtext: #b9c7de;
+  --muted: #7f90ac;
+  --accent: #7dd3fc;
+  --accent-strong: #38bdf8;
+  --danger: #fda4af;
+  --success: #86efac;
+
+  color: var(--text);
+}
+
+.pageHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.pageTitle {
+  margin: 0;
+  font-size: 28px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background:
+    radial-gradient(circle at top right, rgba(125, 211, 252, 0.16), transparent 34%),
+    linear-gradient(180deg, rgba(24, 34, 53, 0.98), rgba(15, 23, 38, 0.98));
+  border: 1px solid var(--border);
+  border-radius: 20px;
+}
+
+.sidebarHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebarTitle {
+  margin: 0;
+  font-size: 16px;
+}
+
+.sidebarHint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.profileList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profileCard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  padding: 14px 16px;
+  background: rgba(17, 24, 39, 0.7);
+  border: 1px solid transparent;
+  border-radius: 14px;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.profileCard:hover {
+  border-color: var(--border);
+  background: rgba(33, 49, 77, 0.64);
+  transform: translateY(-1px);
+}
+
+.profileCardActive {
+  border-color: var(--accent-strong);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.profileName {
+  font-weight: 600;
+}
+
+.profileMeta {
+  color: var(--subtext);
+  font-size: 12px;
+  word-break: break-word;
+}
+
+.emptyCard {
+  padding: 18px;
+  background: rgba(17, 24, 39, 0.72);
+  border: 1px dashed var(--border);
+  border-radius: 14px;
+}
+
+.emptyTitle {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.emptyText {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section {
+  padding: 24px;
+  background:
+    linear-gradient(180deg, rgba(24, 34, 53, 0.96), rgba(15, 23, 38, 0.98)),
+    var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.18);
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.sectionTitle {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.sectionDescription {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px 16px;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fieldGroupWide {
+  grid-column: 1 / -1;
+}
+
+.fieldLabel {
+  color: var(--subtext);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.fieldInput,
+.fieldSelect,
+.fieldTextarea,
+.apiKeyInput {
+  width: 100%;
+  padding: 11px 12px;
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.fieldTextarea {
+  resize: vertical;
+  min-height: 88px;
+}
+
+.fieldInput:focus,
+.fieldSelect:focus,
+.fieldTextarea:focus,
+.apiKeyInput:focus {
+  border-color: var(--accent-strong);
+  outline: none;
+}
+
+.fieldHint,
+.fieldError,
+.apiKeyNote {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.fieldHint,
+.apiKeyNote {
+  color: var(--muted);
+}
+
+.fieldError {
+  color: var(--danger);
+}
+
+.sliderRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.slider {
+  flex: 1;
+  accent-color: var(--accent-strong);
+}
+
+.sliderValue {
+  min-width: 32px;
+  color: var(--accent);
+  font-weight: 700;
+  text-align: right;
+}
+
+.formFooter {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton {
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 0.16s ease,
+    opacity 0.16s ease,
+    border-color 0.16s ease;
+}
+
+.primaryButton {
+  padding: 11px 18px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+  color: #082032;
+}
+
+.secondaryButton {
+  padding: 10px 16px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--subtext);
+}
+
+.dangerButton {
+  padding: 10px 16px;
+  background: transparent;
+  border: 1px solid rgba(253, 164, 175, 0.36);
+  color: var(--danger);
+}
+
+.primaryButton:hover:not(:disabled),
+.secondaryButton:hover:not(:disabled),
+.dangerButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.dangerButton:disabled {
+  opacity: 0.56;
+  cursor: not-allowed;
+}
+
+.feedbackSuccess,
+.apiKeyStatusSet {
+  color: var(--success);
+}
+
+.feedbackError,
+.apiKeyStatusUnset {
+  color: var(--danger);
+}
+
+.apiKeyInputRow {
+  display: flex;
+  gap: 10px;
+}
+
+.apiKeyStatus {
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+.loadingMsg,
+.errorMsg {
+  padding: 36px;
+  text-align: center;
+}
+
+.errorMsg {
+  color: var(--danger);
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .pageHeader,
+  .sectionHeader,
+  .formFooter,
+  .apiKeyInputRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .formGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pageTitle {
+    font-size: 24px;
+  }
+}

--- a/packages/ui/src/pages/ExecutionProfilesPage.tsx
+++ b/packages/ui/src/pages/ExecutionProfilesPage.tsx
@@ -1,0 +1,485 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useApiKey } from "../hooks/useApiKey";
+import {
+  ApiError,
+  type ApiProvider,
+  type LLMModelOption,
+  createExecutionProfile,
+  deleteExecutionProfile,
+  getExecutionProfiles,
+  listExecutionProfileModels,
+  updateExecutionProfile,
+} from "../lib/api";
+import styles from "./ExecutionProfilesPage.module.css";
+
+type SaveFeedback = "success" | "error" | null;
+
+type ProfileFormState = {
+  name: string;
+  description: string;
+  model: string;
+  temperature: number;
+  apiProvider: ApiProvider;
+  maxTokens: string;
+};
+
+const DEFAULT_FORM_STATE: ProfileFormState = {
+  name: "",
+  description: "",
+  model: "",
+  temperature: 0.7,
+  apiProvider: "anthropic",
+  maxTokens: "",
+};
+
+function toNullableMaxTokens(value: string): number | null {
+  if (value.trim() === "") {
+    return null;
+  }
+
+  return Number(value);
+}
+
+export function ExecutionProfilesPage() {
+  const queryClient = useQueryClient();
+  const { apiKey, hasApiKey, setApiKey } = useApiKey("shared");
+
+  const [apiKeyInput, setApiKeyInput] = useState(apiKey);
+  const [selectedProfileId, setSelectedProfileId] = useState<number | null>(null);
+  const [formState, setFormState] = useState<ProfileFormState>(DEFAULT_FORM_STATE);
+  const [saveFeedback, setSaveFeedback] = useState<SaveFeedback>(null);
+  const [apiKeySaved, setApiKeySaved] = useState(false);
+
+  const {
+    data: profiles = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["execution-profiles"],
+    queryFn: () => getExecutionProfiles(),
+  });
+
+  const selectedProfile =
+    selectedProfileId === null
+      ? null
+      : (profiles.find((profile) => profile.id === selectedProfileId) ?? null);
+
+  const {
+    data: modelOptionsData,
+    isFetching: isFetchingModels,
+    error: modelsError,
+  } = useQuery({
+    queryKey: ["execution-profile-models", formState.apiProvider, hasApiKey],
+    queryFn: () =>
+      listExecutionProfileModels({
+        api_provider: formState.apiProvider,
+        api_key: apiKey,
+      }),
+    enabled: hasApiKey,
+    retry: false,
+  });
+
+  const modelOptions = modelOptionsData?.models ?? [];
+  const modelIds = modelOptions.map((option) => option.id);
+  const hasRemoteModelOptions = modelOptions.length > 0;
+  const shouldShowSavedModelOption = formState.model !== "" && !modelIds.includes(formState.model);
+  const isModelSelectDisabled = !hasApiKey || isFetchingModels || !hasRemoteModelOptions;
+
+  useEffect(() => {
+    setApiKeyInput(apiKey);
+  }, [apiKey]);
+
+  useEffect(() => {
+    if (!selectedProfile) {
+      return;
+    }
+
+    setFormState({
+      name: selectedProfile.name,
+      description: selectedProfile.description ?? "",
+      model: selectedProfile.model,
+      temperature: selectedProfile.temperature,
+      apiProvider: selectedProfile.api_provider,
+      maxTokens: selectedProfile.max_tokens === null ? "" : String(selectedProfile.max_tokens),
+    });
+  }, [selectedProfile]);
+
+  useEffect(() => {
+    if (selectedProfileId !== null && !selectedProfile) {
+      setSelectedProfileId(null);
+      setFormState(DEFAULT_FORM_STATE);
+    }
+  }, [selectedProfile, selectedProfileId]);
+
+  useEffect(() => {
+    const firstModelOption = modelOptionsData?.models[0];
+    if (formState.model === "" && firstModelOption) {
+      setFormState((current) =>
+        current.model === ""
+          ? {
+              ...current,
+              model: firstModelOption.id,
+            }
+          : current,
+      );
+    }
+  }, [formState.model, modelOptionsData]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        name: formState.name.trim(),
+        description: formState.description.trim() || null,
+        model: formState.model,
+        temperature: formState.temperature,
+        api_provider: formState.apiProvider,
+        max_tokens: toNullableMaxTokens(formState.maxTokens),
+      };
+
+      if (selectedProfileId === null) {
+        return createExecutionProfile(payload);
+      }
+
+      return updateExecutionProfile(selectedProfileId, payload);
+    },
+    onSuccess: async (savedProfile) => {
+      setSaveFeedback("success");
+      setSelectedProfileId(savedProfile.id);
+      await queryClient.invalidateQueries({ queryKey: ["execution-profiles"] });
+      setTimeout(() => setSaveFeedback(null), 3000);
+    },
+    onError: () => {
+      setSaveFeedback("error");
+      setTimeout(() => setSaveFeedback(null), 5000);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteExecutionProfile(id),
+    onSuccess: async () => {
+      setSelectedProfileId(null);
+      setFormState(DEFAULT_FORM_STATE);
+      await queryClient.invalidateQueries({ queryKey: ["execution-profiles"] });
+    },
+  });
+
+  function handleSaveApiKey() {
+    setApiKey(apiKeyInput);
+    setApiKeySaved(true);
+    void queryClient.invalidateQueries({ queryKey: ["execution-profile-models"] });
+    setTimeout(() => setApiKeySaved(false), 2000);
+  }
+
+  function handleCreateNew() {
+    setSelectedProfileId(null);
+    setFormState(DEFAULT_FORM_STATE);
+    setSaveFeedback(null);
+  }
+
+  function handleDelete() {
+    if (!selectedProfile) {
+      return;
+    }
+
+    const confirmed = window.confirm(`「${selectedProfile.name}」を削除しますか？`);
+    if (!confirmed) {
+      return;
+    }
+
+    deleteMutation.mutate(selectedProfile.id);
+  }
+
+  function updateForm<K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) {
+    setFormState((current) => ({ ...current, [key]: value }));
+  }
+
+  const canSaveProfile =
+    formState.name.trim().length > 0 &&
+    formState.model.trim().length > 0 &&
+    !saveMutation.isPending;
+
+  if (isLoading) {
+    return (
+      <div className={styles.root}>
+        <p className={styles.loadingMsg}>読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.root}>
+        <p className={styles.errorMsg}>実行設定の取得に失敗しました。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <div>
+          <p className={styles.eyebrow}>Execution Profiles</p>
+          <h2 className={styles.pageTitle}>実行設定</h2>
+        </div>
+        <button type="button" onClick={handleCreateNew} className={styles.primaryButton}>
+          新規プロファイル
+        </button>
+      </div>
+
+      <div className={styles.layout}>
+        <aside className={styles.sidebar}>
+          <div className={styles.sidebarHeader}>
+            <h3 className={styles.sidebarTitle}>登録済みプロファイル</h3>
+            <p className={styles.sidebarHint}>Run 実行時に使うモデル設定を管理します。</p>
+          </div>
+
+          <div className={styles.profileList}>
+            {profiles.map((profile) => (
+              <button
+                type="button"
+                key={profile.id}
+                onClick={() => setSelectedProfileId(profile.id)}
+                className={`${styles.profileCard} ${selectedProfileId === profile.id ? styles.profileCardActive : ""}`}
+              >
+                <span className={styles.profileName}>{profile.name}</span>
+                <span className={styles.profileMeta}>
+                  {profile.api_provider} / {profile.model}
+                </span>
+              </button>
+            ))}
+            {profiles.length === 0 && (
+              <div className={styles.emptyCard}>
+                <p className={styles.emptyTitle}>まだプロファイルがありません</p>
+                <p className={styles.emptyText}>右側のフォームから最初の実行設定を作成できます。</p>
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <div className={styles.content}>
+          <section className={styles.section}>
+            <div className={styles.sectionHeader}>
+              <div>
+                <h3 className={styles.sectionTitle}>
+                  {selectedProfile ? "実行設定を編集" : "実行設定を作成"}
+                </h3>
+                <p className={styles.sectionDescription}>
+                  モデル・temperature・トークン上限をひとまとまりで保存できます。
+                </p>
+              </div>
+              {selectedProfile && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleteMutation.isPending}
+                  className={styles.dangerButton}
+                >
+                  {deleteMutation.isPending ? "削除中..." : "削除"}
+                </button>
+              )}
+            </div>
+
+            <div className={styles.formGrid}>
+              <div className={styles.fieldGroup}>
+                <label htmlFor="execution-profile-name" className={styles.fieldLabel}>
+                  プロファイル名
+                </label>
+                <input
+                  id="execution-profile-name"
+                  type="text"
+                  value={formState.name}
+                  onChange={(event) => updateForm("name", event.target.value)}
+                  placeholder="例: Claude 4 Sonnet / 安定運用"
+                  className={styles.fieldInput}
+                />
+              </div>
+
+              <div className={styles.fieldGroup}>
+                <label htmlFor="execution-profile-provider" className={styles.fieldLabel}>
+                  API プロバイダー
+                </label>
+                <select
+                  id="execution-profile-provider"
+                  value={formState.apiProvider}
+                  onChange={(event) => {
+                    updateForm("apiProvider", event.target.value as ApiProvider);
+                    updateForm("model", "");
+                  }}
+                  className={styles.fieldSelect}
+                >
+                  <option value="anthropic">Anthropic</option>
+                  <option value="openai">OpenAI</option>
+                </select>
+                <p className={styles.fieldHint}>変更すると候補モデルを再取得します。</p>
+              </div>
+
+              <div className={`${styles.fieldGroup} ${styles.fieldGroupWide}`}>
+                <label htmlFor="execution-profile-description" className={styles.fieldLabel}>
+                  説明
+                </label>
+                <textarea
+                  id="execution-profile-description"
+                  value={formState.description}
+                  onChange={(event) => updateForm("description", event.target.value)}
+                  placeholder="この設定をどんな用途で使うかをメモできます"
+                  rows={3}
+                  className={styles.fieldTextarea}
+                />
+              </div>
+
+              <div className={styles.fieldGroup}>
+                <label htmlFor="execution-profile-model" className={styles.fieldLabel}>
+                  モデル
+                </label>
+                <select
+                  id="execution-profile-model"
+                  value={formState.model}
+                  onChange={(event) => updateForm("model", event.target.value)}
+                  className={styles.fieldSelect}
+                  disabled={isModelSelectDisabled}
+                >
+                  {!hasApiKey && <option value="">API キーを保存すると候補を取得します</option>}
+                  {hasApiKey && isFetchingModels && (
+                    <option value={formState.model}>候補を取得中...</option>
+                  )}
+                  {hasApiKey && !isFetchingModels && !hasRemoteModelOptions && (
+                    <option value={formState.model}>候補を取得できません</option>
+                  )}
+                  {modelOptions.map((option: LLMModelOption) => (
+                    <option key={option.id} value={option.id}>
+                      {option.displayName === option.id
+                        ? option.id
+                        : `${option.displayName} (${option.id})`}
+                    </option>
+                  ))}
+                  {shouldShowSavedModelOption && (
+                    <option value={formState.model}>{formState.model}（保存済み）</option>
+                  )}
+                </select>
+                {!hasApiKey && (
+                  <p className={styles.fieldHint}>
+                    先に下の API キー欄を保存すると、利用可能なモデル候補を取得します。
+                  </p>
+                )}
+                {hasApiKey &&
+                  !isFetchingModels &&
+                  hasRemoteModelOptions &&
+                  formState.model === "" && (
+                    <p className={styles.fieldHint}>取得した候補からモデルを選択してください。</p>
+                  )}
+                {shouldShowSavedModelOption && (
+                  <p className={styles.fieldHint}>
+                    保存済みモデルは現在の候補一覧に含まれていません。
+                  </p>
+                )}
+                {modelsError instanceof ApiError && (
+                  <p className={styles.fieldError}>
+                    {modelsError.status === 501
+                      ? "このプロバイダーのモデル候補取得は未対応です。"
+                      : modelsError.status === 401
+                        ? "API キーの認証に失敗しました。キーを確認してください。"
+                        : "モデル候補の取得に失敗しました。"}
+                  </p>
+                )}
+              </div>
+
+              <div className={styles.fieldGroup}>
+                <label htmlFor="execution-profile-temperature" className={styles.fieldLabel}>
+                  Temperature
+                </label>
+                <div className={styles.sliderRow}>
+                  <input
+                    id="execution-profile-temperature"
+                    type="range"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    value={formState.temperature}
+                    onChange={(event) => updateForm("temperature", Number(event.target.value))}
+                    className={styles.slider}
+                  />
+                  <span className={styles.sliderValue}>{formState.temperature.toFixed(1)}</span>
+                </div>
+                <p className={styles.fieldHint}>0.0 で安定寄り、2.0 で発散寄りです。</p>
+              </div>
+
+              <div className={styles.fieldGroup}>
+                <label htmlFor="execution-profile-max-tokens" className={styles.fieldLabel}>
+                  Max Tokens
+                </label>
+                <input
+                  id="execution-profile-max-tokens"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={formState.maxTokens}
+                  onChange={(event) => updateForm("maxTokens", event.target.value)}
+                  placeholder="デフォルト値を使う場合は空欄"
+                  className={styles.fieldInput}
+                />
+                <p className={styles.fieldHint}>空欄ならプロバイダー既定値を利用します。</p>
+              </div>
+            </div>
+
+            <div className={styles.formFooter}>
+              <button
+                type="button"
+                onClick={() => saveMutation.mutate()}
+                disabled={!canSaveProfile}
+                className={styles.primaryButton}
+              >
+                {saveMutation.isPending
+                  ? "保存中..."
+                  : selectedProfile
+                    ? "変更を保存"
+                    : "プロファイルを作成"}
+              </button>
+              {saveFeedback === "success" && (
+                <span className={styles.feedbackSuccess}>保存しました</span>
+              )}
+              {saveFeedback === "error" && (
+                <span className={styles.feedbackError}>保存に失敗しました</span>
+              )}
+            </div>
+          </section>
+
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>モデル候補取得用 API キー</h3>
+            <p className={styles.apiKeyNote}>
+              API キーはブラウザの localStorage に保存され、モデル候補取得時と Run
+              実行時に一時的に送信されます。サーバー側では保存しません。
+            </p>
+
+            <div className={styles.fieldGroup}>
+              <label htmlFor="execution-profile-api-key" className={styles.fieldLabel}>
+                API キー
+              </label>
+              <div className={styles.apiKeyInputRow}>
+                <input
+                  id="execution-profile-api-key"
+                  type="password"
+                  value={apiKeyInput}
+                  onChange={(event) => setApiKeyInput(event.target.value)}
+                  placeholder="sk-ant-... または sk-..."
+                  className={styles.apiKeyInput}
+                  autoComplete="off"
+                />
+                <button type="button" onClick={handleSaveApiKey} className={styles.secondaryButton}>
+                  {apiKeySaved ? "保存済み" : "保存"}
+                </button>
+              </div>
+              <div className={styles.apiKeyStatus}>
+                {hasApiKey ? (
+                  <span className={styles.apiKeyStatusSet}>設定済み</span>
+                ) : (
+                  <span className={styles.apiKeyStatusUnset}>未設定</span>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/ExecutionProfilesPage.tsx
+++ b/packages/ui/src/pages/ExecutionProfilesPage.tsx
@@ -70,7 +70,7 @@ export function ExecutionProfilesPage() {
     isFetching: isFetchingModels,
     error: modelsError,
   } = useQuery({
-    queryKey: ["execution-profile-models", formState.apiProvider, hasApiKey],
+    queryKey: ["execution-profile-models", formState.apiProvider, hasApiKey, apiKey],
     queryFn: () =>
       listExecutionProfileModels({
         api_provider: formState.apiProvider,

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -42,7 +42,7 @@ export function ProjectDetailPage() {
           { to: "runs", label: "Run 実行・管理" },
           { to: "score", label: "採点" },
           { to: "annotation-tasks", label: "アノテーション設定" },
-          { to: "settings", label: "プロジェクト設定" },
+          { to: "/execution-profiles", label: "実行設定" },
         ].map(({ to, label }) => (
           <Link
             key={to}

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -874,10 +874,10 @@ export function RunsPage() {
                 {!hasApiKey && (
                   <p className={styles.fieldHint}>
                     APIキーが未設定です。
-                    <Link to={`/projects/${projectId}/settings`} className={styles.settingsLink}>
-                      設定画面
+                    <Link to="/execution-profiles" className={styles.settingsLink}>
+                      実行設定
                     </Link>
-                    で入力してください。
+                    で API キーを入力してください。
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## 概要
- Project Settings 画面を Execution Profiles の独立画面へ置き換え
- 実行設定の一覧・作成・編集・削除とモデル候補取得 UI を追加
- 旧 settings 導線を新画面へリダイレクトし、API キーを共通利用できるよう調整

## 変更内容
- `/execution-profiles` ルートと `ExecutionProfilesPage` を追加
- サイドバー、プロジェクト詳細、Runs 画面の設定導線を Execution Profiles に差し替え
- `useApiKey` を拡張し、共通 API キー保存値を Runs 画面からも参照できるよう変更

## 確認
- `pnpm --filter @prompt-reviewer/ui typecheck`
- `pnpm run check` は失敗
  - 既存の未変更ファイル `packages/ui/src/pages/ScorePage.tsx`
  - 既存の未変更ファイル `packages/ui/src/pages/AnnotationTaskSettingsPage.tsx`
  - 既存の未変更ファイル `packages/ui/src/pages/AnnotationReviewPage.tsx`
  - 既存の未変更ファイル `packages/server/src/routes/runs.ts`
