### PR TITLE
既存ファイルの Biome lint/format エラーを修正 (#178)

### DIFF
--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -291,7 +291,9 @@ function parseStructuredItems(
   return parsed.data.items;
 }
 
-function parseItemsFromStructuredOutput(json: string | null): z.infer<typeof structuredOutputSchema>["items"] | null {
+function parseItemsFromStructuredOutput(
+  json: string | null,
+): z.infer<typeof structuredOutputSchema>["items"] | null {
   const parsedStructuredOutput = parseStructuredOutput(json);
   if (parsedStructuredOutput === null) {
     return null;
@@ -626,9 +628,7 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       return c.json({ error: "Invalid include_discarded" }, 400);
     }
 
-    const conditions = [
-      ...(includeDiscarded === true ? [] : [eq(runs.is_discarded, false)]),
-    ];
+    const conditions = [...(includeDiscarded === true ? [] : [eq(runs.is_discarded, false)])];
 
     if (filterProjectId !== undefined) {
       const versionIds = await fetchVersionIdsByProject(db, filterProjectId);
@@ -696,8 +696,9 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       }
     }
 
-    const legacySnapshot: Partial<Pick<ExecutionSettings, "model" | "temperature" | "api_provider">> =
-      {};
+    const legacySnapshot: Partial<
+      Pick<ExecutionSettings, "model" | "temperature" | "api_provider">
+    > = {};
     if (body.model !== undefined) legacySnapshot.model = body.model;
     if (body.temperature !== undefined) legacySnapshot.temperature = body.temperature;
     if (body.api_provider !== undefined) legacySnapshot.api_provider = body.api_provider;
@@ -1043,17 +1044,19 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
             const versionIds = await fetchVersionIdsByProject(db, legacyProjectId);
             if (versionIds.length === 0) return null;
             return (
-              await db
-                .select()
-                .from(runs)
-                .where(
-                  and(
-                    eq(runs.id, id),
-                    eq(runs.project_id, legacyProjectId),
-                    inArray(runs.prompt_version_id, versionIds),
-                  ),
-                )
-            )[0] ?? null;
+              (
+                await db
+                  .select()
+                  .from(runs)
+                  .where(
+                    and(
+                      eq(runs.id, id),
+                      eq(runs.project_id, legacyProjectId),
+                      inArray(runs.prompt_version_id, versionIds),
+                    ),
+                  )
+              )[0] ?? null
+            );
           })()
         : await fetchRunById(db, id);
 

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -511,22 +511,24 @@ function AnnotationReviewContent({
               <p className={styles.emptyMsg}>候補がありません。Run ページから抽出してください。</p>
             ) : (
               <div className={styles.candidateList}>
-                {[...candidates].sort((a, b) => a.start_line - b.start_line).map((c) => (
-                  <CandidateCard
-                    key={c.id}
-                    candidate={c}
-                    labels={labels}
-                    onStatusChange={(status) =>
-                      updateMutation.mutate({ candidateId: c.id, data: { status } })
-                    }
-                    onEdit={(data) => updateMutation.mutate({ candidateId: c.id, data })}
-                    isUpdating={updateMutation.isPending}
-                    onHover={setActiveRange}
-                    isActive={
-                      activeRange?.start === c.start_line && activeRange?.end === c.end_line
-                    }
-                  />
-                ))}
+                {[...candidates]
+                  .sort((a, b) => a.start_line - b.start_line)
+                  .map((c) => (
+                    <CandidateCard
+                      key={c.id}
+                      candidate={c}
+                      labels={labels}
+                      onStatusChange={(status) =>
+                        updateMutation.mutate({ candidateId: c.id, data: { status } })
+                      }
+                      onEdit={(data) => updateMutation.mutate({ candidateId: c.id, data })}
+                      isUpdating={updateMutation.isPending}
+                      onHover={setActiveRange}
+                      isActive={
+                        activeRange?.start === c.start_line && activeRange?.end === c.end_line
+                      }
+                    />
+                  ))}
               </div>
             )}
           </div>
@@ -540,14 +542,16 @@ function AnnotationReviewContent({
               <p className={styles.emptyMsg}>まだ Gold Annotation がありません</p>
             ) : (
               <div className={styles.goldList}>
-                {[...goldAnnotations].sort((a, b) => a.start_line - b.start_line).map((g) => (
-                  <GoldAnnotationCard
-                    key={g.id}
-                    gold={g}
-                    labels={labels}
-                    onDelete={() => deleteGoldMutation.mutate(g.id)}
-                  />
-                ))}
+                {[...goldAnnotations]
+                  .sort((a, b) => a.start_line - b.start_line)
+                  .map((g) => (
+                    <GoldAnnotationCard
+                      key={g.id}
+                      gold={g}
+                      labels={labels}
+                      onDelete={() => deleteGoldMutation.mutate(g.id)}
+                    />
+                  ))}
               </div>
             )}
           </div>
@@ -830,16 +834,18 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
                 <p className={styles.emptyMsg}>Gold Annotation がありません</p>
               ) : (
                 <div className={styles.goldList}>
-                  {[...goldAnnotations].sort((a, b) => a.start_line - b.start_line).map((g) => (
-                    <GoldAnnotationCard
-                      key={g.id}
-                      gold={g}
-                      labels={labels}
-                      onHover={(range) => setActiveRange(range)}
-                      onLeave={() => setActiveRange(null)}
-                      onDelete={() => deleteGoldMutation.mutate(g.id)}
-                    />
-                  ))}
+                  {[...goldAnnotations]
+                    .sort((a, b) => a.start_line - b.start_line)
+                    .map((g) => (
+                      <GoldAnnotationCard
+                        key={g.id}
+                        gold={g}
+                        labels={labels}
+                        onHover={(range) => setActiveRange(range)}
+                        onLeave={() => setActiveRange(null)}
+                        onDelete={() => deleteGoldMutation.mutate(g.id)}
+                      />
+                    ))}
                 </div>
               )}
 

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -672,10 +672,7 @@ export function AnnotationTaskSettingsPage() {
                     const currentForm = isEditing ? editingLabelForm : buildLabelForm(label);
 
                     return (
-                      <div
-                        key={label.id}
-                        className={styles.labelCard}
-                      >
+                      <div key={label.id} className={styles.labelCard}>
                         <div className={styles.labelCardHeader}>
                           <div>
                             <h4 className={styles.labelTitle}>{label.name}</h4>
@@ -913,7 +910,11 @@ export function AnnotationTaskSettingsPage() {
                     </div>
 
                     <div className={styles.formFooter}>
-                      <button type="submit" className={styles.primaryButton} disabled={!canCreateLabel}>
+                      <button
+                        type="submit"
+                        className={styles.primaryButton}
+                        disabled={!canCreateLabel}
+                      >
                         {createLabelMutation.isPending ? "追加中..." : "ラベルを追加"}
                       </button>
                       <button

--- a/packages/ui/src/pages/ScorePage.tsx
+++ b/packages/ui/src/pages/ScorePage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { RunCompareView } from "../components/RunCompareView";
+import { ScoreSectionTabs } from "../components/ScoreSectionTabs";
 import {
   type Run,
   type Score,
@@ -12,7 +13,6 @@ import {
   getScore,
   updateScore,
 } from "../lib/api";
-import { ScoreSectionTabs } from "../components/ScoreSectionTabs";
 import styles from "./ScorePage.module.css";
 
 function formatDate(timestamp: number): string {


### PR DESCRIPTION
## 概要

Issue #178 で報告された既存ファイルの Biome 指摘を修正します。

- `packages/ui/src/pages/ScorePage.tsx` — `organizeImports`（import 順序の修正）
- `packages/server/src/routes/runs.ts` — `format`（長い行の折り返し等）
- `packages/ui/src/pages/AnnotationReviewPage.tsx` — `format`
- `packages/ui/src/pages/AnnotationTaskSettingsPage.tsx` — `format`

## テスト計画

- [x] `pnpm run check` がエラーなしで通ること
- [x] `pnpm run typecheck` がエラーなしで通ること

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)