### PR TITLE
ContextAssetsPage を追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,8 @@ schema: [
 
 ### 1. 前準備（Worktree作成前）
 - 現在のブランチがmasterでなければ、masterブランチをチェックアウトしてください。
-  - **すでにworktreeに配置されている場合**: `git checkout -b issue-番号-内容 master` でworktree内にissueブランチを作成してください。
-- リモートの最新のmasterブランチをpullしてください。
+- **必ず** `git fetch origin && git pull origin master`（またはworktree内では `git fetch origin master`）でリモートの最新masterを取得してから作業を開始してください。ローカルのmasterが古いままブランチを切ると、マージ済みの変更が欠落します。
+  - **すでにworktreeに配置されている場合**: `git fetch origin master` でリモートを最新化した上で、`git checkout -b issue-番号-内容 origin/master` でworktree内にissueブランチを作成してください（`master` ではなく `origin/master` を起点にすること）。
 - 最新のmasterブランチからIssueに対応するブランチを作成してください。ブランチ名は `issue-番号-内容` の形式にしてください（例: `issue-118-runs-api-migration`）。
 
 ### 2. Worktree作成と環境構築

--- a/packages/server/src/routes/context-assets.test.ts
+++ b/packages/server/src/routes/context-assets.test.ts
@@ -21,6 +21,7 @@ type MockContextAsset = {
 };
 
 type MockContextAssetSummary = Omit<MockContextAsset, "content">;
+type MockContextAssetDetail = MockContextAsset & { project_ids: number[] };
 
 function buildApp(db: unknown) {
   const app = new Hono();
@@ -47,6 +48,11 @@ const sampleAssetSummary: MockContextAssetSummary = {
   content_hash: "sha256:old",
   created_at: 1000000,
   updated_at: 1000000,
+};
+
+const sampleAssetDetail: MockContextAssetDetail = {
+  ...sampleAsset,
+  project_ids: [],
 };
 
 describe("GET /api/context-assets", () => {
@@ -233,6 +239,11 @@ describe("POST /api/context-assets", () => {
     let capturedValues: Record<string, unknown> = {};
 
     const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
       insert: () => ({
         values: (values: Record<string, unknown>) => {
           capturedValues = values;
@@ -255,6 +266,7 @@ describe("POST /api/context-assets", () => {
     });
 
     expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual(sampleAssetDetail);
     expect(capturedValues.name).toBe(sampleAsset.name);
     expect(capturedValues.path).toBe(sampleAsset.path);
     expect(capturedValues.mime_type).toBe(sampleAsset.mime_type);
@@ -279,10 +291,14 @@ describe("POST /api/context-assets", () => {
 
 describe("GET /api/context-assets/:id", () => {
   it("詳細を返す", async () => {
+    let selectCallCount = 0;
     const db = {
       select: () => ({
         from: () => ({
-          where: () => Promise.resolve([sampleAsset]),
+          where: () => {
+            selectCallCount++;
+            return Promise.resolve(selectCallCount === 1 ? [sampleAsset] : []);
+          },
         }),
       }),
     };
@@ -290,7 +306,7 @@ describe("GET /api/context-assets/:id", () => {
     const res = await buildApp(db).request("/api/context-assets/1");
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual(sampleAsset);
+    await expect(res.json()).resolves.toEqual(sampleAssetDetail);
   });
 
   it("見つからない場合は 404 を返す", async () => {
@@ -313,11 +329,15 @@ describe("PATCH /api/context-assets/:id", () => {
   it("更新して 200 を返す", async () => {
     const updated = { ...sampleAsset, name: "refund-policy-v2.md", updated_at: 2000000 };
     let capturedValues: Record<string, unknown> = {};
+    let selectCallCount = 0;
 
     const db = {
       select: () => ({
         from: () => ({
-          where: () => Promise.resolve([sampleAsset]),
+          where: () => {
+            selectCallCount++;
+            return Promise.resolve(selectCallCount === 1 ? [sampleAsset] : []);
+          },
         }),
       }),
       update: () => ({
@@ -339,6 +359,10 @@ describe("PATCH /api/context-assets/:id", () => {
     });
 
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ...updated,
+      project_ids: [],
+    });
     expect(capturedValues.name).toBe("refund-policy-v2.md");
     expect(capturedValues.content).toBe("更新後本文");
     expect(typeof capturedValues.content_hash).toBe("string");
@@ -396,7 +420,10 @@ describe("PUT /api/context-assets/:id/projects", () => {
             if (selectCallCount === 1) {
               return Promise.resolve([sampleAsset]);
             }
-            return Promise.resolve([{ id: 10 }]);
+            if (selectCallCount <= 3) {
+              return Promise.resolve([{ id: 10 }]);
+            }
+            return Promise.resolve([{ project_id: 10 }, { project_id: 11 }]);
           },
         }),
       }),
@@ -421,6 +448,10 @@ describe("PUT /api/context-assets/:id/projects", () => {
     });
 
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ...sampleAsset,
+      project_ids: [10, 11],
+    });
     expect(deleteCalled).toBe(true);
     expect(inserted).toHaveLength(2);
     expect(inserted[0]).toMatchObject({ context_asset_id: 1, project_id: 10 });

--- a/packages/server/src/routes/context-assets.ts
+++ b/packages/server/src/routes/context-assets.ts
@@ -36,6 +36,9 @@ const updateContextAssetProjectsSchema = z.object({
 
 type ContextAssetRecord = typeof context_assets.$inferSelect;
 type ContextAssetSummary = Omit<ContextAssetRecord, "content">;
+type ContextAssetDetail = ContextAssetRecord & {
+  project_ids: number[];
+};
 
 function parseIdParam(value: string): number | null {
   const parsed = Number(value);
@@ -117,6 +120,24 @@ function serializeContextAssetSummary(asset: ContextAssetRecord): ContextAssetSu
   return summary;
 }
 
+async function getProjectIdsByAssetId(db: DB, assetId: number): Promise<number[]> {
+  const links = await db
+    .select({ project_id: context_asset_projects.project_id })
+    .from(context_asset_projects)
+    .where(eq(context_asset_projects.context_asset_id, assetId));
+  return links.map((link) => link.project_id).sort((a, b) => a - b);
+}
+
+async function serializeContextAssetDetail(
+  db: DB,
+  asset: ContextAssetRecord,
+): Promise<ContextAssetDetail> {
+  return {
+    ...asset,
+    project_ids: await getProjectIdsByAssetId(db, asset.id),
+  };
+}
+
 export function createContextAssetsRouter(db: DB) {
   const router = new Hono();
 
@@ -195,7 +216,7 @@ export function createContextAssetsRouter(db: DB) {
       return c.json({ error: "Failed to create ContextAsset" }, 500);
     }
 
-    return c.json(created, 201);
+    return c.json(await serializeContextAssetDetail(db, created), 201);
   });
 
   router.get("/:id", async (c) => {
@@ -209,7 +230,7 @@ export function createContextAssetsRouter(db: DB) {
       return c.json({ error: "ContextAsset not found" }, 404);
     }
 
-    return c.json(asset);
+    return c.json(await serializeContextAssetDetail(db, asset));
   });
 
   router.patch("/:id", zValidator("json", updateContextAssetSchema), async (c) => {
@@ -254,7 +275,7 @@ export function createContextAssetsRouter(db: DB) {
       return c.json({ error: "Failed to update ContextAsset" }, 500);
     }
 
-    return c.json(updated);
+    return c.json(await serializeContextAssetDetail(db, updated));
   });
 
   router.delete("/:id", async (c) => {
@@ -311,7 +332,7 @@ export function createContextAssetsRouter(db: DB) {
       });
     }
 
-    return c.json(existing);
+    return c.json(await serializeContextAssetDetail(db, existing));
   });
 
   return router;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 import { Layout } from "./components/Layout";
 import { AnnotationReviewPage } from "./pages/AnnotationReviewPage";
 import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
+import { ContextAssetsPage } from "./pages/ContextAssetsPage";
 import { ContextFilesPage } from "./pages/ContextFilesPage";
 import { ExecutionProfilesPage } from "./pages/ExecutionProfilesPage";
 import { HealthPage } from "./pages/HealthPage";
@@ -46,6 +47,7 @@ export function App() {
             <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
             <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             <Route path="execution-profiles" element={<ExecutionProfilesPage />} />
+            <Route path="context-assets" element={<ContextAssetsPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />
             {/* 404 */}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -82,6 +82,7 @@ function SidebarNav() {
   const topNavItems = [
     { to: "/", label: "プロジェクト一覧", end: true },
     { to: "/prompts", label: "プロンプト", end: false },
+    { to: "/context-assets", label: "コンテキスト素材", end: false },
     { to: "/execution-profiles", label: "実行設定", end: false },
     { to: "/health", label: "ヘルスチェック", end: false },
   ];

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -850,6 +850,7 @@ export type ContextAssetSummary = {
 
 export type ContextAssetDetail = ContextAssetSummary & {
   content: string;
+  project_ids: number[];
 };
 
 export type ContextAssetFilters = {

--- a/packages/ui/src/pages/ContextAssetsPage.module.css
+++ b/packages/ui/src/pages/ContextAssetsPage.module.css
@@ -21,10 +21,31 @@
   font-size: 14px;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fileInput {
+  display: none;
+}
+
 .btnPrimary {
   composes: btnPrimary from '../styles/shared.module.css';
   padding: 9px 16px;
   font-size: 13px;
+}
+
+.btnSecondary {
+  padding: 9px 16px;
+  font-size: 13px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  cursor: pointer;
+  font-family: inherit;
 }
 
 .btnSave {

--- a/packages/ui/src/pages/ContextAssetsPage.module.css
+++ b/packages/ui/src/pages/ContextAssetsPage.module.css
@@ -1,0 +1,424 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.pageHeader {
+  composes: pageHeader from '../styles/shared.module.css';
+  margin-bottom: 12px;
+  gap: 16px;
+}
+
+.pageTitle {
+  composes: pageTitle from '../styles/shared.module.css';
+  margin: 0 0 4px;
+}
+
+.pageDescription {
+  margin: 0;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+.btnPrimary {
+  composes: btnPrimary from '../styles/shared.module.css';
+  padding: 9px 16px;
+  font-size: 13px;
+}
+
+.btnSave {
+  composes: btnPrimary from '../styles/shared.module.css';
+  padding: 8px 16px;
+  font-size: 13px;
+}
+
+.btnDisabled {
+  composes: btnDisabled from '../styles/shared.module.css';
+}
+
+.btnDanger {
+  padding: 8px 14px;
+  font-size: 13px;
+  background: transparent;
+  border: 1px solid var(--c-danger);
+  border-radius: 6px;
+  color: var(--c-danger);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btnDanger:hover {
+  background: rgba(243, 139, 168, 0.1);
+}
+
+.btnCancel {
+  padding: 8px 14px;
+  font-size: 13px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  cursor: pointer;
+}
+
+.statusMessage {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: rgba(166, 227, 161, 0.12);
+  border: 1px solid rgba(166, 227, 161, 0.25);
+  border-radius: 8px;
+  color: var(--c-green);
+  font-size: 13px;
+}
+
+.createForm {
+  margin-bottom: 16px;
+  padding: 16px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.createFormRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.createFormLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--c-subtext);
+}
+
+.createFormActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.textInput {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-text);
+  font-size: 13px;
+  outline: none;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.textInput:focus {
+  border-color: var(--c-accent);
+}
+
+.textareaInput {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-text);
+  font-size: 13px;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: monospace;
+}
+
+.textareaInput:focus {
+  border-color: var(--c-accent);
+}
+
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.filterBar .textInput {
+  width: 240px;
+  flex-shrink: 0;
+}
+
+.filterToggle {
+  padding: 6px 12px;
+  font-size: 12px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.filterToggleActive {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+  background: rgba(203, 166, 247, 0.1);
+}
+
+.projectFilterList {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.projectBadge {
+  composes: badge from '../styles/shared.module.css';
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--c-subtext);
+  cursor: pointer;
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+}
+
+.projectBadgeActive {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+  background: rgba(203, 166, 247, 0.1);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.sidebar,
+.viewerPanel {
+  min-height: 0;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.panelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.panelTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-text);
+  word-break: break-word;
+}
+
+.panelSubtitle {
+  margin: 4px 0 0;
+  color: var(--c-muted);
+  font-size: 12px;
+}
+
+.panelActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.badge {
+  composes: badge from '../styles/shared.module.css';
+  color: var(--c-subtext);
+}
+
+.panelStatus,
+.panelError {
+  margin: 0;
+  padding: 14px 16px;
+  font-size: 13px;
+}
+
+.panelStatus {
+  color: var(--c-muted);
+}
+
+.panelError,
+.emptyViewerError {
+  color: var(--c-danger);
+}
+
+.emptyState,
+.emptyViewer,
+.emptyViewerError {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  text-align: center;
+  color: var(--c-muted);
+  font-size: 14px;
+}
+
+.fileList {
+  flex: 1;
+  overflow: auto;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fileItem {
+  width: 100%;
+  border: 1px solid var(--c-border);
+  background: var(--c-overlay);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--c-text);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.fileItemActive {
+  border-color: var(--c-accent);
+  background: rgba(203, 166, 247, 0.12);
+}
+
+.fileName {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.filePath,
+.fileMeta {
+  font-size: 12px;
+  color: var(--c-muted);
+  word-break: break-word;
+}
+
+.detailMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.detailMetaRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.metaLabel {
+  font-size: 12px;
+  color: var(--c-subtext);
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.deleteConfirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.deleteConfirmText {
+  font-size: 13px;
+  color: var(--c-danger);
+  white-space: nowrap;
+}
+
+.projectAssignSection {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.projectAssignTitle {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--c-subtext);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.projectAssignList {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.noProjects {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
+.editorArea {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
+
+:global(.cm-theme) {
+  flex: 1;
+  min-height: 0;
+}
+
+:global(.cm-editor) {
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  font-size: 13px;
+  overflow: hidden;
+}
+
+:global(.cm-scroller) {
+  font-family: Consolas, "SFMono-Regular", Monaco, monospace;
+  height: 100%;
+  overflow: auto !important;
+  scrollbar-gutter: stable;
+}
+
+:global(.cm-content),
+:global(.cm-gutter) {
+  min-height: 100%;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    max-height: 280px;
+  }
+
+  .editorArea {
+    min-height: 55vh;
+  }
+
+  .createFormRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -1,0 +1,532 @@
+import { css } from "@codemirror/lang-css";
+import { html } from "@codemirror/lang-html";
+import { javascript } from "@codemirror/lang-javascript";
+import { json } from "@codemirror/lang-json";
+import { markdown } from "@codemirror/lang-markdown";
+import { python } from "@codemirror/lang-python";
+import { sql } from "@codemirror/lang-sql";
+import { EditorView } from "@codemirror/view";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import CodeMirror from "@uiw/react-codemirror";
+import { useEffect, useState } from "react";
+import {
+  type ContextAssetDetail,
+  type ContextAssetFilters,
+  type ContextAssetSummary,
+  type Project,
+  createContextAsset,
+  deleteContextAsset,
+  getContextAsset,
+  getContextAssets,
+  getProjects,
+  setContextAssetProjects,
+  updateContextAsset,
+} from "../lib/api";
+import styles from "./ContextAssetsPage.module.css";
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getLanguageExtensions(filePath: string) {
+  const lowerPath = filePath.toLowerCase();
+  const baseExtensions = [EditorView.lineWrapping];
+  if (
+    lowerPath.endsWith(".ts") ||
+    lowerPath.endsWith(".tsx") ||
+    lowerPath.endsWith(".js") ||
+    lowerPath.endsWith(".jsx")
+  ) {
+    return [
+      ...baseExtensions,
+      javascript({
+        jsx: lowerPath.endsWith("x"),
+        typescript: lowerPath.endsWith(".ts") || lowerPath.endsWith(".tsx"),
+      }),
+    ];
+  }
+  if (lowerPath.endsWith(".json")) return [...baseExtensions, json()];
+  if (lowerPath.endsWith(".md")) return [...baseExtensions, markdown()];
+  if (lowerPath.endsWith(".py")) return [...baseExtensions, python()];
+  if (lowerPath.endsWith(".sql")) return [...baseExtensions, sql()];
+  if (lowerPath.endsWith(".css")) return [...baseExtensions, css()];
+  if (lowerPath.endsWith(".html")) return [...baseExtensions, html()];
+  return baseExtensions;
+}
+
+type CreateFormState = {
+  name: string;
+  path: string;
+  content: string;
+  mime_type: string;
+};
+
+const EMPTY_CREATE_FORM: CreateFormState = {
+  name: "",
+  path: "",
+  content: "",
+  mime_type: "text/plain",
+};
+
+export function ContextAssetsPage() {
+  const queryClient = useQueryClient();
+
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [draftContent, setDraftContent] = useState("");
+  const [draftName, setDraftName] = useState("");
+  const [draftPath, setDraftPath] = useState("");
+  const [draftMimeType, setDraftMimeType] = useState("");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createForm, setCreateForm] = useState<CreateFormState>(EMPTY_CREATE_FORM);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
+  const [filters, setFilters] = useState<ContextAssetFilters>({});
+  const [searchInput, setSearchInput] = useState("");
+  const [selectedProjectIds, setSelectedProjectIds] = useState<number[]>([]);
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects"],
+    queryFn: getProjects,
+  });
+
+  const assetsQuery = useQuery({
+    queryKey: ["context-assets", filters],
+    queryFn: () => getContextAssets(filters),
+  });
+
+  const selectedDetailQuery = useQuery({
+    queryKey: ["context-asset", selectedId],
+    queryFn: () => {
+      if (selectedId === null) throw new Error("id is required");
+      return getContextAsset(selectedId);
+    },
+    enabled: selectedId !== null,
+  });
+
+  useEffect(() => {
+    const assets = assetsQuery.data ?? [];
+    if (assets.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !assets.some((a) => a.id === selectedId)) {
+      setSelectedId(assets[0]?.id ?? null);
+    }
+  }, [assetsQuery.data, selectedId]);
+
+  useEffect(() => {
+    const detail = selectedDetailQuery.data;
+    if (detail) {
+      setDraftContent(detail.content);
+      setDraftName(detail.name);
+      setDraftPath(detail.path);
+      setDraftMimeType(detail.mime_type);
+    }
+  }, [selectedDetailQuery.data]);
+
+  useEffect(() => {
+    if (selectedId !== null && selectedDetailQuery.data) {
+      const asset = assetsQuery.data?.find((a) => a.id === selectedId);
+      if (!asset) return;
+      // project assignment は detail にないため projects query の情報は使えない
+      // setContextAssetProjects 後の invalidate で再取得される
+    }
+  }, [selectedId, selectedDetailQuery.data, assetsQuery.data]);
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createContextAsset({
+        name: createForm.name,
+        path: createForm.path,
+        content: createForm.content,
+        mime_type: createForm.mime_type,
+      }),
+    onSuccess: (created) => {
+      setStatusMessage(`作成しました: ${created.name}`);
+      setShowCreateForm(false);
+      setCreateForm(EMPTY_CREATE_FORM);
+      void queryClient.invalidateQueries({ queryKey: ["context-assets"] });
+      setSelectedId(created.id);
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      if (selectedId === null) throw new Error("selectedId is required");
+      return updateContextAsset(selectedId, {
+        content: draftContent,
+        name: draftName,
+        path: draftPath,
+        mime_type: draftMimeType,
+      });
+    },
+    onSuccess: (updated) => {
+      setStatusMessage(`保存しました: ${updated.name}`);
+      void queryClient.invalidateQueries({ queryKey: ["context-assets"] });
+      void queryClient.invalidateQueries({ queryKey: ["context-asset", selectedId] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteContextAsset(id),
+    onSuccess: () => {
+      setStatusMessage("削除しました");
+      setDeleteConfirmId(null);
+      void queryClient.invalidateQueries({ queryKey: ["context-assets"] });
+      setSelectedId(null);
+    },
+  });
+
+  const setProjectsMutation = useMutation({
+    mutationFn: (projectIds: number[]) => {
+      if (selectedId === null) throw new Error("selectedId is required");
+      return setContextAssetProjects(selectedId, { project_ids: projectIds });
+    },
+    onSuccess: () => {
+      setStatusMessage("プロジェクト割り当てを更新しました");
+      void queryClient.invalidateQueries({ queryKey: ["context-asset", selectedId] });
+    },
+  });
+
+  const selectedDetail: ContextAssetDetail | undefined = selectedDetailQuery.data;
+  const selectedSummary: ContextAssetSummary | undefined = (assetsQuery.data ?? []).find(
+    (a) => a.id === selectedId,
+  );
+
+  const isDetailDirty =
+    selectedDetail !== undefined &&
+    (draftContent !== selectedDetail.content ||
+      draftName !== selectedDetail.name ||
+      draftPath !== selectedDetail.path ||
+      draftMimeType !== selectedDetail.mime_type);
+
+  function handleSearchKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      setFilters((prev) => ({ ...prev, q: searchInput || undefined }));
+    }
+  }
+
+  function handleProjectFilterChange(projectId: number) {
+    setFilters((prev) => ({
+      ...prev,
+      project_id: prev.project_id === projectId ? undefined : projectId,
+    }));
+  }
+
+  function handleUnclassifiedToggle() {
+    setFilters((prev) => ({
+      ...prev,
+      unclassified: prev.unclassified ? undefined : true,
+    }));
+  }
+
+  function handleProjectAssignToggle(projectId: number) {
+    const next = selectedProjectIds.includes(projectId)
+      ? selectedProjectIds.filter((id) => id !== projectId)
+      : [...selectedProjectIds, projectId];
+    setSelectedProjectIds(next);
+    setProjectsMutation.mutate(next);
+  }
+
+  function handleSelectAsset(id: number) {
+    setStatusMessage(null);
+    setDeleteConfirmId(null);
+    setSelectedId(id);
+    setSelectedProjectIds([]);
+  }
+
+  const projects: Project[] = projectsQuery.data ?? [];
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.pageHeader}>
+        <div>
+          <h2 className={styles.pageTitle}>コンテキスト素材</h2>
+          <p className={styles.pageDescription}>グローバルなコンテキスト素材を管理します。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setShowCreateForm((v) => !v);
+            setStatusMessage(null);
+          }}
+          className={styles.btnPrimary}
+        >
+          {showCreateForm ? "キャンセル" : "新規作成"}
+        </button>
+      </div>
+
+      {statusMessage && <p className={styles.statusMessage}>{statusMessage}</p>}
+
+      {showCreateForm && (
+        <div className={styles.createForm}>
+          <div className={styles.createFormRow}>
+            <label className={styles.createFormLabel}>
+              名前
+              <input
+                type="text"
+                className={styles.textInput}
+                value={createForm.name}
+                onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                placeholder="例: system-prompt.md"
+              />
+            </label>
+            <label className={styles.createFormLabel}>
+              パス
+              <input
+                type="text"
+                className={styles.textInput}
+                value={createForm.path}
+                onChange={(e) => setCreateForm((f) => ({ ...f, path: e.target.value }))}
+                placeholder="例: docs/system-prompt.md"
+              />
+            </label>
+            <label className={styles.createFormLabel}>
+              MIMEタイプ
+              <input
+                type="text"
+                className={styles.textInput}
+                value={createForm.mime_type}
+                onChange={(e) => setCreateForm((f) => ({ ...f, mime_type: e.target.value }))}
+                placeholder="例: text/plain"
+              />
+            </label>
+          </div>
+          <label className={styles.createFormLabel}>
+            内容
+            <textarea
+              className={styles.textareaInput}
+              rows={6}
+              value={createForm.content}
+              onChange={(e) => setCreateForm((f) => ({ ...f, content: e.target.value }))}
+              placeholder="素材の内容を入力してください"
+            />
+          </label>
+          <div className={styles.createFormActions}>
+            <button
+              type="button"
+              onClick={() => createMutation.mutate()}
+              disabled={!createForm.name || !createForm.path || createMutation.isPending}
+              className={`${styles.btnPrimary} ${!createForm.name || !createForm.path || createMutation.isPending ? styles.btnDisabled : ""}`}
+            >
+              {createMutation.isPending ? "作成中..." : "作成"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.filterBar}>
+        <input
+          type="text"
+          className={styles.textInput}
+          placeholder="名前・パスで検索（Enter で確定）"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
+        />
+        <button
+          type="button"
+          onClick={handleUnclassifiedToggle}
+          className={`${styles.filterToggle} ${filters.unclassified ? styles.filterToggleActive : ""}`}
+        >
+          未分類のみ
+        </button>
+        <div className={styles.projectFilterList}>
+          {projects.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => handleProjectFilterChange(p.id)}
+              className={`${styles.projectBadge} ${filters.project_id === p.id ? styles.projectBadgeActive : ""}`}
+            >
+              {p.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.layout}>
+        <section className={styles.sidebar}>
+          <div className={styles.panelHeader}>
+            <span className={styles.panelTitle}>素材一覧</span>
+            <span className={styles.badge}>{assetsQuery.data?.length ?? 0} 件</span>
+          </div>
+          {assetsQuery.isLoading && <p className={styles.panelStatus}>読み込み中...</p>}
+          {assetsQuery.isError && <p className={styles.panelError}>一覧の取得に失敗しました。</p>}
+          {!assetsQuery.isLoading &&
+            !assetsQuery.isError &&
+            (assetsQuery.data?.length ?? 0) === 0 && (
+              <div className={styles.emptyState}>
+                素材がありません。
+                <br />
+                上部の「新規作成」から追加してください。
+              </div>
+            )}
+          <div className={styles.fileList}>
+            {(assetsQuery.data ?? []).map((asset) => (
+              <button
+                key={asset.id}
+                type="button"
+                onClick={() => handleSelectAsset(asset.id)}
+                className={`${styles.fileItem} ${selectedId === asset.id ? styles.fileItemActive : ""}`}
+              >
+                <span className={styles.fileName}>{asset.name}</span>
+                <span className={styles.filePath}>{asset.path}</span>
+                <span className={styles.fileMeta}>
+                  {asset.mime_type} / {formatDate(asset.updated_at)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.viewerPanel}>
+          {!selectedId && <div className={styles.emptyViewer}>左から素材を選択してください。</div>}
+
+          {selectedId && selectedDetailQuery.isLoading && (
+            <div className={styles.emptyViewer}>内容を読み込み中...</div>
+          )}
+
+          {selectedId && selectedDetailQuery.isError && (
+            <div className={styles.emptyViewerError}>内容の読み込みに失敗しました。</div>
+          )}
+
+          {selectedId && selectedDetail && (
+            <>
+              <div className={styles.panelHeader}>
+                <div className={styles.detailMeta}>
+                  <div className={styles.detailMetaRow}>
+                    <label htmlFor="detail-name" className={styles.metaLabel}>
+                      名前
+                    </label>
+                    <input
+                      id="detail-name"
+                      type="text"
+                      className={styles.textInput}
+                      value={draftName}
+                      onChange={(e) => setDraftName(e.target.value)}
+                    />
+                  </div>
+                  <div className={styles.detailMetaRow}>
+                    <label htmlFor="detail-path" className={styles.metaLabel}>
+                      パス
+                    </label>
+                    <input
+                      id="detail-path"
+                      type="text"
+                      className={styles.textInput}
+                      value={draftPath}
+                      onChange={(e) => setDraftPath(e.target.value)}
+                    />
+                  </div>
+                  <div className={styles.detailMetaRow}>
+                    <label htmlFor="detail-mime" className={styles.metaLabel}>
+                      MIMEタイプ
+                    </label>
+                    <input
+                      id="detail-mime"
+                      type="text"
+                      className={styles.textInput}
+                      value={draftMimeType}
+                      onChange={(e) => setDraftMimeType(e.target.value)}
+                    />
+                  </div>
+                  {selectedSummary && (
+                    <p className={styles.panelSubtitle}>
+                      {formatBytes(selectedSummary.content_hash.length)} / 更新:{" "}
+                      {formatDate(selectedSummary.updated_at)}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.panelActions}>
+                  <button
+                    type="button"
+                    onClick={() => saveMutation.mutate()}
+                    disabled={!isDetailDirty || saveMutation.isPending}
+                    className={`${styles.btnSave} ${!isDetailDirty || saveMutation.isPending ? styles.btnDisabled : ""}`}
+                  >
+                    {saveMutation.isPending ? "保存中..." : "保存"}
+                  </button>
+                  {deleteConfirmId === selectedId ? (
+                    <div className={styles.deleteConfirm}>
+                      <span className={styles.deleteConfirmText}>本当に削除しますか？</span>
+                      <button
+                        type="button"
+                        onClick={() => deleteMutation.mutate(selectedId)}
+                        disabled={deleteMutation.isPending}
+                        className={styles.btnDanger}
+                      >
+                        {deleteMutation.isPending ? "削除中..." : "削除"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteConfirmId(null)}
+                        className={styles.btnCancel}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setDeleteConfirmId(selectedId)}
+                      className={styles.btnDanger}
+                    >
+                      削除
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className={styles.projectAssignSection}>
+                <p className={styles.projectAssignTitle}>プロジェクト割り当て</p>
+                <div className={styles.projectAssignList}>
+                  {projects.length === 0 && (
+                    <span className={styles.noProjects}>プロジェクトがありません</span>
+                  )}
+                  {projects.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => handleProjectAssignToggle(p.id)}
+                      className={`${styles.projectBadge} ${selectedProjectIds.includes(p.id) ? styles.projectBadgeActive : ""}`}
+                    >
+                      {p.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className={styles.editorArea}>
+                <CodeMirror
+                  value={draftContent}
+                  height="100%"
+                  theme="dark"
+                  extensions={getLanguageExtensions(draftPath)}
+                  onChange={(value) => setDraftContent(value)}
+                  basicSetup={{
+                    lineNumbers: true,
+                    highlightActiveLine: true,
+                    foldGutter: true,
+                  }}
+                />
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -40,6 +40,10 @@ function formatBytes(size: number): string {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function getContentSize(content: string): number {
+  return new TextEncoder().encode(content).length;
+}
+
 function getLanguageExtensions(filePath: string) {
   const lowerPath = filePath.toLowerCase();
   const baseExtensions = [EditorView.lineWrapping];
@@ -134,6 +138,7 @@ export function ContextAssetsPage() {
       setDraftName(detail.name);
       setDraftPath(detail.path);
       setDraftMimeType(detail.mime_type);
+      setSelectedProjectIds(detail.project_ids);
     }
   }, [selectedDetailQuery.data]);
 
@@ -253,7 +258,6 @@ export function ContextAssetsPage() {
     setStatusMessage(null);
     setDeleteConfirmId(null);
     setSelectedId(id);
-    setSelectedProjectIds([]);
   }
 
   async function handleFileSelection(event: React.ChangeEvent<HTMLInputElement>) {
@@ -484,7 +488,7 @@ export function ContextAssetsPage() {
                   </div>
                   {selectedSummary && (
                     <p className={styles.panelSubtitle}>
-                      {formatBytes(selectedSummary.content_hash.length)} / 更新:{" "}
+                      {formatBytes(getContentSize(selectedDetail.content))} / 更新:{" "}
                       {formatDate(selectedSummary.updated_at)}
                     </p>
                   )}

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -8,7 +8,7 @@ import { sql } from "@codemirror/lang-sql";
 import { EditorView } from "@codemirror/view";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import CodeMirror from "@uiw/react-codemirror";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   type ContextAssetDetail,
   type ContextAssetFilters,
@@ -82,6 +82,7 @@ const EMPTY_CREATE_FORM: CreateFormState = {
 
 export function ContextAssetsPage() {
   const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [draftContent, setDraftContent] = useState("");
@@ -136,14 +137,22 @@ export function ContextAssetsPage() {
     }
   }, [selectedDetailQuery.data]);
 
-  useEffect(() => {
-    if (selectedId !== null && selectedDetailQuery.data) {
-      const asset = assetsQuery.data?.find((a) => a.id === selectedId);
-      if (!asset) return;
-      // project assignment は detail にないため projects query の情報は使えない
-      // setContextAssetProjects 後の invalidate で再取得される
-    }
-  }, [selectedId, selectedDetailQuery.data, assetsQuery.data]);
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const content = await file.text();
+      return createContextAsset({
+        name: file.name,
+        path: file.webkitRelativePath || file.name,
+        content,
+        mime_type: file.type || "text/plain",
+      });
+    },
+    onSuccess: (created) => {
+      setStatusMessage(`取り込みました: ${created.name}`);
+      void queryClient.invalidateQueries({ queryKey: ["context-assets"] });
+      setSelectedId(created.id);
+    },
+  });
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -247,6 +256,16 @@ export function ContextAssetsPage() {
     setSelectedProjectIds([]);
   }
 
+  async function handleFileSelection(event: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) return;
+    setStatusMessage(null);
+    const results = await Promise.all(files.map((f) => uploadMutation.mutateAsync(f)));
+    const last = results[results.length - 1];
+    if (last) setSelectedId(last.id);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
   const projects: Project[] = projectsQuery.data ?? [];
 
   return (
@@ -256,16 +275,36 @@ export function ContextAssetsPage() {
           <h2 className={styles.pageTitle}>コンテキスト素材</h2>
           <p className={styles.pageDescription}>グローバルなコンテキスト素材を管理します。</p>
         </div>
-        <button
-          type="button"
-          onClick={() => {
-            setShowCreateForm((v) => !v);
-            setStatusMessage(null);
-          }}
-          className={styles.btnPrimary}
-        >
-          {showCreateForm ? "キャンセル" : "新規作成"}
-        </button>
+        <div className={styles.headerActions}>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".txt,.md,.json,.ts,.tsx,.js,.jsx,.py,.sql,.css,.html,.yml,.yaml"
+            multiple
+            className={styles.fileInput}
+            onChange={(e) => {
+              void handleFileSelection(e);
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className={styles.btnPrimary}
+            disabled={uploadMutation.isPending}
+          >
+            {uploadMutation.isPending ? "取込中..." : "ファイルを取り込む"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowCreateForm((v) => !v);
+              setStatusMessage(null);
+            }}
+            className={styles.btnSecondary}
+          >
+            {showCreateForm ? "キャンセル" : "テキストで作成"}
+          </button>
+        </div>
       </div>
 
       {statusMessage && <p className={styles.statusMessage}>{statusMessage}</p>}

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -6,8 +6,8 @@ import {
   type Turn,
   createTestCase,
   deleteTestCase,
-  getContextFile,
-  getContextFiles,
+  getContextAsset,
+  getContextAssets,
   getTestCases,
   updateTestCase,
 } from "../lib/api";
@@ -162,34 +162,33 @@ type TestCaseModalProps = {
 
 function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: TestCaseModalProps) {
   const [formData, setFormData] = useState<TestCaseFormData>(() => getInitialFormData(testCase));
-  const [selectedContextFilePath, setSelectedContextFilePath] = useState("");
+  const [selectedContextAssetId, setSelectedContextAssetId] = useState<number | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
   const isEdit = !!testCase;
 
-  const contextFilesQuery = useQuery({
-    queryKey: ["context-files", projectId],
-    queryFn: () => getContextFiles(projectId),
+  const contextAssetsQuery = useQuery({
+    queryKey: ["context-assets", { project_id: projectId }],
+    queryFn: () => getContextAssets({ project_id: projectId }),
     enabled: !Number.isNaN(projectId),
   });
 
   useEffect(() => {
-    const files = contextFilesQuery.data ?? [];
-    if (files.length === 0) {
-      setSelectedContextFilePath("");
+    const assets = contextAssetsQuery.data ?? [];
+    if (assets.length === 0) {
+      setSelectedContextAssetId(null);
       return;
     }
-
-    if (!selectedContextFilePath || !files.some((file) => file.path === selectedContextFilePath)) {
-      setSelectedContextFilePath(files[0]?.path ?? "");
+    if (!selectedContextAssetId || !assets.some((a) => a.id === selectedContextAssetId)) {
+      setSelectedContextAssetId(assets[0]?.id ?? null);
     }
-  }, [contextFilesQuery.data, selectedContextFilePath]);
+  }, [contextAssetsQuery.data, selectedContextAssetId]);
 
   const importContextMutation = useMutation({
-    mutationFn: (filePath: string) => getContextFile(projectId, filePath),
-    onSuccess: (file) => {
-      setFormData((prev) => ({ ...prev, context_content: file.content }));
+    mutationFn: (assetId: number) => getContextAsset(assetId),
+    onSuccess: (asset) => {
+      setFormData((prev) => ({ ...prev, context_content: asset.content }));
       setImportNotice(
-        `${file.path} の内容を取り込みました。保存するとこのスナップショットがテストケースに保存されます。`,
+        `${asset.name} の内容を取り込みました。保存するとこのスナップショットがテストケースに保存されます。`,
       );
     },
   });
@@ -247,22 +246,22 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
             <div className={styles.contextImportRow}>
               <div className={styles.contextImportControls}>
                 <select
-                  value={selectedContextFilePath}
+                  value={selectedContextAssetId ?? ""}
                   onChange={(e) => {
                     setImportNotice(null);
-                    setSelectedContextFilePath(e.target.value);
+                    setSelectedContextAssetId(e.target.value ? Number(e.target.value) : null);
                   }}
                   disabled={
-                    (contextFilesQuery.data?.length ?? 0) === 0 || importContextMutation.isPending
+                    (contextAssetsQuery.data?.length ?? 0) === 0 || importContextMutation.isPending
                   }
                   className={styles.contextFileSelect}
                 >
-                  {(contextFilesQuery.data?.length ?? 0) === 0 ? (
-                    <option value="">利用可能なコンテキストファイルはありません</option>
+                  {(contextAssetsQuery.data?.length ?? 0) === 0 ? (
+                    <option value="">利用可能なコンテキスト素材はありません</option>
                   ) : (
-                    (contextFilesQuery.data ?? []).map((file) => (
-                      <option key={file.path} value={file.path}>
-                        {file.path}
+                    (contextAssetsQuery.data ?? []).map((asset) => (
+                      <option key={asset.id} value={asset.id}>
+                        {asset.name}
                       </option>
                     ))
                   )}
@@ -270,21 +269,21 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
                 <button
                   type="button"
                   onClick={() => {
-                    if (!selectedContextFilePath) return;
-                    importContextMutation.mutate(selectedContextFilePath);
+                    if (!selectedContextAssetId) return;
+                    importContextMutation.mutate(selectedContextAssetId);
                   }}
-                  disabled={!selectedContextFilePath || importContextMutation.isPending}
+                  disabled={!selectedContextAssetId || importContextMutation.isPending}
                   className={`${styles.btnSecondary} ${styles.contextImportButton}`}
                 >
                   {importContextMutation.isPending ? "取込中..." : "取り込む"}
                 </button>
               </div>
               <p className={styles.modeHint}>
-                コンテキスト管理で取り込んだファイルをここへコピーします。取り込み後に編集して保存できます。
+                コンテキスト素材管理で登録した素材をここへコピーします。取り込み後に編集して保存できます。
               </p>
-              {contextFilesQuery.isError && (
+              {contextAssetsQuery.isError && (
                 <p className={styles.contextImportError}>
-                  コンテキストファイル一覧の取得に失敗しました。
+                  コンテキスト素材一覧の取得に失敗しました。
                 </p>
               )}
               {importContextMutation.isError && (


### PR DESCRIPTION
## Summary

- グローバルスコープの Context Assets 管理ページ（`/context-assets`）を新規作成
- 一覧・作成・編集・削除 UI とプロジェクトフィルタ・テキスト検索・未分類フィルタを実装
- 右パネルに CodeMirror エディタ + name/path/mime_type 編集フォームとプロジェクト割り当てセクションを追加
- `App.tsx` にグローバルルート `context-assets` を追加
- `Layout.tsx` のトップナビに「コンテキスト素材」リンクを追加
- 既存の `ContextFilesPage` (`projects/:id/context-files`) は変更なし

## Test plan

- [ ] `/context-assets` にアクセスして素材一覧が表示されること
- [ ] 新規作成フォームで素材を作成できること（name/path/content/mime_type）
- [ ] 左パネルで素材を選択すると右パネルに詳細が表示されること
- [ ] name/path/mime_type/content を編集して「保存」ボタンで更新できること
- [ ] 削除確認 → 削除が正常に動作すること
- [ ] テキスト検索（Enter 確定）・プロジェクトフィルタ・未分類フィルタが動作すること
- [ ] プロジェクト割り当てボタンで setContextAssetProjects が呼ばれること
- [ ] 旧 `ContextFilesPage`（`projects/:id/context-files`）が引き続き動作すること
- [ ] `pnpm --filter @prompt-reviewer/ui typecheck` がエラーなし
- [ ] `pnpm run check` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)