### PR TITLE
[codex] Prompt Family ベースのプロンプト管理画面へ移行

### DIFF
--- a/packages/core/drizzle/0017_abnormal_firebird.sql
+++ b/packages/core/drizzle/0017_abnormal_firebird.sql
@@ -1,0 +1,77 @@
+PRAGMA foreign_keys=OFF;
+--> statement-breakpoint
+CREATE TABLE `__prompt_family_backfill` AS
+SELECT
+  `project_id`,
+  (
+    SELECT COALESCE(MAX(`id`), 0) FROM `prompt_families`
+  ) + ROW_NUMBER() OVER (ORDER BY `project_id`) AS `prompt_family_id`
+FROM (
+  SELECT DISTINCT `project_id`
+  FROM `prompt_versions`
+  WHERE `prompt_family_id` IS NULL
+);
+--> statement-breakpoint
+INSERT INTO `prompt_families` (`id`, `name`, `description`, `created_at`, `updated_at`)
+SELECT `prompt_family_id`, NULL, NULL, CAST(unixepoch('subsec') * 1000 AS integer), CAST(unixepoch('subsec') * 1000 AS integer)
+FROM `__prompt_family_backfill`;
+--> statement-breakpoint
+UPDATE `prompt_versions`
+SET `prompt_family_id` = (
+  SELECT `prompt_family_id`
+  FROM `__prompt_family_backfill`
+  WHERE `__prompt_family_backfill`.`project_id` = `prompt_versions`.`project_id`
+)
+WHERE `prompt_family_id` IS NULL;
+--> statement-breakpoint
+CREATE TABLE `__new_prompt_versions` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `prompt_family_id` integer NOT NULL,
+  `project_id` integer,
+  `version` integer NOT NULL,
+  `name` text,
+  `memo` text,
+  `content` text NOT NULL,
+  `workflow_definition` text,
+  `parent_version_id` integer,
+  `created_at` integer NOT NULL,
+  `is_selected` integer DEFAULT 0 NOT NULL,
+  FOREIGN KEY (`prompt_family_id`) REFERENCES `prompt_families`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`parent_version_id`) REFERENCES `__new_prompt_versions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_prompt_versions`(
+  `id`,
+  `prompt_family_id`,
+  `project_id`,
+  `version`,
+  `name`,
+  `memo`,
+  `content`,
+  `workflow_definition`,
+  `parent_version_id`,
+  `created_at`,
+  `is_selected`
+)
+SELECT
+  `id`,
+  `prompt_family_id`,
+  `project_id`,
+  `version`,
+  `name`,
+  `memo`,
+  `content`,
+  `workflow_definition`,
+  `parent_version_id`,
+  `created_at`,
+  `is_selected`
+FROM `prompt_versions`;
+--> statement-breakpoint
+DROP TABLE `prompt_versions`;
+--> statement-breakpoint
+ALTER TABLE `__new_prompt_versions` RENAME TO `prompt_versions`;
+--> statement-breakpoint
+DROP TABLE `__prompt_family_backfill`;
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/core/drizzle/meta/0017_snapshot.json
+++ b/packages/core/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1540 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c6acf875-10bb-407b-ad3e-1ac6ca3c4240",
+  "prevId": "b4ca6c35-a32e-471e-b66a-bc5fb5a5181d",
+  "tables": {
+    "project_settings": {
+      "name": "project_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_settings_project_id_unique": {
+          "name": "project_settings_project_id_unique",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_families": {
+      "name": "prompt_families",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_profiles": {
+      "name": "execution_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-opus-4-5'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.7
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic'"
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "execution_profiles_name_unique": {
+          "name": "execution_profiles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_assets": {
+      "name": "context_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_asset_projects": {
+      "name": "context_asset_projects",
+      "columns": {
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "context_asset_projects_context_asset_id_context_assets_id_fk": {
+          "name": "context_asset_projects_context_asset_id_context_assets_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "context_assets",
+          "columnsFrom": [
+            "context_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_asset_projects_project_id_projects_id_fk": {
+          "name": "context_asset_projects_project_id_projects_id_fk",
+          "tableFrom": "context_asset_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "context_asset_projects_context_asset_id_project_id_pk": {
+          "columns": [
+            "context_asset_id",
+            "project_id"
+          ],
+          "name": "context_asset_projects_context_asset_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_family_context_assets": {
+      "name": "prompt_family_context_assets",
+      "columns": {
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_family_context_assets_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "prompt_families",
+          "columnsFrom": [
+            "prompt_family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_family_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "prompt_family_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "prompt_family_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": [
+            "context_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_family_context_assets_prompt_family_id_context_asset_id_pk": {
+          "columns": [
+            "prompt_family_id",
+            "context_asset_id"
+          ],
+          "name": "prompt_family_context_assets_prompt_family_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_version_projects": {
+      "name": "prompt_version_projects",
+      "columns": {
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_version_projects_prompt_version_id_prompt_versions_id_fk": {
+          "name": "prompt_version_projects_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "prompt_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_version_projects_project_id_projects_id_fk": {
+          "name": "prompt_version_projects_project_id_projects_id_fk",
+          "tableFrom": "prompt_version_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_version_projects_prompt_version_id_project_id_pk": {
+          "columns": [
+            "prompt_version_id",
+            "project_id"
+          ],
+          "name": "prompt_version_projects_prompt_version_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_context_assets": {
+      "name": "test_case_context_assets",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_asset_id": {
+          "name": "context_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_context_assets_test_case_id_test_cases_id_fk": {
+          "name": "test_case_context_assets_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_context_assets_context_asset_id_context_assets_id_fk": {
+          "name": "test_case_context_assets_context_asset_id_context_assets_id_fk",
+          "tableFrom": "test_case_context_assets",
+          "tableTo": "context_assets",
+          "columnsFrom": [
+            "context_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_context_assets_test_case_id_context_asset_id_pk": {
+          "columns": [
+            "test_case_id",
+            "context_asset_id"
+          ],
+          "name": "test_case_context_assets_test_case_id_context_asset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_case_projects": {
+      "name": "test_case_projects",
+      "columns": {
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_projects_test_case_id_test_cases_id_fk": {
+          "name": "test_case_projects_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_case_projects_project_id_projects_id_fk": {
+          "name": "test_case_projects_project_id_projects_id_fk",
+          "tableFrom": "test_case_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_case_projects_test_case_id_project_id_pk": {
+          "columns": [
+            "test_case_id",
+            "project_id"
+          ],
+          "name": "test_case_projects_test_case_id_project_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_content": {
+          "name": "context_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "expected_description": {
+          "name": "expected_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "prompt_family_id": {
+          "name": "prompt_family_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_definition": {
+          "name": "workflow_definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_selected": {
+          "name": "is_selected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_prompt_family_id_prompt_families_id_fk": {
+          "name": "prompt_versions_prompt_family_id_prompt_families_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_families",
+          "columnsFrom": [
+            "prompt_family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_project_id_projects_id_fk": {
+          "name": "prompt_versions_project_id_projects_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_versions_parent_version_id_prompt_versions_id_fk": {
+          "name": "prompt_versions_parent_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "execution_profile_id": {
+          "name": "execution_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation": {
+          "name": "conversation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_best": {
+          "name": "is_best",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_provider": {
+          "name": "api_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_execution_profile_id_execution_profiles_id_fk": {
+          "name": "runs_execution_profile_id_execution_profiles_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "execution_profiles",
+          "columnsFrom": [
+            "execution_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_prompt_version_id_prompt_versions_id_fk": {
+          "name": "runs_prompt_version_id_prompt_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "prompt_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "runs_test_case_id_test_cases_id_fk": {
+          "name": "runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "human_score": {
+          "name": "human_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "human_comment": {
+          "name": "human_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_reason": {
+          "name": "judge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_discarded": {
+          "name": "is_discarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scores_run_id_runs_id_fk": {
+          "name": "scores_run_id_runs_id_fk",
+          "tableFrom": "scores",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotation_candidates": {
+      "name": "annotation_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text_ref": {
+          "name": "target_text_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_step_id": {
+          "name": "source_step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "annotation_candidates_run_id_runs_id_fk": {
+          "name": "annotation_candidates_run_id_runs_id_fk",
+          "tableFrom": "annotation_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "annotation_candidates_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "annotation_candidates_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "annotation_candidates",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": [
+            "annotation_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "annotation_candidates_source_type_check": {
+          "name": "annotation_candidates_source_type_check",
+          "value": "\"annotation_candidates\".\"source_type\" in ('final_answer', 'structured_json', 'trace_step')"
+        },
+        "annotation_candidates_status_check": {
+          "name": "annotation_candidates_status_check",
+          "value": "\"annotation_candidates\".\"status\" in ('pending', 'accepted', 'rejected')"
+        }
+      }
+    },
+    "annotation_labels": {
+      "name": "annotation_labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "annotation_labels_task_key_unique": {
+          "name": "annotation_labels_task_key_unique",
+          "columns": [
+            "annotation_task_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "annotation_labels_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "annotation_labels_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "annotation_labels",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": [
+            "annotation_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "annotation_tasks": {
+      "name": "annotation_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_mode": {
+          "name": "output_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'span_label'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "annotation_tasks_output_mode_check": {
+          "name": "annotation_tasks_output_mode_check",
+          "value": "\"annotation_tasks\".\"output_mode\" in ('span_label')"
+        }
+      }
+    },
+    "gold_annotations": {
+      "name": "gold_annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "annotation_task_id": {
+          "name": "annotation_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text_ref": {
+          "name": "target_text_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_line": {
+          "name": "end_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_candidate_id": {
+          "name": "source_candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gold_annotations_annotation_task_id_annotation_tasks_id_fk": {
+          "name": "gold_annotations_annotation_task_id_annotation_tasks_id_fk",
+          "tableFrom": "gold_annotations",
+          "tableTo": "annotation_tasks",
+          "columnsFrom": [
+            "annotation_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gold_annotations_source_candidate_id_annotation_candidates_id_fk": {
+          "name": "gold_annotations_source_candidate_id_annotation_candidates_id_fk",
+          "tableFrom": "gold_annotations",
+          "tableTo": "annotation_candidates",
+          "columnsFrom": [
+            "source_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1745193600000,
       "tag": "0016_max_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1776851067202,
+      "tag": "0017_abnormal_firebird",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/routes/runs.test.ts
+++ b/packages/server/src/routes/runs.test.ts
@@ -721,6 +721,127 @@ describe("POST /api/projects/:projectId/runs", () => {
 });
 
 describe("POST /api/projects/:projectId/runs/execute", () => {
+  it("prompt_versions.project_id だけで紐づいた旧データでも実行できる", async () => {
+    const version = {
+      id: 1,
+      project_id: 1,
+      content: "あなたは親切なアシスタントです。",
+      workflow_definition: null,
+    };
+    const testCase = {
+      id: 1,
+      project_id: 1,
+      turns: JSON.stringify([{ role: "user", content: "要約してください" }]),
+      context_content: "",
+      title: "テストケース1",
+      expected_description: null,
+      display_order: 0,
+      created_at: 0,
+      updated_at: 0,
+    };
+    const projectSettings = {
+      id: 1,
+      project_id: 1,
+      model: "claude-opus-4-5",
+      temperature: 0.7,
+      api_provider: "anthropic" as const,
+      created_at: 0,
+      updated_at: 0,
+    };
+    const created = {
+      ...sampleRun,
+      conversation: JSON.stringify([
+        { role: "user", content: "要約してください" },
+        { role: "assistant", content: "要約結果です" },
+      ]),
+      model: projectSettings.model,
+      temperature: projectSettings.temperature,
+      api_provider: projectSettings.api_provider,
+      execution_profile_id: null,
+    };
+
+    let selectCallCount = 0;
+    const capturedRequests: LLMRequest[] = [];
+    const db = {
+      select: () => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([]),
+            }),
+          };
+        }
+        if (selectCallCount === 2) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ id: version.id }]),
+            }),
+          };
+        }
+        if (selectCallCount === 3) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ test_case_id: 1, project_id: 1, created_at: 0 }]),
+            }),
+          };
+        }
+        if (selectCallCount === 4) {
+          return { from: () => ({ where: () => Promise.resolve([version]) }) };
+        }
+        if (selectCallCount === 5) {
+          return { from: () => ({ where: () => Promise.resolve([testCase]) }) };
+        }
+        return { from: () => ({ where: () => Promise.resolve([projectSettings]) }) };
+      },
+      insert: () => ({
+        values: () => ({
+          returning: () => Promise.resolve([created]),
+        }),
+      }),
+    };
+
+    const app = new Hono();
+    app.route(
+      "/api/projects/:projectId/runs",
+      createRunsRouter(db as unknown as DB, {
+        llmClientFactory: () => ({
+          async sendMessage() {
+            throw new Error("sendMessage should not be used for streaming execute");
+          },
+          async *stream(request: LLMRequest) {
+            capturedRequests.push(request);
+            yield {
+              type: "response" as const,
+              response: {
+                content: "要約結果です",
+                stopReason: "end_turn",
+                raw: {},
+              },
+            };
+          },
+        }),
+      }),
+    );
+    const res = await app.request("/api/projects/1/runs/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt_version_id: 1,
+        test_case_id: 1,
+        api_key: "sk-ant-test",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]).toMatchObject({
+      model: projectSettings.model,
+      temperature: projectSettings.temperature,
+    });
+  });
+
   it("execution_profile_id が未指定でも project_settings にフォールバックして実行できる", async () => {
     const version = {
       id: 1,

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -580,14 +580,21 @@ function normalizeExecuteError(error: unknown): { status: number; message: strin
 }
 
 /**
- * projectIdに紐づく prompt_version_id 一覧を prompt_version_projects 経由で取得する
+ * legacy project 紐づけは中間テーブルと旧 prompt_versions.project_id の両方を許容する。
  */
 async function fetchVersionIdsByProject(db: DB, projectId: number): Promise<number[]> {
-  const links = await db
-    .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
-    .from(prompt_version_projects)
-    .where(eq(prompt_version_projects.project_id, projectId));
-  return links.map((l) => l.prompt_version_id);
+  const [links, directVersions] = await Promise.all([
+    db
+      .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+      .from(prompt_version_projects)
+      .where(eq(prompt_version_projects.project_id, projectId)),
+    db
+      .select({ prompt_version_id: prompt_versions.id })
+      .from(prompt_versions)
+      .where(eq(prompt_versions.project_id, projectId)),
+  ]);
+
+  return [...new Set([...links.map((l) => l.prompt_version_id), ...directVersions.map((v) => v.prompt_version_id)])];
 }
 
 /**
@@ -599,6 +606,33 @@ async function fetchTestCaseIdsByProject(db: DB, projectId: number): Promise<num
     .from(test_case_projects)
     .where(eq(test_case_projects.project_id, projectId));
   return links.map((l) => l.test_case_id);
+}
+
+async function hasLegacyProjectPromptVersion(
+  db: DB,
+  projectId: number,
+  promptVersionId: number,
+): Promise<boolean> {
+  const [link] = await db
+    .select({ prompt_version_id: prompt_version_projects.prompt_version_id })
+    .from(prompt_version_projects)
+    .where(
+      and(
+        eq(prompt_version_projects.prompt_version_id, promptVersionId),
+        eq(prompt_version_projects.project_id, projectId),
+      ),
+    );
+
+  if (link) {
+    return true;
+  }
+
+  const [directVersion] = await db
+    .select({ id: prompt_versions.id })
+    .from(prompt_versions)
+    .where(and(eq(prompt_versions.id, promptVersionId), eq(prompt_versions.project_id, projectId)));
+
+  return directVersion !== undefined;
 }
 
 export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
@@ -681,17 +715,13 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const body = c.req.valid("json");
 
     if (legacyProjectId !== undefined) {
-      const [versionLink] = await db
-        .select()
-        .from(prompt_version_projects)
-        .where(
-          and(
-            eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
-            eq(prompt_version_projects.project_id, legacyProjectId),
-          ),
-        );
+      const hasVersionLink = await hasLegacyProjectPromptVersion(
+        db,
+        legacyProjectId,
+        body.prompt_version_id,
+      );
 
-      if (!versionLink) {
+      if (!hasVersionLink) {
         return c.json({ error: "Prompt version not found in this project" }, 404);
       }
     }
@@ -787,17 +817,13 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
     const body: ExecuteRunBody = c.req.valid("json");
 
     if (legacyProjectId !== undefined) {
-      const [versionLink] = await db
-        .select()
-        .from(prompt_version_projects)
-        .where(
-          and(
-            eq(prompt_version_projects.prompt_version_id, body.prompt_version_id),
-            eq(prompt_version_projects.project_id, legacyProjectId),
-          ),
-        );
+      const hasVersionLink = await hasLegacyProjectPromptVersion(
+        db,
+        legacyProjectId,
+        body.prompt_version_id,
+      );
 
-      if (!versionLink) {
+      if (!hasVersionLink) {
         return c.json({ error: "Prompt version not found" }, 404);
       }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -36,6 +36,7 @@ export function App() {
             <Route path="projects/:id" element={<ProjectDetailPage />} />
             <Route path="projects/:id/context-files" element={<ContextFilesPage />} />
             <Route path="projects/:id/test-cases" element={<TestCasesPage />} />
+            <Route path="prompts" element={<PromptsPage />} />
             <Route path="projects/:id/prompts" element={<PromptsPage />} />
             <Route path="projects/:id/runs" element={<RunsPage />} />
             <Route path="projects/:id/score" element={<ScorePage />} />

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router";
+import { BrowserRouter, Route, Routes } from "react-router";
 import { Layout } from "./components/Layout";
 import { AnnotationReviewPage } from "./pages/AnnotationReviewPage";
 import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
@@ -8,6 +8,7 @@ import { ExecutionProfilesPage } from "./pages/ExecutionProfilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { ProjectDetailPage } from "./pages/ProjectDetailPage";
+import { ProjectSettingsPage } from "./pages/ProjectSettingsPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
 import { PromptsPage } from "./pages/PromptsPage";
 import { RunsPage } from "./pages/RunsPage";
@@ -43,10 +44,7 @@ export function App() {
             <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
             <Route path="projects/:id/annotation-tasks" element={<AnnotationTaskSettingsPage />} />
             <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
-            <Route
-              path="projects/:id/settings"
-              element={<Navigate to="/execution-profiles" replace />}
-            />
+            <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             <Route path="execution-profiles" element={<ExecutionProfilesPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -81,6 +81,7 @@ function SidebarNav() {
 
   const topNavItems = [
     { to: "/", label: "プロジェクト一覧", end: true },
+    { to: "/prompts", label: "プロンプト", end: false },
     { to: "/execution-profiles", label: "実行設定", end: false },
     { to: "/health", label: "ヘルスチェック", end: false },
   ];

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -665,7 +665,16 @@ export async function executeRunStream(
   });
 
   if (!response.ok) {
-    throw new ApiError(response.status, `API error: ${response.status} ${response.statusText}`);
+    let message = `API error: ${response.status} ${response.statusText}`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) {
+        message = body.error;
+      }
+    } catch {
+      // ignore JSON parse errors and keep the HTTP status text
+    }
+    throw new ApiError(response.status, message);
   }
 
   if (!response.body) {

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -38,7 +38,7 @@ export function ProjectDetailPage() {
         {[
           { to: "context-files", label: "コンテキスト管理" },
           { to: "test-cases", label: "テストケース管理" },
-          { to: "prompts", label: "プロンプト管理" },
+          { to: `/prompts?project_id=${id}`, label: "プロンプト管理" },
           { to: "runs", label: "Run 実行・管理" },
           { to: "score", label: "採点" },
           { to: "annotation-tasks", label: "アノテーション設定" },

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -42,7 +42,7 @@ export function ProjectDetailPage() {
           { to: "runs", label: "Run 実行・管理" },
           { to: "score", label: "採点" },
           { to: "annotation-tasks", label: "アノテーション設定" },
-          { to: "/execution-profiles", label: "実行設定" },
+          { to: "settings", label: "実行設定" },
         ].map(({ to, label }) => (
           <Link
             key={to}

--- a/packages/ui/src/pages/PromptsPage.module.css
+++ b/packages/ui/src/pages/PromptsPage.module.css
@@ -1,4 +1,10 @@
-/* ==================== Page layout ==================== */
+.root {
+  --prompts-family-bg: color-mix(in srgb, var(--c-accent) 10%, var(--c-card));
+  --prompts-branch-bg: rgba(249, 226, 175, 0.1);
+  --prompts-compare-bg: rgba(137, 180, 250, 0.1);
+  --prompts-filter-bg: color-mix(in srgb, var(--c-card) 78%, var(--c-overlay));
+}
+
 .page {
   display: flex;
   flex-direction: column;
@@ -15,7 +21,7 @@
   margin: 0 0 4px;
 }
 
-.projectName {
+.pageDescription {
   margin: 0;
   font-size: 13px;
   color: var(--c-muted);
@@ -24,19 +30,15 @@
 .pageActions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
-/* ==================== Shared buttons ==================== */
 .btnPrimary {
   composes: btnPrimary from '../styles/shared.module.css';
-  padding: 7px 16px;
-  font-size: 13px;
 }
 
 .btnSecondary {
   composes: btnSecondary from '../styles/shared.module.css';
-  padding: 7px 16px;
-  font-size: 13px;
 }
 
 .btnBlue {
@@ -53,7 +55,43 @@
   composes: btnDisabled from '../styles/shared.module.css';
 }
 
-/* ==================== Compare bar ==================== */
+.filterBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  background: var(--prompts-filter-bg);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  flex-wrap: wrap;
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.filterLabel {
+  font-size: 12px;
+  color: var(--c-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.filterSelect {
+  composes: fieldInput from '../styles/shared.module.css';
+  min-width: 220px;
+}
+
+.filterHint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--c-subtext);
+}
+
 .compareBar {
   padding: 8px 12px;
   background: var(--c-card);
@@ -64,6 +102,7 @@
   gap: 12px;
   align-items: center;
   font-size: 13px;
+  flex-wrap: wrap;
 }
 
 .compareBarLabel {
@@ -98,7 +137,6 @@
   cursor: pointer;
 }
 
-/* ==================== Main content ==================== */
 .mainContent {
   display: flex;
   gap: 16px;
@@ -106,13 +144,67 @@
   min-height: 0;
 }
 
-/* ==================== Tree panel ==================== */
-.treePanel {
-  width: 300px;
+.sidebarColumn {
+  width: 360px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+.familyPanel,
+.treePanel,
+.rightPanel {
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+}
+
+.familyPanel {
+  padding: 14px;
+}
+
+.familyPanelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.familyActions {
+  display: flex;
+  gap: 6px;
+}
+
+.btnMini,
+.btnMiniDanger {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.btnMini {
+  background: transparent;
+  border: 1px solid var(--c-border);
+  color: var(--c-subtext);
+}
+
+.btnMiniDanger {
+  background: transparent;
+  border: 1px solid rgba(243, 139, 168, 0.45);
+  color: var(--c-danger);
+}
+
+.treePanel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
+  padding: 14px;
 }
 
 .treePanelLabel {
@@ -120,43 +212,107 @@
   color: var(--c-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: 8px;
+}
+
+.treeFamilyName {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--c-accent);
+  font-weight: 600;
+}
+
+.familyList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 280px;
+  overflow: auto;
+}
+
+.familyCard {
+  padding: 10px 12px;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--c-text);
+}
+
+.familyCardSelected {
+  background: var(--prompts-family-bg);
+  border-color: var(--c-accent);
+}
+
+.familyName {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.familyDescription {
+  font-size: 12px;
+  color: var(--c-muted);
+  line-height: 1.5;
 }
 
 .treeStatus {
   color: var(--c-muted);
   font-size: 13px;
+  margin: 12px 0 0;
 }
 
 .treeError {
   color: var(--c-danger);
   font-size: 13px;
+  margin: 12px 0 0;
 }
 
 .treeEmpty {
-  padding: 20px;
+  padding: 18px 14px;
+  margin-top: 12px;
   text-align: center;
   color: var(--c-muted);
   font-size: 13px;
-  background: var(--c-card);
+  background: var(--c-overlay);
   border-radius: 8px;
-  border: 1px solid var(--c-border);
+  border: 1px dashed var(--c-border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.treeEmptyHint {
+  font-size: 12px;
 }
 
 .treeScroll {
-  overflow-y: auto;
+  margin-top: 12px;
+  overflow: auto;
   flex: 1;
 }
 
-/* ==================== Tree item ==================== */
-.treeItem {
+.treeItemRow {
   display: flex;
   align-items: stretch;
-  margin-bottom: 2px;
+  gap: 2px;
+  margin-bottom: 6px;
+}
+
+.treeIndent {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.treeIndentUnit {
+  width: 18px;
+  flex-shrink: 0;
 }
 
 .treeConnector {
-  width: 20px;
+  width: 16px;
   flex-shrink: 0;
   position: relative;
 }
@@ -165,7 +321,7 @@
   position: absolute;
   left: 0;
   top: 50%;
-  width: 16px;
+  width: 14px;
   height: 1px;
   background: var(--c-border);
 }
@@ -181,28 +337,44 @@
 
 .treeCard {
   flex: 1;
-  padding: 8px 12px;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
   background: var(--c-card);
   border: 1px solid var(--c-border);
-  border-radius: 6px;
+  border-radius: 8px;
   color: var(--c-text);
-  cursor: pointer;
   text-align: left;
-  font-family: inherit;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
+  cursor: pointer;
 }
 
 .treeCardSelected {
-  background: rgba(203, 166, 247, 0.15);
+  background: color-mix(in srgb, var(--c-accent) 12%, var(--c-card));
   border-color: var(--c-accent);
 }
 
 .treeCardComparing {
-  background: rgba(137, 180, 250, 0.1);
+  background: var(--prompts-compare-bg);
   border-color: var(--c-blue);
+}
+
+.treeCardMain {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.treeCardTitleRow,
+.treeMetaRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 .treeVersionNum {
@@ -210,7 +382,6 @@
   font-weight: 700;
   color: var(--c-muted);
   flex-shrink: 0;
-  min-width: 28px;
 }
 
 .treeVersionNumSelected {
@@ -223,23 +394,48 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
 }
 
 .badgeBranch {
   font-size: 10px;
   color: var(--c-yellow);
-  background: rgba(249, 226, 175, 0.1);
+  background: var(--prompts-branch-bg);
   border: 1px solid rgba(249, 226, 175, 0.3);
-  border-radius: 4px;
-  padding: 1px 5px;
-  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.projectTag,
+.projectTagMuted,
+.badgeSelectedInline {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+}
+
+.projectTag {
+  background: color-mix(in srgb, var(--c-blue) 16%, var(--c-card));
+  border: 1px solid color-mix(in srgb, var(--c-blue) 34%, transparent);
+  color: var(--c-blue);
+}
+
+.projectTagMuted {
+  background: transparent;
+  border: 1px solid var(--c-border);
+  color: var(--c-muted);
+}
+
+.badgeSelectedInline {
+  background: rgba(137, 220, 235, 0.2);
+  border: 1px solid rgba(137, 220, 235, 0.4);
+  color: var(--c-blue);
 }
 
 .treeCardActions {
   display: flex;
   gap: 4px;
-  margin-left: auto;
   flex-shrink: 0;
 }
 
@@ -261,14 +457,11 @@
   color: var(--c-yellow);
 }
 
-/* ==================== Right panel ==================== */
 .rightPanel {
   flex: 1;
-  background: var(--c-card);
-  border: 1px solid var(--c-border);
-  border-radius: 8px;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -279,6 +472,8 @@
   justify-content: center;
   color: var(--c-muted);
   font-size: 14px;
+  padding: 20px;
+  text-align: center;
 }
 
 .panelHeader {
@@ -287,6 +482,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 10px;
 }
 
 .panelHeaderTitle {
@@ -309,25 +505,23 @@
   color: var(--c-text);
 }
 
-.panelBody {
+.panelHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.panelBody,
+.panelEditorBody {
   flex: 1;
   overflow: auto;
   padding: 16px;
 }
 
 .panelEditorBody {
-  flex: 1;
-  padding: 16px;
-  overflow: auto;
   display: flex;
   flex-direction: column;
-  min-height: 0;
-}
-
-.panelHeaderRight {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .btnEdit {
@@ -340,7 +534,6 @@
   cursor: pointer;
 }
 
-/* ==================== Selected badge & button ==================== */
 .badgeSelected {
   padding: 2px 8px;
   background: rgba(137, 220, 235, 0.2);
@@ -356,7 +549,6 @@
   border-radius: 6px;
   font-size: 12px;
   cursor: pointer;
-  white-space: nowrap;
 }
 
 .btnSelectedInactive {
@@ -370,6 +562,57 @@
   color: var(--c-blue);
   border: 1px solid rgba(137, 220, 235, 0.4);
   cursor: not-allowed;
+}
+
+.familySummaryCard {
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--c-accent) 28%, transparent);
+  background: var(--prompts-family-bg);
+  margin-bottom: 14px;
+}
+
+.familySummaryLabel {
+  display: block;
+  font-size: 11px;
+  color: var(--c-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+
+.familySummaryName {
+  display: block;
+  font-size: 16px;
+}
+
+.familySummaryDescription {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--c-subtext);
+}
+
+.versionMetaRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.versionMeta {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.badgeParentVersion {
+  color: var(--c-yellow);
+  background: var(--prompts-branch-bg);
+  border: 1px solid rgba(249, 226, 175, 0.3);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
 }
 
 .memoBox {
@@ -387,22 +630,6 @@
   margin-right: 6px;
 }
 
-.versionMeta {
-  font-size: 12px;
-  color: var(--c-muted);
-  margin-bottom: 6px;
-}
-
-.badgeParentVersion {
-  margin-left: 10px;
-  color: var(--c-yellow);
-  background: rgba(249, 226, 175, 0.1);
-  border: 1px solid rgba(249, 226, 175, 0.3);
-  border-radius: 4px;
-  padding: 1px 6px;
-  font-size: 11px;
-}
-
 .promptPre {
   margin: 0;
   padding: 14px;
@@ -415,7 +642,6 @@
   font-family: monospace;
   white-space: pre-wrap;
   word-break: break-word;
-  overflow-wrap: break-word;
 }
 
 .workflowPreview {
@@ -466,7 +692,6 @@
   word-break: break-word;
 }
 
-/* ==================== Editor form ==================== */
 .editorForm {
   display: flex;
   flex-direction: column;
@@ -485,28 +710,26 @@
 
 .fieldInput {
   composes: fieldInput from '../styles/shared.module.css';
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-family: inherit;
 }
 
 .fieldTextareaWrapper {
-  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+}
+
+.fieldTextarea,
+.familyTextarea,
+.workflowTextarea {
+  composes: fieldTextarea from '../styles/shared.module.css';
+  font-family: monospace;
 }
 
 .fieldTextarea {
-  composes: fieldTextarea from '../styles/shared.module.css';
-  padding: 8px 12px;
-  border-radius: 6px;
-  resize: vertical;
-  line-height: 1.6;
-  font-family: monospace;
-  min-height: 160px;
-  max-height: 280px;
-  overflow: auto;
+  min-height: 200px;
+}
+
+.familyTextarea {
+  min-height: 120px;
 }
 
 .workflowSection {
@@ -595,23 +818,8 @@
   gap: 8px;
 }
 
-.workflowTextarea {
-  min-height: 120px;
-  padding: 8px 12px;
-  background: var(--c-card);
-  border: 1px solid var(--c-border);
-  border-radius: 6px;
-  color: var(--c-text);
-  font-size: 13px;
-  line-height: 1.6;
-  font-family: monospace;
-  resize: vertical;
-}
-
 .formActions {
   composes: formActions from '../styles/shared.module.css';
-  gap: 8px;
-  flex-shrink: 0;
 }
 
 .btnSave {
@@ -639,26 +847,23 @@
   composes: errorMsg from '../styles/shared.module.css';
 }
 
-/* ==================== Branch modal ==================== */
 .modalOverlay {
   composes: modalOverlay from '../styles/shared.module.css';
 }
 
 .modalContent {
   composes: modalContent from '../styles/shared.module.css';
-  width: 480px;
+  width: min(520px, calc(100vw - 32px));
 }
 
 .modalTitle {
   composes: modalTitle from '../styles/shared.module.css';
-  margin: 0 0 8px;
-  font-size: 17px;
 }
 
 .modalSubtext {
-  margin: 0 0 20px;
-  color: var(--c-muted);
+  margin: 0 0 16px;
   font-size: 13px;
+  color: var(--c-muted);
 }
 
 .modalForm {
@@ -669,8 +874,8 @@
 
 .modalActions {
   display: flex;
-  gap: 10px;
   justify-content: flex-end;
+  gap: 8px;
 }
 
 .btnBranchSubmit {
@@ -684,7 +889,6 @@
   cursor: pointer;
 }
 
-/* ==================== Compare view ==================== */
 .compareOverlay {
   position: fixed;
   inset: 0;
@@ -719,7 +923,6 @@
 .compareHeaderTitle {
   margin: 0;
   font-size: 16px;
-  color: var(--c-text);
 }
 
 .compareHeaderActions {
@@ -768,7 +971,6 @@
   display: flex;
 }
 
-/* Side-by-side */
 .sideBySide {
   display: flex;
   flex: 1;
@@ -793,7 +995,7 @@
   color: var(--c-subtext);
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  gap: 12px;
 }
 
 .comparePanelHeaderA {
@@ -822,7 +1024,6 @@
   word-break: break-word;
 }
 
-/* Unified diff */
 .unifiedView {
   flex: 1;
   display: flex;
@@ -882,4 +1083,45 @@
   white-space: pre-wrap;
   word-break: break-word;
   flex: 1;
+}
+
+@media (max-width: 980px) {
+  .mainContent {
+    flex-direction: column;
+  }
+
+  .sidebarColumn {
+    width: 100%;
+  }
+
+  .treePanel {
+    min-height: 320px;
+  }
+
+  .panelHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .filterBar,
+  .compareBar,
+  .pageHeader,
+  .workflowHeader,
+  .compareHeader,
+  .compareHeaderActions,
+  .sideBySide {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .workflowFields {
+    grid-template-columns: 1fr;
+  }
+
+  .comparePanelLeft {
+    border-right: none;
+    border-bottom: 1px solid var(--c-border);
+  }
 }

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -811,10 +811,8 @@ export function PromptsPage() {
   const familyFilterParam = searchParams.get("family_id");
   const selectedProjectId =
     routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
+  const isProjectScopedView = routeProjectId !== null;
 
-  const [selectedFamilyId, setSelectedFamilyId] = useState<number | null>(
-    familyFilterParam ? Number(familyFilterParam) : null,
-  );
   const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
   const [compareVersion, setCompareVersion] = useState<PromptVersion | null>(null);
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
@@ -836,36 +834,27 @@ export function PromptsPage() {
     queryFn: getPromptFamilies,
   });
 
+  const requestedFamilyId = familyFilterParam ? Number(familyFilterParam) : null;
+  const selectedFamilyId =
+    requestedFamilyId !== null && families.some((family) => family.id === requestedFamilyId)
+      ? requestedFamilyId
+      : (families[0]?.id ?? null);
   const selectedFamily = families.find((family) => family.id === selectedFamilyId) ?? null;
 
   useEffect(() => {
-    if (families.length === 0) {
-      if (selectedFamilyId !== null) {
-        setSelectedFamilyId(null);
-      }
-      return;
-    }
-
-    if (selectedFamilyId !== null && families.some((family) => family.id === selectedFamilyId)) {
-      return;
-    }
-
-    const nextFamilyId = familyFilterParam ? Number(familyFilterParam) : (families[0]?.id ?? null);
-    setSelectedFamilyId(nextFamilyId);
-  }, [families, familyFilterParam, selectedFamilyId]);
-
-  useEffect(() => {
+    const nextParams = new URLSearchParams(searchParams);
     if (selectedFamilyId === null) {
-      searchParams.delete("family_id");
-      setSearchParams(searchParams, { replace: true });
+      if (!nextParams.has("family_id")) {
+        return;
+      }
+      nextParams.delete("family_id");
+      setSearchParams(nextParams, { replace: true });
       return;
     }
 
     if (searchParams.get("family_id") === String(selectedFamilyId)) {
       return;
     }
-
-    const nextParams = new URLSearchParams(searchParams);
     nextParams.set("family_id", String(selectedFamilyId));
     setSearchParams(nextParams, { replace: true });
   }, [searchParams, selectedFamilyId, setSearchParams]);
@@ -926,7 +915,9 @@ export function PromptsPage() {
           }),
     onSuccess: (family) => {
       void queryClient.invalidateQueries({ queryKey: ["promptFamilies"] });
-      setSelectedFamilyId(family.id);
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set("family_id", String(family.id));
+      setSearchParams(nextParams, { replace: true });
       setEditingFamily(undefined);
     },
   });
@@ -963,7 +954,9 @@ export function PromptsPage() {
   }
 
   function handleSelectFamily(familyId: number) {
-    setSelectedFamilyId(familyId);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("family_id", String(familyId));
+    setSearchParams(nextParams);
     setSelectedVersion(null);
     setCompareVersion(null);
     setPanelMode(null);
@@ -1033,6 +1026,7 @@ export function PromptsPage() {
             id="project-filter"
             value={selectedProjectId ?? ""}
             onChange={(event) => handleProjectFilterChange(event.target.value)}
+            disabled={isProjectScopedView}
             className={styles.filterSelect}
           >
             <option value="">すべてのプロジェクト</option>
@@ -1045,8 +1039,10 @@ export function PromptsPage() {
         </div>
         {selectedProjectName ? (
           <p className={styles.filterHint}>
-            現在は <span className={styles.projectTag}>{selectedProjectName}</span> の付いた
-            バージョンだけを表示しています。
+            現在は <span className={styles.projectTag}>{selectedProjectName}</span>
+            {isProjectScopedView
+              ? " 固定の画面として表示しています。"
+              : " の付いたバージョンだけを表示しています。"}
           </p>
         ) : (
           <p className={styles.filterHint}>未分類を含む全バージョンを表示しています。</p>

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1,15 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { useParams } from "react-router";
+import { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "react-router";
 import {
+  type Project,
   type PromptExecutionStepDefinition,
+  type PromptFamily,
   type PromptVersion,
-  branchPromptVersion,
-  createPromptVersion,
-  getProject,
-  getPromptVersions,
-  setSelectedVersion,
-  updatePromptVersion,
+  branchIndependentPromptVersion,
+  createIndependentPromptVersion,
+  createPromptFamily,
+  deletePromptFamily,
+  getProjects,
+  getPromptFamilies,
+  getPromptVersionsByFamily,
+  setPromptVersionProjects,
+  setSelectedIndependentPromptVersion,
+  updateIndependentPromptVersion,
+  updatePromptFamily,
 } from "../lib/api";
 import styles from "./PromptsPage.module.css";
 
@@ -26,7 +33,6 @@ function formatDate(timestamp: number): string {
   });
 }
 
-// バージョンツリーのノード型
 type VersionTreeNode = {
   version: PromptVersion;
   children: VersionTreeNode[];
@@ -37,65 +43,58 @@ function buildVersionTree(versions: PromptVersion[]): VersionTreeNode[] {
   const map = new Map<number, VersionTreeNode>();
   const roots: VersionTreeNode[] = [];
 
-  // まずノードマップを作成
-  for (const v of versions) {
-    map.set(v.id, { version: v, children: [], depth: 0 });
+  for (const version of versions) {
+    map.set(version.id, { version, children: [], depth: 0 });
   }
 
-  // 親子関係を構築
-  for (const v of versions) {
-    const node = map.get(v.id);
+  for (const version of versions) {
+    const node = map.get(version.id);
     if (!node) continue;
-    if (v.parent_version_id !== null) {
-      const parent = map.get(v.parent_version_id);
-      if (parent) {
-        parent.children.push(node);
-      } else {
-        roots.push(node);
-      }
-    } else {
+
+    if (version.parent_version_id === null) {
       roots.push(node);
+      continue;
     }
+
+    const parent = map.get(version.parent_version_id);
+    if (!parent) {
+      roots.push(node);
+      continue;
+    }
+
+    parent.children.push(node);
   }
 
-  // depthを計算
-  function setDepth(node: VersionTreeNode, depth: number) {
+  function assignDepth(node: VersionTreeNode, depth: number) {
     node.depth = depth;
-    for (const child of node.children) {
-      setDepth(child, depth + 1);
-    }
-  }
-  for (const root of roots) {
-    setDepth(root, 0);
-  }
-
-  // versionでソート
-  roots.sort((a, b) => a.version.version - b.version.version);
-  function sortChildren(node: VersionTreeNode) {
     node.children.sort((a, b) => a.version.version - b.version.version);
     for (const child of node.children) {
-      sortChildren(child);
+      assignDepth(child, depth + 1);
     }
   }
+
+  roots.sort((a, b) => a.version.version - b.version.version);
   for (const root of roots) {
-    sortChildren(root);
+    assignDepth(root, 0);
   }
 
   return roots;
 }
 
-// ツリーをフラットリストに変換（表示順序）
 function flattenTree(nodes: VersionTreeNode[]): VersionTreeNode[] {
   const result: VersionTreeNode[] = [];
-  function traverse(node: VersionTreeNode) {
+
+  function visit(node: VersionTreeNode) {
     result.push(node);
     for (const child of node.children) {
-      traverse(child);
+      visit(child);
     }
   }
+
   for (const node of nodes) {
-    traverse(node);
+    visit(node);
   }
+
   return result;
 }
 
@@ -134,52 +133,101 @@ function getWorkflowValidationMessage(steps: PromptExecutionStepDefinition[]): s
   return null;
 }
 
-// Determine whether to draw a vertical line at depth d for each node
-
-function computeVerticalLines(flatNodes: VersionTreeNode[]): boolean[][] {
-  const result: boolean[][] = flatNodes.map(() => []);
-  const maxDepth = Math.max(...flatNodes.map((n) => n.depth), 0);
-
-  for (let d = 0; d <= maxDepth; d++) {
-    for (let i = 0; i < flatNodes.length; i++) {
-      const node = flatNodes[i];
-      if (!node) continue;
-      if (node.depth >= d) {
-        if (node.depth === d) {
-          // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
-          result[i]![d] = false;
-        } else {
-          let showLine = false;
-          for (let j = i + 1; j < flatNodes.length; j++) {
-            const jNode = flatNodes[j];
-            if (!jNode) break;
-            if (jNode.depth < d) break;
-            if (jNode.depth === d) {
-              showLine = true;
-              break;
-            }
-          }
-          // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
-          result[i]![d] = showLine;
-        }
-      } else {
-        // biome-ignore lint/style/noNonNullAssertion: result[i] is always initialized above
-        result[i]![d] = false;
-      }
-    }
+function getProjectName(projects: Project[], projectId: number | null): string | null {
+  if (projectId === null) {
+    return null;
   }
 
-  return result;
+  return projects.find((project) => project.id === projectId)?.name ?? `Project ${projectId}`;
+}
+
+type FamilyModalProps = {
+  family: PromptFamily | null;
+  onClose: () => void;
+  onSubmit: (data: { name?: string | null; description?: string | null }) => void;
+  isPending: boolean;
+  isError: boolean;
+};
+
+function FamilyModal({ family, onClose, onSubmit, isPending, isError }: FamilyModalProps) {
+  const [name, setName] = useState(family?.name ?? "");
+  const [description, setDescription] = useState(family?.description ?? "");
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    onSubmit({
+      name: name.trim() || null,
+      description: description.trim() || null,
+    });
+  }
+
+  return (
+    <div
+      className={styles.modalOverlay}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
+      }}
+    >
+      <div className={styles.modalContent}>
+        <h3 className={styles.modalTitle}>
+          {family ? "プロンプトファミリーを編集" : "プロンプトファミリーを作成"}
+        </h3>
+        <form onSubmit={handleSubmit} className={styles.modalForm}>
+          <div>
+            <label htmlFor="family-name" className={styles.fieldLabel}>
+              名前
+            </label>
+            <input
+              id="family-name"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="例: FAQ 応答改善"
+              className={styles.fieldInput}
+            />
+          </div>
+          <div>
+            <label htmlFor="family-description" className={styles.fieldLabel}>
+              説明
+            </label>
+            <textarea
+              id="family-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="このファミリーで検証したい目的や前提"
+              className={styles.familyTextarea}
+            />
+          </div>
+          {isError && <p className={styles.errorMsg}>ファミリーの保存に失敗しました。</p>}
+          <div className={styles.modalActions}>
+            <button type="button" onClick={onClose} className={styles.btnCancel}>
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className={`${styles.btnSave} ${isPending ? styles.btnDisabled : ""}`}
+            >
+              {isPending ? "保存中..." : family ? "更新" : "作成"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }
 
 type VersionTreeItemProps = {
   node: VersionTreeNode;
   isSelected: boolean;
   isComparing: boolean;
-  onSelect: (v: PromptVersion) => void;
-  onBranch: (v: PromptVersion) => void;
-  onCompare: (v: PromptVersion) => void;
-  verticalLines: boolean[];
+  onSelect: (version: PromptVersion) => void;
+  onBranch: (version: PromptVersion) => void;
+  onCompare: (version: PromptVersion) => void;
+  projectName: string | null;
 };
 
 function VersionTreeItem({
@@ -189,53 +237,62 @@ function VersionTreeItem({
   onSelect,
   onBranch,
   onCompare,
-  verticalLines: _verticalLines,
+  projectName,
 }: VersionTreeItemProps) {
-  const { version } = node;
-  const depth = node.depth;
-
   return (
-    <div className={styles.treeItem} style={{ paddingLeft: `${depth * 20}px` }}>
-      {/* 接続線（分岐ノードのみ） */}
-      {depth > 0 && (
+    <div className={styles.treeItemRow}>
+      <div className={styles.treeIndent}>
+        {Array.from({ length: node.depth }).map((_, index) => (
+          <span key={`${node.version.id}-indent-${index}`} className={styles.treeIndentUnit} />
+        ))}
+      </div>
+      {node.depth > 0 && (
         <div className={styles.treeConnector}>
           <div className={styles.treeConnectorH} />
           <div className={styles.treeConnectorV} />
         </div>
       )}
-
-      {/* バージョンカード */}
       <button
         type="button"
-        onClick={() => onSelect(version)}
+        onClick={() => onSelect(node.version)}
         className={`${styles.treeCard} ${isSelected ? styles.treeCardSelected : ""} ${isComparing ? styles.treeCardComparing : ""}`}
       >
-        <span
-          className={`${styles.treeVersionNum} ${isSelected ? styles.treeVersionNumSelected : ""}`}
-        >
-          v{version.version}
-        </span>
-        <span className={styles.treeVersionName}>
-          {version.name ?? `バージョン ${version.version}`}
-        </span>
-        {version.parent_version_id !== null && <span className={styles.badgeBranch}>分岐</span>}
+        <div className={styles.treeCardMain}>
+          <div className={styles.treeCardTitleRow}>
+            <span
+              className={`${styles.treeVersionNum} ${isSelected ? styles.treeVersionNumSelected : ""}`}
+            >
+              v{node.version.version}
+            </span>
+            <span className={styles.treeVersionName}>
+              {node.version.name ?? `バージョン ${node.version.version}`}
+            </span>
+            {node.version.parent_version_id !== null && (
+              <span className={styles.badgeBranch}>分岐</span>
+            )}
+          </div>
+          <div className={styles.treeMetaRow}>
+            {projectName ? <span className={styles.projectTag}>{projectName}</span> : null}
+            {node.version.is_selected && (
+              <span className={styles.badgeSelectedInline}>Selected</span>
+            )}
+          </div>
+        </div>
         <div
           className={styles.treeCardActions}
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
         >
           <button
             type="button"
-            onClick={() => onCompare(version)}
-            title="比較"
+            onClick={() => onCompare(node.version)}
             className={`${styles.btnTreeAction} ${isComparing ? styles.btnTreeCompareActive : ""}`}
           >
             比較
           </button>
           <button
             type="button"
-            onClick={() => onBranch(version)}
-            title="分岐"
+            onClick={() => onBranch(node.version)}
             className={`${styles.btnTreeAction} ${styles.btnTreeBranch}`}
           >
             分岐
@@ -247,86 +304,82 @@ function VersionTreeItem({
 }
 
 type PromptEditorProps = {
+  familyId: number;
+  projects: Project[];
   version: PromptVersion | null;
-  projectId: number;
+  defaultProjectId: number | null;
   isNew?: boolean;
-  onSave: () => void;
+  onSave: (version: PromptVersion) => void;
   onCancel: () => void;
 };
 
-function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: PromptEditorProps) {
+function PromptEditor({
+  familyId,
+  projects,
+  version,
+  defaultProjectId,
+  isNew = false,
+  onSave,
+  onCancel,
+}: PromptEditorProps) {
   const queryClient = useQueryClient();
   const [name, setName] = useState(version?.name ?? "");
   const [memo, setMemo] = useState(version?.memo ?? "");
   const [content, setContent] = useState(version?.content ?? "");
+  const [linkedProjectId, setLinkedProjectId] = useState(
+    version?.project_id !== null && version?.project_id !== undefined
+      ? String(version.project_id)
+      : defaultProjectId !== null
+        ? String(defaultProjectId)
+        : "",
+  );
   const [workflowSteps, setWorkflowSteps] = useState<PromptExecutionStepDefinition[]>(
     version?.workflow_definition?.steps ?? [],
   );
 
-  const createMutation = useMutation({
-    mutationFn: (data: {
-      content: string;
-      name?: string;
-      memo?: string;
-      workflow_definition?: { steps: PromptExecutionStepDefinition[] };
-    }) => createPromptVersion(projectId, data),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
-      onSave();
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const workflowDefinition = buildWorkflowDefinition(workflowSteps);
+
+      const savedVersion = isNew
+        ? await createIndependentPromptVersion({
+            prompt_family_id: familyId,
+            content: content.trim(),
+            name: name.trim() || undefined,
+            memo: memo.trim() || undefined,
+            workflow_definition: workflowDefinition ?? undefined,
+          })
+        : await updateIndependentPromptVersion(version?.id ?? 0, {
+            content: content.trim(),
+            name: name.trim() || null,
+            memo: memo.trim() || null,
+            workflow_definition: workflowDefinition,
+          });
+
+      const nextProjectId = linkedProjectId ? Number(linkedProjectId) : null;
+      if (savedVersion.project_id === nextProjectId) {
+        return savedVersion;
+      }
+
+      return setPromptVersionProjects(savedVersion.id, { project_id: nextProjectId });
+    },
+    onSuccess: (savedVersion) => {
+      void queryClient.invalidateQueries({ queryKey: ["promptFamilies"] });
+      void queryClient.invalidateQueries({ queryKey: ["promptVersionsByFamily", familyId] });
+      onSave(savedVersion);
     },
   });
 
-  const updateMutation = useMutation({
-    mutationFn: (data: {
-      content?: string;
-      name?: string | null;
-      memo?: string | null;
-      workflow_definition?: { steps: PromptExecutionStepDefinition[] } | null;
-    }) => {
-      if (!version) throw new Error("version is required for update");
-      return updatePromptVersion(projectId, version.id, data);
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
-      onSave();
-    },
-  });
-
-  const isPending = createMutation.isPending || updateMutation.isPending;
   const workflowValidationMessage = getWorkflowValidationMessage(workflowSteps);
-  const isDisabled = !content.trim() || isPending || workflowValidationMessage !== null;
+  const isDisabled =
+    !content.trim() || saveMutation.isPending || workflowValidationMessage !== null;
 
-  function buildWorkflowDefinition() {
-    const steps = workflowSteps
-      .map((step, index) => ({
-        id: step.id.trim(),
-        title: step.title.trim() || `ステップ ${index + 2}`,
-        prompt: step.prompt.trim(),
-      }))
-      .filter((step) => step.id && step.prompt);
-
-    return steps.length > 0 ? { steps } : undefined;
-  }
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!content.trim()) return;
-
-    if (isNew) {
-      createMutation.mutate({
-        content: content.trim(),
-        name: name.trim() || undefined,
-        memo: memo.trim() || undefined,
-        workflow_definition: buildWorkflowDefinition(),
-      });
-    } else {
-      updateMutation.mutate({
-        content: content.trim(),
-        name: name.trim() || null,
-        memo: memo.trim() || null,
-        workflow_definition: buildWorkflowDefinition() ?? null,
-      });
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (isDisabled) {
+      return;
     }
+    saveMutation.mutate();
   }
 
   return (
@@ -341,7 +394,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
           id="editor-name"
           type="text"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(event) => setName(event.target.value)}
           placeholder={
             isNew || version?.parent_version_id === null
               ? "未入力なら自動で名前を付けます"
@@ -351,6 +404,24 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
         />
       </div>
       <div>
+        <label htmlFor="editor-project" className={styles.fieldLabel}>
+          プロジェクトラベル
+        </label>
+        <select
+          id="editor-project"
+          value={linkedProjectId}
+          onChange={(event) => setLinkedProjectId(event.target.value)}
+          className={styles.fieldInput}
+        >
+          <option value="">未分類</option>
+          {projects.map((project) => (
+            <option key={project.id} value={project.id}>
+              {project.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
         <label htmlFor="editor-memo" className={styles.fieldLabel}>
           メモ（任意）
         </label>
@@ -358,7 +429,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
           id="editor-memo"
           type="text"
           value={memo}
-          onChange={(e) => setMemo(e.target.value)}
+          onChange={(event) => setMemo(event.target.value)}
           placeholder="変更内容や目的を記入..."
           className={styles.fieldInput}
         />
@@ -371,7 +442,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
         <textarea
           id="editor-content"
           value={content}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={(event) => setContent(event.target.value)}
           placeholder="システムプロンプトを入力..."
           className={styles.fieldTextarea}
         />
@@ -381,7 +452,7 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
           <div>
             <p className={styles.fieldLabel}>追加ステップ（Step 2 以降）</p>
             <p className={styles.workflowHint}>
-              各ステップで `{"{{conversation}}"}`、`{"{{context}}"}`、`{"{{previous_output}}"}`、 `
+              各ステップで `{"{{conversation}}"}`、`{"{{context}}"}`、`{"{{previous_output}}"}`、`
               {"{{step:step_id}}"}` を利用できます。
             </p>
           </div>
@@ -417,10 +488,10 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
                   <input
                     type="text"
                     value={step.id}
-                    onChange={(e) =>
+                    onChange={(event) =>
                       setWorkflowSteps((prev) =>
                         prev.map((current, currentIndex) =>
-                          currentIndex === index ? { ...current, id: e.target.value } : current,
+                          currentIndex === index ? { ...current, id: event.target.value } : current,
                         ),
                       )
                     }
@@ -430,10 +501,12 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
                   <input
                     type="text"
                     value={step.title}
-                    onChange={(e) =>
+                    onChange={(event) =>
                       setWorkflowSteps((prev) =>
                         prev.map((current, currentIndex) =>
-                          currentIndex === index ? { ...current, title: e.target.value } : current,
+                          currentIndex === index
+                            ? { ...current, title: event.target.value }
+                            : current,
                         ),
                       )
                     }
@@ -443,10 +516,12 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
                 </div>
                 <textarea
                   value={step.prompt}
-                  onChange={(e) =>
+                  onChange={(event) =>
                     setWorkflowSteps((prev) =>
                       prev.map((current, currentIndex) =>
-                        currentIndex === index ? { ...current, prompt: e.target.value } : current,
+                        currentIndex === index
+                          ? { ...current, prompt: event.target.value }
+                          : current,
                       ),
                     )
                   }
@@ -468,60 +543,82 @@ function PromptEditor({ version, projectId, isNew = false, onSave, onCancel }: P
           disabled={isDisabled}
           className={`${styles.btnSave} ${isDisabled ? styles.btnDisabled : ""}`}
         >
-          {isPending ? "保存中..." : isNew ? "作成" : "保存"}
+          {saveMutation.isPending ? "保存中..." : isNew ? "作成" : "保存"}
         </button>
       </div>
-      {(createMutation.isError || updateMutation.isError) && (
-        <p className={styles.errorMsg}>保存に失敗しました。再度お試しください。</p>
+      {saveMutation.isError && (
+        <p className={styles.errorMsg}>プロンプトの保存に失敗しました。再度お試しください。</p>
       )}
     </form>
   );
 }
 
+function buildWorkflowDefinition(steps: PromptExecutionStepDefinition[]) {
+  const normalizedSteps = steps
+    .map((step, index) => ({
+      id: step.id.trim(),
+      title: step.title.trim() || `ステップ ${index + 2}`,
+      prompt: step.prompt.trim(),
+    }))
+    .filter((step) => step.id && step.prompt);
+
+  return normalizedSteps.length > 0 ? { steps: normalizedSteps } : null;
+}
+
 type BranchModalProps = {
   parentVersion: PromptVersion;
-  projectId: number;
+  defaultProjectId: number | null;
   onClose: () => void;
   onCreated: (newVersion: PromptVersion) => void;
 };
 
-function BranchModal({ parentVersion, projectId, onClose, onCreated }: BranchModalProps) {
+function BranchModal({ parentVersion, defaultProjectId, onClose, onCreated }: BranchModalProps) {
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [memo, setMemo] = useState("");
 
   const branchMutation = useMutation({
-    mutationFn: (data: { name?: string; memo?: string }) =>
-      branchPromptVersion(projectId, parentVersion.id, data),
+    mutationFn: async () => {
+      const created = await branchIndependentPromptVersion(parentVersion.id, {
+        name: name.trim() || undefined,
+        memo: memo.trim() || undefined,
+      });
+
+      const nextProjectId = parentVersion.project_id ?? defaultProjectId;
+      if (created.project_id === nextProjectId) {
+        return created;
+      }
+
+      return setPromptVersionProjects(created.id, { project_id: nextProjectId });
+    },
     onSuccess: (newVersion) => {
-      void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["promptVersionsByFamily", parentVersion.prompt_family_id],
+      });
       onCreated(newVersion);
     },
   });
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    branchMutation.mutate({
-      name: name.trim() || undefined,
-      memo: memo.trim() || undefined,
-    });
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    branchMutation.mutate();
   }
 
   return (
     <div
       className={styles.modalOverlay}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
       }}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") onClose();
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
       }}
     >
       <div className={styles.modalContent}>
         <h3 className={styles.modalTitle}>バージョンを分岐</h3>
         <p className={styles.modalSubtext}>
-          v{parentVersion.version}「{parentVersion.name ?? `バージョン ${parentVersion.version}`}
-          」から分岐します
+          v{parentVersion.version}「{parentVersion.name ?? `バージョン ${parentVersion.version}`}」
+          から分岐します
         </p>
         <form onSubmit={handleSubmit} className={styles.modalForm}>
           <div>
@@ -532,7 +629,7 @@ function BranchModal({ parentVersion, projectId, onClose, onCreated }: BranchMod
               id="branch-name"
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(event) => setName(event.target.value)}
               placeholder="例: 別アプローチ版"
               className={styles.fieldInput}
             />
@@ -545,7 +642,7 @@ function BranchModal({ parentVersion, projectId, onClose, onCreated }: BranchMod
               id="branch-memo"
               type="text"
               value={memo}
-              onChange={(e) => setMemo(e.target.value)}
+              onChange={(event) => setMemo(event.target.value)}
               placeholder="分岐の目的や変更予定..."
               className={styles.fieldInput}
             />
@@ -580,66 +677,28 @@ function diffLines(a: string, b: string): { type: "same" | "removed" | "added"; 
   const bLines = b.split("\n");
   const result: { type: "same" | "removed" | "added"; text: string }[] = [];
 
-  // 単純なLCS差分アルゴリズム（Myers diff の簡易実装）
-  const maxLen = Math.max(aLines.length, bLines.length);
   let ai = 0;
   let bi = 0;
 
   while (ai < aLines.length || bi < bLines.length) {
-    if (ai < aLines.length && bi < bLines.length && aLines[ai] === bLines[bi]) {
-      // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-      result.push({ type: "same", text: aLines[ai]! });
-      ai++;
-      bi++;
-    } else {
-      const aRemainder = aLines.slice(ai);
-      const bRemainder = bLines.slice(bi);
+    const aLine = aLines[ai];
+    const bLine = bLines[bi];
 
-      let foundInA = -1;
-      let foundInB = -1;
-      const lookAhead = Math.min(5, maxLen);
+    if (aLine !== undefined && bLine !== undefined && aLine === bLine) {
+      result.push({ type: "same", text: aLine });
+      ai += 1;
+      bi += 1;
+      continue;
+    }
 
-      for (let d = 0; d < lookAhead; d++) {
-        // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-        if (d < bRemainder.length && aRemainder.slice(0, lookAhead).includes(bRemainder[d]!)) {
-          foundInB = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < bRemainder.length checked
-          foundInA = aRemainder.indexOf(bRemainder[d]!);
-          break;
-        }
-        // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-        if (d < aRemainder.length && bRemainder.slice(0, lookAhead).includes(aRemainder[d]!)) {
-          foundInA = d;
-          // biome-ignore lint/style/noNonNullAssertion: d < aRemainder.length checked
-          foundInB = bRemainder.indexOf(aRemainder[d]!);
-          break;
-        }
-      }
+    if (aLine !== undefined) {
+      result.push({ type: "removed", text: aLine });
+      ai += 1;
+    }
 
-      if (foundInA > 0) {
-        for (let i = 0; i < foundInA; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInA <= aRemainder.length
-          result.push({ type: "removed", text: aRemainder[i]! });
-        }
-        ai += foundInA;
-      } else if (foundInB > 0) {
-        for (let i = 0; i < foundInB; i++) {
-          // biome-ignore lint/style/noNonNullAssertion: i < foundInB <= bRemainder.length
-          result.push({ type: "added", text: bRemainder[i]! });
-        }
-        bi += foundInB;
-      } else {
-        if (ai < aLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "removed", text: aLines[ai]! });
-          ai++;
-        }
-        if (bi < bLines.length) {
-          // biome-ignore lint/style/noNonNullAssertion: bounds checked above
-          result.push({ type: "added", text: bLines[bi]! });
-          bi++;
-        }
-      }
+    if (bLine !== undefined) {
+      result.push({ type: "added", text: bLine });
+      bi += 1;
     }
   }
 
@@ -653,27 +712,26 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
   return (
     <div
       className={styles.compareOverlay}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
       }}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") onClose();
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
       }}
     >
       <div className={styles.compareBox}>
-        {/* ヘッダー */}
         <div className={styles.compareHeader}>
           <h3 className={styles.compareHeaderTitle}>バージョン比較</h3>
           <div className={styles.compareHeaderActions}>
             <div className={styles.compareModeToggle}>
-              {(["side-by-side", "unified"] as const).map((m) => (
+              {(["side-by-side", "unified"] as const).map((modeValue) => (
                 <button
-                  key={m}
+                  key={modeValue}
                   type="button"
-                  onClick={() => setMode(m)}
-                  className={`${styles.btnMode} ${mode === m ? styles.btnModeActive : styles.btnModeInactive}`}
+                  onClick={() => setMode(modeValue)}
+                  className={`${styles.btnMode} ${mode === modeValue ? styles.btnModeActive : styles.btnModeInactive}`}
                 >
-                  {m === "side-by-side" ? "並列" : "統合"}
+                  {modeValue === "side-by-side" ? "並列" : "統合"}
                 </button>
               ))}
             </div>
@@ -682,26 +740,22 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
             </button>
           </div>
         </div>
-
-        {/* コンテンツ */}
         <div className={styles.compareContent}>
           {mode === "side-by-side" ? (
             <div className={styles.sideBySide}>
-              {/* 左: versionA */}
               <div className={`${styles.comparePanel} ${styles.comparePanelLeft}`}>
                 <div className={`${styles.comparePanelHeader} ${styles.comparePanelHeaderA}`}>
                   <span>
-                    v{versionA.version} {versionA.name && `— ${versionA.name}`}
+                    v{versionA.version} {versionA.name ? `— ${versionA.name}` : ""}
                   </span>
                   <span className={styles.comparePanelDate}>{formatDate(versionA.created_at)}</span>
                 </div>
                 <pre className={styles.comparePre}>{versionA.content}</pre>
               </div>
-              {/* 右: versionB */}
               <div className={styles.comparePanel}>
                 <div className={`${styles.comparePanelHeader} ${styles.comparePanelHeaderB}`}>
                   <span>
-                    v{versionB.version} {versionB.name && `— ${versionB.name}`}
+                    v{versionB.version} {versionB.name ? `— ${versionB.name}` : ""}
                   </span>
                   <span className={styles.comparePanelDate}>{formatDate(versionB.created_at)}</span>
                 </div>
@@ -709,16 +763,15 @@ function CompareView({ versionA, versionB, onClose }: CompareViewProps) {
               </div>
             </div>
           ) : (
-            // 統合表示（差分ハイライト）
             <div className={styles.unifiedView}>
               <div className={styles.unifiedHeader}>
-                <span className={styles.unifiedLabelA}>ー v{versionA.version}</span>
+                <span className={styles.unifiedLabelA}>- v{versionA.version}</span>
                 <span className={styles.unifiedLabelB}>+ v{versionB.version}</span>
               </div>
               <div className={styles.diffScroll}>
-                {diff.map((line, i) => (
+                {diff.map((line, index) => (
                   <div
-                    key={`diff-${line.type}-${i}`}
+                    key={`${line.type}-${index}`}
                     className={`${styles.diffLine} ${
                       line.type === "removed"
                         ? styles.diffLineRemoved
@@ -749,118 +802,270 @@ type PanelMode =
   | null;
 
 export function PromptsPage() {
-  const { id } = useParams<{ id: string }>();
-  const projectId = Number(id);
+  const { id } = useParams<{ id?: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
 
-  const [selectedVersion, setSelectedVersionState] = useState<PromptVersion | null>(null);
+  const routeProjectId = id ? Number(id) : null;
+  const projectFilterParam = searchParams.get("project_id");
+  const familyFilterParam = searchParams.get("family_id");
+  const selectedProjectId =
+    routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
+
+  const [selectedFamilyId, setSelectedFamilyId] = useState<number | null>(
+    familyFilterParam ? Number(familyFilterParam) : null,
+  );
+  const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
   const [compareVersion, setCompareVersion] = useState<PromptVersion | null>(null);
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
   const [branchTarget, setBranchTarget] = useState<PromptVersion | null>(null);
+  const [editingFamily, setEditingFamily] = useState<PromptFamily | null | undefined>(undefined);
   const [isCompareOpen, setIsCompareOpen] = useState(false);
 
-  const { data: project } = useQuery({
-    queryKey: ["project", projectId],
-    queryFn: () => getProject(projectId),
-    enabled: !Number.isNaN(projectId),
+  const { data: projects = [] } = useQuery({
+    queryKey: ["projects"],
+    queryFn: getProjects,
   });
 
   const {
-    data: versions,
-    isLoading,
-    isError,
+    data: families = [],
+    isLoading: isFamiliesLoading,
+    isError: isFamiliesError,
   } = useQuery({
-    queryKey: ["promptVersions", projectId],
-    queryFn: () => getPromptVersions(projectId),
-    enabled: !Number.isNaN(projectId),
+    queryKey: ["promptFamilies"],
+    queryFn: getPromptFamilies,
+  });
+
+  const selectedFamily = families.find((family) => family.id === selectedFamilyId) ?? null;
+
+  useEffect(() => {
+    if (families.length === 0) {
+      if (selectedFamilyId !== null) {
+        setSelectedFamilyId(null);
+      }
+      return;
+    }
+
+    if (selectedFamilyId !== null && families.some((family) => family.id === selectedFamilyId)) {
+      return;
+    }
+
+    const nextFamilyId = familyFilterParam ? Number(familyFilterParam) : (families[0]?.id ?? null);
+    setSelectedFamilyId(nextFamilyId);
+  }, [families, familyFilterParam, selectedFamilyId]);
+
+  useEffect(() => {
+    if (selectedFamilyId === null) {
+      searchParams.delete("family_id");
+      setSearchParams(searchParams, { replace: true });
+      return;
+    }
+
+    if (searchParams.get("family_id") === String(selectedFamilyId)) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("family_id", String(selectedFamilyId));
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, selectedFamilyId, setSearchParams]);
+
+  const {
+    data: familyVersions = [],
+    isLoading: isVersionsLoading,
+    isError: isVersionsError,
+  } = useQuery({
+    queryKey: ["promptVersionsByFamily", selectedFamilyId],
+    queryFn: () => getPromptVersionsByFamily(selectedFamilyId ?? 0),
+    enabled: selectedFamilyId !== null,
+  });
+
+  const filteredVersions =
+    selectedProjectId === null
+      ? familyVersions
+      : familyVersions.filter((version) => version.project_id === selectedProjectId);
+
+  const tree = buildVersionTree(filteredVersions);
+  const flatNodes = flattenTree(tree);
+
+  useEffect(() => {
+    if (!selectedVersion) {
+      return;
+    }
+
+    const nextSelected =
+      familyVersions.find((version) => version.id === selectedVersion.id) ?? null;
+    setSelectedVersion(nextSelected);
+    if (nextSelected && panelMode?.type === "view") {
+      setPanelMode({ type: "view", version: nextSelected });
+    }
+    if (nextSelected && panelMode?.type === "edit") {
+      setPanelMode({ type: "edit", version: nextSelected });
+    }
+  }, [familyVersions, panelMode?.type, selectedVersion]);
+
+  useEffect(() => {
+    if (!compareVersion) {
+      return;
+    }
+
+    const nextCompare = familyVersions.find((version) => version.id === compareVersion.id) ?? null;
+    setCompareVersion(nextCompare);
+  }, [compareVersion, familyVersions]);
+
+  const familySaveMutation = useMutation({
+    mutationFn: (data: { familyId?: number; name?: string | null; description?: string | null }) =>
+      data.familyId
+        ? updatePromptFamily(data.familyId, {
+            name: data.name,
+            description: data.description,
+          })
+        : createPromptFamily({
+            name: data.name,
+            description: data.description,
+          }),
+    onSuccess: (family) => {
+      void queryClient.invalidateQueries({ queryKey: ["promptFamilies"] });
+      setSelectedFamilyId(family.id);
+      setEditingFamily(undefined);
+    },
+  });
+
+  const familyDeleteMutation = useMutation({
+    mutationFn: (familyId: number) => deletePromptFamily(familyId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["promptFamilies"] });
+      setSelectedVersion(null);
+      setCompareVersion(null);
+      setPanelMode(null);
+    },
   });
 
   const setSelectedMutation = useMutation({
-    mutationFn: (versionId: number) => setSelectedVersion(projectId, versionId),
+    mutationFn: (versionId: number) => setSelectedIndependentPromptVersion(versionId),
     onSuccess: (updatedVersion) => {
-      void queryClient.invalidateQueries({ queryKey: ["promptVersions", projectId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["promptVersionsByFamily", selectedFamilyId],
+      });
+      setSelectedVersion(updatedVersion);
       setPanelMode({ type: "view", version: updatedVersion });
     },
   });
 
-  const tree = versions ? buildVersionTree(versions) : [];
-  const flatNodes = flattenTree(tree);
-  const verticalLinesPerNode = computeVerticalLines(flatNodes);
-
-  function handleSelectVersion(v: PromptVersion) {
-    setSelectedVersionState(v);
-    setPanelMode({ type: "view", version: v });
+  function handleProjectFilterChange(nextValue: string) {
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextValue) {
+      nextParams.set("project_id", nextValue);
+    } else {
+      nextParams.delete("project_id");
+    }
+    setSearchParams(nextParams);
   }
 
-  function handleBranch(v: PromptVersion) {
-    setBranchTarget(v);
+  function handleSelectFamily(familyId: number) {
+    setSelectedFamilyId(familyId);
+    setSelectedVersion(null);
+    setCompareVersion(null);
+    setPanelMode(null);
   }
 
-  function handleCompare(v: PromptVersion) {
-    if (compareVersion?.id === v.id) {
+  function handleSelectVersion(version: PromptVersion) {
+    setSelectedVersion(version);
+    setPanelMode({ type: "view", version });
+  }
+
+  function handleCompare(version: PromptVersion) {
+    if (compareVersion?.id === version.id) {
       setCompareVersion(null);
       return;
     }
-    if (selectedVersion && selectedVersion.id !== v.id) {
-      setCompareVersion(v);
-    } else {
-      setCompareVersion(v);
-    }
+    setCompareVersion(version);
   }
 
-  function handleOpenCompare() {
-    if (selectedVersion && compareVersion) {
-      setIsCompareOpen(true);
+  function handleFamilyDelete() {
+    if (!selectedFamily) {
+      return;
     }
+    familyDeleteMutation.mutate(selectedFamily.id);
   }
 
-  function handleBranchCreated(newVersion: PromptVersion) {
-    setBranchTarget(null);
-    setSelectedVersionState(newVersion);
-    setPanelMode({ type: "edit", version: newVersion });
-  }
+  const selectedProjectName = getProjectName(projects, selectedProjectId);
 
   return (
     <div className={`${styles.root} ${styles.page}`}>
-      {/* ページヘッダー */}
       <div className={styles.pageHeader}>
         <div>
           <h2 className={styles.pageTitle}>プロンプト管理</h2>
-          {project && <p className={styles.projectName}>{project.name}</p>}
+          <p className={styles.pageDescription}>
+            Prompt Family 単位で履歴を管理し、必要に応じてプロジェクトラベルで絞り込みます。
+          </p>
         </div>
         <div className={styles.pageActions}>
           {selectedVersion && compareVersion && (
-            <button type="button" onClick={handleOpenCompare} className={styles.btnBlue}>
+            <button type="button" onClick={() => setIsCompareOpen(true)} className={styles.btnBlue}>
               比較を表示
             </button>
           )}
           <button
             type="button"
-            onClick={() => {
-              setSelectedVersionState(null);
-              setPanelMode({ type: "new" });
-            }}
-            className={styles.btnPrimary}
+            onClick={() => setEditingFamily(null)}
+            className={styles.btnSecondary}
           >
-            + 新規作成
+            + ファミリー作成
+          </button>
+          <button
+            type="button"
+            onClick={() => setPanelMode({ type: "new" })}
+            disabled={!selectedFamily}
+            className={`${styles.btnPrimary} ${selectedFamily ? "" : styles.btnDisabled}`}
+          >
+            + 新規バージョン
           </button>
         </div>
       </div>
 
-      {/* 比較バー */}
+      <div className={styles.filterBar}>
+        <div className={styles.filterGroup}>
+          <label htmlFor="project-filter" className={styles.filterLabel}>
+            プロジェクトフィルタ
+          </label>
+          <select
+            id="project-filter"
+            value={selectedProjectId ?? ""}
+            onChange={(event) => handleProjectFilterChange(event.target.value)}
+            className={styles.filterSelect}
+          >
+            <option value="">すべてのプロジェクト</option>
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {selectedProjectName ? (
+          <p className={styles.filterHint}>
+            現在は <span className={styles.projectTag}>{selectedProjectName}</span> の付いた
+            バージョンだけを表示しています。
+          </p>
+        ) : (
+          <p className={styles.filterHint}>未分類を含む全バージョンを表示しています。</p>
+        )}
+      </div>
+
       {(selectedVersion || compareVersion) && (
         <div className={styles.compareBar}>
           <span className={styles.compareBarLabel}>選択中:</span>
           {selectedVersion && (
             <span className={styles.compareBarSelected}>
-              v{selectedVersion.version} {selectedVersion.name && `— ${selectedVersion.name}`}
+              v{selectedVersion.version} {selectedVersion.name ? `— ${selectedVersion.name}` : ""}
             </span>
           )}
           {compareVersion && (
             <>
               <span className={styles.compareBarVs}>vs</span>
               <span className={styles.compareBarComparing}>
-                v{compareVersion.version} {compareVersion.name && `— ${compareVersion.name}`}
+                v{compareVersion.version} {compareVersion.name ? `— ${compareVersion.name}` : ""}
               </span>
               <button
                 type="button"
@@ -879,54 +1084,129 @@ export function PromptsPage() {
         </div>
       )}
 
-      {/* メインコンテンツ */}
       <div className={styles.mainContent}>
-        {/* バージョンツリー */}
-        <div className={styles.treePanel}>
-          <div className={styles.treePanelLabel}>バージョン履歴</div>
+        <div className={styles.sidebarColumn}>
+          <section className={styles.familyPanel}>
+            <div className={styles.familyPanelHeader}>
+              <div className={styles.treePanelLabel}>Prompt Families</div>
+              <div className={styles.familyActions}>
+                <button
+                  type="button"
+                  onClick={() => selectedFamily && setEditingFamily(selectedFamily)}
+                  disabled={!selectedFamily}
+                  className={`${styles.btnMini} ${!selectedFamily ? styles.btnDisabled : ""}`}
+                >
+                  編集
+                </button>
+                <button
+                  type="button"
+                  onClick={handleFamilyDelete}
+                  disabled={!selectedFamily || familyDeleteMutation.isPending}
+                  className={`${styles.btnMiniDanger} ${!selectedFamily ? styles.btnDisabled : ""}`}
+                >
+                  削除
+                </button>
+              </div>
+            </div>
+            {isFamiliesLoading && <p className={styles.treeStatus}>読み込み中...</p>}
+            {isFamiliesError && (
+              <p className={styles.treeError}>ファミリー一覧の取得に失敗しました。</p>
+            )}
+            {!isFamiliesLoading && !isFamiliesError && families.length === 0 && (
+              <div className={styles.treeEmpty}>
+                ファミリーがありません
+                <span className={styles.treeEmptyHint}>
+                  まずは「ファミリー作成」から始めましょう
+                </span>
+              </div>
+            )}
+            <div className={styles.familyList}>
+              {families.map((family) => (
+                <button
+                  key={family.id}
+                  type="button"
+                  onClick={() => handleSelectFamily(family.id)}
+                  className={`${styles.familyCard} ${selectedFamilyId === family.id ? styles.familyCardSelected : ""}`}
+                >
+                  <span className={styles.familyName}>
+                    {family.name ?? `ファミリー ${family.id}`}
+                  </span>
+                  {family.description && (
+                    <span className={styles.familyDescription}>{family.description}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+            {familyDeleteMutation.isError && (
+              <p className={styles.errorMsg}>
+                ファミリーの削除に失敗しました。Run 参照が残っている可能性があります。
+              </p>
+            )}
+          </section>
 
-          {isLoading && <p className={styles.treeStatus}>読み込み中...</p>}
-          {isError && <p className={styles.treeError}>読み込みに失敗しました</p>}
+          <section className={styles.treePanel}>
+            <div className={styles.treePanelLabel}>バージョン履歴</div>
+            {selectedFamily && (
+              <p className={styles.treeFamilyName}>
+                {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`}
+              </p>
+            )}
 
-          {!isLoading && !isError && flatNodes.length === 0 && (
-            <div className={styles.treeEmpty}>
-              バージョンがありません
-              <br />
-              <span style={{ fontSize: "12px" }}>「新規作成」から始めましょう</span>
+            {!selectedFamily && <p className={styles.treeStatus}>ファミリーを選択してください。</p>}
+            {selectedFamily && isVersionsLoading && (
+              <p className={styles.treeStatus}>読み込み中...</p>
+            )}
+            {selectedFamily && isVersionsError && (
+              <p className={styles.treeError}>バージョン一覧の取得に失敗しました。</p>
+            )}
+            {selectedFamily && !isVersionsLoading && !isVersionsError && flatNodes.length === 0 && (
+              <div className={styles.treeEmpty}>
+                条件に合うバージョンがありません
+                <span className={styles.treeEmptyHint}>
+                  プロジェクトフィルタを変更するか、新規バージョンを作成してください
+                </span>
+              </div>
+            )}
+            <div className={styles.treeScroll}>
+              {flatNodes.map((node) => (
+                <VersionTreeItem
+                  key={node.version.id}
+                  node={node}
+                  isSelected={selectedVersion?.id === node.version.id}
+                  isComparing={compareVersion?.id === node.version.id}
+                  onSelect={handleSelectVersion}
+                  onBranch={(version) => setBranchTarget(version)}
+                  onCompare={handleCompare}
+                  projectName={getProjectName(projects, node.version.project_id)}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div className={styles.rightPanel}>
+          {panelMode === null && (
+            <div className={styles.panelEmpty}>
+              ファミリーを選択してバージョンを開くか、新規バージョンを作成してください
             </div>
           )}
 
-          <div className={styles.treeScroll}>
-            {flatNodes.map((node, i) => (
-              <VersionTreeItem
-                key={node.version.id}
-                node={node}
-                isSelected={selectedVersion?.id === node.version.id}
-                isComparing={compareVersion?.id === node.version.id}
-                onSelect={handleSelectVersion}
-                onBranch={handleBranch}
-                onCompare={handleCompare}
-                verticalLines={verticalLinesPerNode[i] ?? []}
-              />
-            ))}
-          </div>
-        </div>
-
-        {/* 右パネル */}
-        <div className={styles.rightPanel}>
-          {panelMode === null && (
-            <div className={styles.panelEmpty}>バージョンを選択するか、新規作成してください</div>
-          )}
-
-          {panelMode?.type === "new" && (
+          {panelMode?.type === "new" && selectedFamily && (
             <>
-              <div className={styles.panelHeaderTitle}>新規プロンプト作成</div>
+              <div className={styles.panelHeaderTitle}>
+                {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`} に新規追加
+              </div>
               <div className={styles.panelEditorBody}>
                 <PromptEditor
+                  familyId={selectedFamily.id}
+                  projects={projects}
                   version={null}
-                  projectId={projectId}
+                  defaultProjectId={selectedProjectId}
                   isNew={true}
-                  onSave={() => setPanelMode(null)}
+                  onSave={(version) => {
+                    setSelectedVersion(version);
+                    setPanelMode({ type: "view", version });
+                  }}
                   onCancel={() => setPanelMode(null)}
                 />
               </div>
@@ -964,23 +1244,46 @@ export function PromptsPage() {
                 </div>
               </div>
               <div className={styles.panelBody}>
+                {selectedFamily && (
+                  <div className={styles.familySummaryCard}>
+                    <span className={styles.familySummaryLabel}>Family</span>
+                    <strong className={styles.familySummaryName}>
+                      {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`}
+                    </strong>
+                    {selectedFamily.description && (
+                      <p className={styles.familySummaryDescription}>
+                        {selectedFamily.description}
+                      </p>
+                    )}
+                  </div>
+                )}
+                <div className={styles.versionMetaRow}>
+                  {panelMode.version.project_id !== null ? (
+                    <span className={styles.projectTag}>
+                      {getProjectName(projects, panelMode.version.project_id)}
+                    </span>
+                  ) : (
+                    <span className={styles.projectTagMuted}>未分類</span>
+                  )}
+                  <span className={styles.versionMeta}>
+                    作成日時: {formatDate(panelMode.version.created_at)}
+                  </span>
+                  {panelMode.version.parent_version_id !== null && (
+                    <span className={styles.badgeParentVersion}>
+                      v
+                      {familyVersions.find(
+                        (version) => version.id === panelMode.version.parent_version_id,
+                      )?.version ?? "?"}
+                      から分岐
+                    </span>
+                  )}
+                </div>
                 {panelMode.version.memo && (
                   <div className={styles.memoBox}>
                     <span className={styles.memoLabel}>メモ:</span>
                     {panelMode.version.memo}
                   </div>
                 )}
-                <div className={styles.versionMeta}>
-                  作成日時: {formatDate(panelMode.version.created_at)}
-                  {panelMode.version.parent_version_id !== null && (
-                    <span className={styles.badgeParentVersion}>
-                      v
-                      {versions?.find((v) => v.id === panelMode.version.parent_version_id)
-                        ?.version ?? "?"}
-                      から分岐
-                    </span>
-                  )}
-                </div>
                 <div className={styles.workflowPreviewLabel}>Step 1: プロンプト本文</div>
                 <pre className={styles.promptPre}>{panelMode.version.content}</pre>
                 {panelMode.version.workflow_definition?.steps.length ? (
@@ -1005,18 +1308,18 @@ export function PromptsPage() {
             </>
           )}
 
-          {panelMode?.type === "edit" && (
+          {panelMode?.type === "edit" && selectedFamily && (
             <>
               <div className={styles.panelHeaderTitle}>v{panelMode.version.version} を編集</div>
               <div className={styles.panelEditorBody}>
                 <PromptEditor
+                  familyId={selectedFamily.id}
+                  projects={projects}
                   version={panelMode.version}
-                  projectId={projectId}
-                  isNew={false}
-                  onSave={() => {
-                    // 編集完了後に最新データで表示モードに戻す
-                    setPanelMode(null);
-                    setSelectedVersionState(null);
+                  defaultProjectId={selectedProjectId}
+                  onSave={(version) => {
+                    setSelectedVersion(version);
+                    setPanelMode({ type: "view", version });
                   }}
                   onCancel={() => setPanelMode({ type: "view", version: panelMode.version })}
                 />
@@ -1026,17 +1329,34 @@ export function PromptsPage() {
         </div>
       </div>
 
-      {/* 分岐モーダル */}
-      {branchTarget && (
-        <BranchModal
-          parentVersion={branchTarget}
-          projectId={projectId}
-          onClose={() => setBranchTarget(null)}
-          onCreated={handleBranchCreated}
+      {editingFamily !== undefined && (
+        <FamilyModal
+          family={editingFamily}
+          onClose={() => setEditingFamily(undefined)}
+          onSubmit={(data) =>
+            familySaveMutation.mutate({
+              familyId: editingFamily?.id,
+              ...data,
+            })
+          }
+          isPending={familySaveMutation.isPending}
+          isError={familySaveMutation.isError}
         />
       )}
 
-      {/* 比較ビュー */}
+      {branchTarget && (
+        <BranchModal
+          parentVersion={branchTarget}
+          defaultProjectId={selectedProjectId}
+          onClose={() => setBranchTarget(null)}
+          onCreated={(newVersion) => {
+            setBranchTarget(null);
+            setSelectedVersion(newVersion);
+            setPanelMode({ type: "edit", version: newVersion });
+          }}
+        />
+      )}
+
       {isCompareOpen && selectedVersion && compareVersion && (
         <CompareView
           versionA={selectedVersion}


### PR DESCRIPTION
## 概要
- Prompts 画面を Prompt Family ベースの管理 UI に移行
- family 作成・編集・削除、version 作成・編集・分岐・Selected 切替を新 API に接続
- `/prompts` 導線と project フィルタ付き遷移を追加

## 変更理由
- Issue #122 の目的である Prompt Families / Prompt Versions 新 API を使う UI への差し替えが必要だったため
- 既存の project 前提 UI では family 単位の履歴管理と project ラベルによる絞り込みを表現できなかったため

## 影響
- プロンプト管理画面を project 配下だけでなく `/prompts` から直接開けるようになります
- Prompt Family 単位で version 履歴を確認しつつ、必要に応じて project ラベルで絞り込めます
- 既存のプロジェクト詳細からも project フィルタ付きで新画面へ遷移できます

## 確認
- `pnpm --filter @prompt-reviewer/ui typecheck`
- `pnpm build:local`
- `biome check packages/ui/src/pages/PromptsPage.tsx packages/ui/src/pages/PromptsPage.module.css packages/ui/src/App.tsx packages/ui/src/components/Layout.tsx packages/ui/src/pages/ProjectDetailPage.tsx`
