### PR TITLE
[codex] テストケース画面を独立資産 + context assets 対応へ移行

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -37,6 +37,7 @@ export function App() {
             {/* プロジェクト詳細 */}
             <Route path="projects/:id" element={<ProjectDetailPage />} />
             <Route path="projects/:id/context-files" element={<ContextFilesPage />} />
+            <Route path="test-cases" element={<TestCasesPage />} />
             <Route path="projects/:id/test-cases" element={<TestCasesPage />} />
             <Route path="prompts" element={<PromptsPage />} />
             <Route path="projects/:id/prompts" element={<PromptsPage />} />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -27,7 +27,7 @@ function ProjectSubNav({ projectId }: { projectId: string }) {
   const subNavItems = [
     { to: `/projects/${projectId}`, label: "ホーム", end: true },
     { to: `/projects/${projectId}/context-files`, label: "コンテキスト" },
-    { to: `/projects/${projectId}/test-cases`, label: "テストケース" },
+    { to: `/test-cases?project_id=${projectId}`, label: "テストケース" },
     { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
     { to: `/projects/${projectId}/runs`, label: "Run" },
     { to: `/projects/${projectId}/score`, label: "採点" },
@@ -81,6 +81,7 @@ function SidebarNav() {
 
   const topNavItems = [
     { to: "/", label: "プロジェクト一覧", end: true },
+    { to: "/test-cases", label: "テストケース", end: false },
     { to: "/prompts", label: "プロンプト", end: false },
     { to: "/context-assets", label: "コンテキスト素材", end: false },
     { to: "/execution-profiles", label: "実行設定", end: false },

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -37,7 +37,7 @@ export function ProjectDetailPage() {
       >
         {[
           { to: "context-files", label: "コンテキスト管理" },
-          { to: "test-cases", label: "テストケース管理" },
+          { to: `/test-cases?project_id=${id}`, label: "テストケース管理" },
           { to: `/prompts?project_id=${id}`, label: "プロンプト管理" },
           { to: "runs", label: "Run 実行・管理" },
           { to: "score", label: "採点" },

--- a/packages/ui/src/pages/TestCasesPage.module.css
+++ b/packages/ui/src/pages/TestCasesPage.module.css
@@ -1,7 +1,12 @@
-/* ==================== Page layout ==================== */
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
 .pageHeader {
   composes: pageHeader from '../styles/shared.module.css';
-  margin-bottom: 8px;
+  margin-bottom: 0;
 }
 
 .pageTitle {
@@ -10,7 +15,46 @@
 
 .pageDescription {
   color: var(--c-subtext);
-  margin: 0 0 24px;
+  margin: 6px 0 0;
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.filterBar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--c-border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--c-card) 82%, transparent);
+}
+
+.searchRow {
+  display: flex;
+  gap: 10px;
+}
+
+.filterTags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.filterTag {
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--c-border);
+  background: transparent;
+  color: var(--c-subtext);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.filterTagActive {
+  background: var(--c-accent);
+  color: var(--c-overlay);
+  border-color: transparent;
 }
 
 .statusText {
@@ -48,7 +92,6 @@
   gap: 12px;
 }
 
-/* ==================== Shared buttons ==================== */
 .btnPrimary {
   composes: btnPrimary from '../styles/shared.module.css';
   padding: 8px 18px;
@@ -57,7 +100,7 @@
 
 .btnSecondary {
   composes: btnSecondary from '../styles/shared.module.css';
-  padding: 8px 20px;
+  padding: 8px 18px;
   font-size: 14px;
 }
 
@@ -76,11 +119,10 @@
   composes: btnDisabled from '../styles/shared.module.css';
 }
 
-/* ==================== Modal ==================== */
 .modalOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgb(0 0 0 / 0.6);
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -95,25 +137,24 @@
 
 .modalContent {
   composes: modalContent from '../styles/shared.module.css';
-  width: 600px;
+  width: min(760px, calc(100vw - 32px));
 }
 
 .modalContentSm {
   composes: modalContent from '../styles/shared.module.css';
-  width: 420px;
+  width: min(420px, calc(100vw - 32px));
 }
 
 .modalTitle {
   composes: modalTitle from '../styles/shared.module.css';
 }
 
-/* ==================== Form ==================== */
 .formActions {
   composes: formActions from '../styles/shared.module.css';
 }
 
 .fieldGroup {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 .fieldGroupLg {
@@ -148,16 +189,12 @@
   resize: vertical;
   box-sizing: border-box;
   font-family: monospace;
-}
-
-.contextImportRow {
-  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 .contextImportControls {
   display: flex;
   gap: 8px;
-  margin-bottom: 6px;
 }
 
 .contextFileSelect {
@@ -175,62 +212,92 @@
 }
 
 .contextImportNotice {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   font-size: 12px;
   color: var(--c-accent);
 }
 
 .contextImportError {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   font-size: 12px;
   color: var(--c-danger);
 }
 
-/* ==================== Input mode toggle ==================== */
-.modeLabel {
-  font-size: 14px;
-  color: var(--c-subtext);
-  margin: 0 0 8px;
+.modeHint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--c-muted);
+  line-height: 1.5;
 }
 
-.modeToggle {
+.tagGroup {
   display: flex;
-  border-radius: 8px;
-  overflow: hidden;
-  border: 1px solid var(--c-border);
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
 }
 
-.btnModeBase {
-  flex: 1;
-  padding: 7px 0;
-  border: none;
+.tagButton {
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--c-border);
+  background: var(--c-bg);
+  color: var(--c-subtext);
   font-size: 13px;
   cursor: pointer;
 }
 
-.btnModeRight {
-  border-left: 1px solid var(--c-border);
+.tagButtonActive {
+  background: color-mix(in srgb, var(--c-accent) 22%, var(--c-card));
+  color: var(--c-text);
+  border-color: color-mix(in srgb, var(--c-accent) 55%, var(--c-border));
 }
 
-.btnModeActive {
-  background: var(--c-accent);
-  color: var(--c-overlay);
-  font-weight: 600;
+.assetSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--c-bg) 55%, transparent);
 }
 
-.btnModeInactive {
+.selectedAssets,
+.availableAssets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.selectedAssetsLabel {
+  margin: 0;
+  font-size: 12px;
+  color: var(--c-subtext);
+}
+
+.assetTagList {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.assetTag {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--c-border);
   background: transparent;
   color: var(--c-subtext);
-  font-weight: 400;
-}
-
-.modeHint {
-  margin: 6px 0 0;
   font-size: 12px;
-  color: var(--c-muted);
+  cursor: pointer;
 }
 
-/* ==================== Turn editor ==================== */
+.assetTagSelected {
+  background: color-mix(in srgb, var(--c-green) 20%, var(--c-card));
+  color: var(--c-text);
+  border-color: color-mix(in srgb, var(--c-green) 55%, var(--c-border));
+}
+
 .turnItem {
   margin-bottom: 12px;
   padding: 12px;
@@ -324,15 +391,14 @@
   margin-top: 4px;
 }
 
-/* ==================== Test case card ==================== */
 .card {
   background: var(--c-card);
   border: 1px solid var(--c-border);
-  border-radius: 12px;
-  padding: 16px 20px;
+  border-radius: 14px;
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .cardHeader {
@@ -344,10 +410,9 @@
 
 .cardTitle {
   margin: 0;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--c-text);
-  word-break: break-word;
   line-height: 1.4;
 }
 
@@ -381,6 +446,7 @@
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  margin-top: 10px;
 }
 
 .badge {
@@ -403,18 +469,50 @@
   color: var(--c-green);
 }
 
+.badgeLinkedAsset {
+  color: var(--c-green);
+}
+
 .badgeExpected {
   color: var(--c-yellow);
+}
+
+.metaGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metaLabel {
+  font-size: 12px;
+  color: var(--c-subtext);
+}
+
+.projectPill,
+.assetPill {
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.projectPill {
+  background: color-mix(in srgb, var(--c-accent) 18%, var(--c-card));
+  color: var(--c-text);
+}
+
+.assetPill {
+  background: color-mix(in srgb, var(--c-green) 18%, var(--c-card));
+  color: var(--c-text);
 }
 
 .preview {
   margin: 0;
   font-size: 13px;
   color: var(--c-muted);
-  line-height: 1.5;
+  line-height: 1.6;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
 
@@ -422,7 +520,6 @@
   font-family: monospace;
 }
 
-/* ==================== Delete dialog ==================== */
 .deleteDescription {
   margin: 0 0 8px;
   color: var(--c-subtext);
@@ -443,4 +540,21 @@
   margin: 0 0 24px;
   color: var(--c-danger);
   font-size: 13px;
+}
+
+@media (max-width: 720px) {
+  .searchRow,
+  .contextImportControls,
+  .cardHeader {
+    flex-direction: column;
+  }
+
+  .cardActions {
+    width: 100%;
+  }
+
+  .btnCardEdit,
+  .btnCardDelete {
+    flex: 1;
+  }
 }

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -1,24 +1,69 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import {
+  type ContextAssetSummary,
+  type Project,
   type TestCase,
+  type TestCaseFilters,
   type Turn,
-  createTestCase,
-  deleteTestCase,
+  createIndependentTestCase,
+  deleteIndependentTestCase,
   getContextAsset,
   getContextAssets,
-  getTestCases,
-  updateTestCase,
+  getIndependentTestCases,
+  getProjects,
+  setTestCaseContextAssets,
+  setTestCaseProjects,
+  updateIndependentTestCase,
 } from "../lib/api";
 import styles from "./TestCasesPage.module.css";
 
-// ターン操作ユーティリティ
 function createEmptyTurn(): Turn {
   return { role: "user", content: "" };
 }
 
-// ターン編集フォームコンポーネント
+function formatProjectNames(projectIds: number[], projects: Project[]): string[] {
+  return projectIds
+    .map((projectId) => projects.find((project) => project.id === projectId)?.name)
+    .filter((name): name is string => Boolean(name));
+}
+
+type TestCaseFormData = {
+  title: string;
+  turns: Turn[];
+  context_content: string;
+  expected_description: string;
+  project_ids: number[];
+  context_asset_ids: number[];
+};
+
+function getInitialFormData(
+  testCase?: TestCase,
+  defaultProjectId?: number | null,
+  initialContextAssetIds: number[] = [],
+): TestCaseFormData {
+  if (testCase) {
+    return {
+      title: testCase.title,
+      turns: testCase.turns,
+      context_content: testCase.context_content ?? "",
+      expected_description: testCase.expected_description ?? "",
+      project_ids: [],
+      context_asset_ids: initialContextAssetIds,
+    };
+  }
+
+  return {
+    title: "",
+    turns: [createEmptyTurn()],
+    context_content: "",
+    expected_description: "",
+    project_ids: defaultProjectId !== null && defaultProjectId !== undefined ? [defaultProjectId] : [],
+    context_asset_ids: [],
+  };
+}
+
 type TurnEditorProps = {
   turns: Turn[];
   onChange: (turns: Turn[]) => void;
@@ -26,13 +71,13 @@ type TurnEditorProps = {
 
 function TurnEditor({ turns, onChange }: TurnEditorProps) {
   function handleRoleChange(index: number, role: "user" | "assistant") {
-    const updated = turns.map((t, i) => (i === index ? { ...t, role } : t));
-    onChange(updated);
+    onChange(turns.map((turn, currentIndex) => (currentIndex === index ? { ...turn, role } : turn)));
   }
 
   function handleContentChange(index: number, content: string) {
-    const updated = turns.map((t, i) => (i === index ? { ...t, content } : t));
-    onChange(updated);
+    onChange(
+      turns.map((turn, currentIndex) => (currentIndex === index ? { ...turn, content } : turn)),
+    );
   }
 
   function handleAddTurn() {
@@ -40,27 +85,29 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
   }
 
   function handleRemoveTurn(index: number) {
-    onChange(turns.filter((_, i) => i !== index));
+    onChange(turns.filter((_, currentIndex) => currentIndex !== index));
   }
 
   function handleMoveUp(index: number) {
     if (index === 0) return;
-    const updated = turns.map((t, i) => {
-      if (i === index - 1) return turns[index] ?? t;
-      if (i === index) return turns[index - 1] ?? t;
-      return t;
-    });
-    onChange(updated);
+    const nextTurns = [...turns];
+    const current = nextTurns[index];
+    const previous = nextTurns[index - 1];
+    if (!current || !previous) return;
+    nextTurns[index] = previous;
+    nextTurns[index - 1] = current;
+    onChange(nextTurns);
   }
 
   function handleMoveDown(index: number) {
     if (index === turns.length - 1) return;
-    const updated = turns.map((t, i) => {
-      if (i === index) return turns[index + 1] ?? t;
-      if (i === index + 1) return turns[index] ?? t;
-      return t;
-    });
-    onChange(updated);
+    const nextTurns = [...turns];
+    const current = nextTurns[index];
+    const next = nextTurns[index + 1];
+    if (!current || !next) return;
+    nextTurns[index] = next;
+    nextTurns[index + 1] = current;
+    onChange(nextTurns);
   }
 
   return (
@@ -77,7 +124,9 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
             <span className={styles.turnNumber}>#{index + 1}</span>
             <select
               value={turn.role}
-              onChange={(e) => handleRoleChange(index, e.target.value as "user" | "assistant")}
+              onChange={(event) =>
+                handleRoleChange(index, event.target.value as "user" | "assistant")
+              }
               className={`${styles.turnSelect} ${turn.role === "user" ? styles.turnSelectUser : styles.turnSelectAssistant}`}
             >
               <option value="user">user</option>
@@ -111,7 +160,7 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
           </div>
           <textarea
             value={turn.content}
-            onChange={(e) => handleContentChange(index, e.target.value)}
+            onChange={(event) => handleContentChange(index, event.target.value)}
             placeholder={
               turn.role === "user" ? "ユーザーの入力を記述..." : "アシスタントの期待応答を記述..."
             }
@@ -127,83 +176,252 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
   );
 }
 
-type TestCaseFormData = {
-  title: string;
-  turns: Turn[];
-  context_content: string;
-  expected_description: string;
+type ProjectTagEditorProps = {
+  projects: Project[];
+  selectedProjectIds: number[];
+  onChange: (projectIds: number[]) => void;
 };
 
-function getInitialFormData(testCase?: TestCase): TestCaseFormData {
-  if (testCase) {
-    return {
-      title: testCase.title,
-      turns: testCase.turns,
-      context_content: testCase.context_content ?? "",
-      expected_description: testCase.expected_description ?? "",
-    };
+function ProjectTagEditor({ projects, selectedProjectIds, onChange }: ProjectTagEditorProps) {
+  function handleToggle(projectId: number) {
+    onChange(
+      selectedProjectIds.includes(projectId)
+        ? selectedProjectIds.filter((id) => id !== projectId)
+        : [...selectedProjectIds, projectId],
+    );
   }
-  return {
-    title: "",
-    turns: [createEmptyTurn()],
-    context_content: "",
-    expected_description: "",
-  };
+
+  if (projects.length === 0) {
+    return <p className={styles.modeHint}>利用可能なプロジェクトはありません。</p>;
+  }
+
+  return (
+    <div className={styles.tagGroup}>
+      {projects.map((project) => (
+        <button
+          key={project.id}
+          type="button"
+          onClick={() => handleToggle(project.id)}
+          className={`${styles.tagButton} ${selectedProjectIds.includes(project.id) ? styles.tagButtonActive : ""}`}
+        >
+          {project.name}
+        </button>
+      ))}
+    </div>
+  );
 }
 
-// 作成・編集モーダルコンポーネント
+type ContextAssetPickerProps = {
+  selectedIds: number[];
+  availableAssets: ContextAssetSummary[];
+  linkedAssets: ContextAssetSummary[];
+  selectedImportId: number | null;
+  isImporting: boolean;
+  onImportSelectionChange: (id: number | null) => void;
+  onImport: () => void;
+  onToggleLink: (assetId: number) => void;
+};
+
+function ContextAssetPicker({
+  selectedIds,
+  availableAssets,
+  linkedAssets,
+  selectedImportId,
+  isImporting,
+  onImportSelectionChange,
+  onImport,
+  onToggleLink,
+}: ContextAssetPickerProps) {
+  const assetMap = new Map<number, ContextAssetSummary>();
+  for (const asset of linkedAssets) {
+    assetMap.set(asset.id, asset);
+  }
+  for (const asset of availableAssets) {
+    assetMap.set(asset.id, asset);
+  }
+
+  const selectedAssets = selectedIds
+    .map((assetId) => assetMap.get(assetId))
+    .filter((asset): asset is ContextAssetSummary => Boolean(asset));
+
+  return (
+    <div className={styles.assetSection}>
+      <div className={styles.contextImportControls}>
+        <select
+          value={selectedImportId ?? ""}
+          onChange={(event) =>
+            onImportSelectionChange(event.target.value ? Number(event.target.value) : null)
+          }
+          disabled={availableAssets.length === 0 || isImporting}
+          className={styles.contextFileSelect}
+        >
+          {availableAssets.length === 0 ? (
+            <option value="">利用可能なコンテキスト素材はありません</option>
+          ) : (
+            <>
+              <option value="">取り込む素材を選択</option>
+              {availableAssets.map((asset) => (
+                <option key={asset.id} value={asset.id}>
+                  {asset.path}
+                </option>
+              ))}
+            </>
+          )}
+        </select>
+        <button
+          type="button"
+          onClick={onImport}
+          disabled={!selectedImportId || isImporting}
+          className={`${styles.btnSecondary} ${styles.contextImportButton}`}
+        >
+          {isImporting ? "取込中..." : "内容を取り込む"}
+        </button>
+      </div>
+
+      <p className={styles.modeHint}>
+        `context_assets` の内容をスナップショットとして `context_content` に取り込みます。関連付けだけ残したい場合は下のタグを切り替えてください。
+      </p>
+
+      {selectedAssets.length > 0 ? (
+        <div className={styles.selectedAssets}>
+          <p className={styles.selectedAssetsLabel}>関連付け中の素材</p>
+          <div className={styles.assetTagList}>
+            {selectedAssets.map((asset) => (
+              <button
+                key={asset.id}
+                type="button"
+                onClick={() => onToggleLink(asset.id)}
+                className={`${styles.assetTag} ${styles.assetTagSelected}`}
+              >
+                {asset.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className={styles.modeHint}>関連付け中の素材はありません。</p>
+      )}
+
+      {availableAssets.length > 0 && (
+        <div className={styles.availableAssets}>
+          <p className={styles.selectedAssetsLabel}>候補から関連付けを切り替える</p>
+          <div className={styles.assetTagList}>
+            {availableAssets.map((asset) => (
+              <button
+                key={asset.id}
+                type="button"
+                onClick={() => onToggleLink(asset.id)}
+                className={`${styles.assetTag} ${selectedIds.includes(asset.id) ? styles.assetTagSelected : ""}`}
+              >
+                {asset.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 type TestCaseModalProps = {
-  projectId: number;
   testCase?: TestCase;
+  defaultProjectId: number | null;
+  initialProjectIds: number[];
+  projects: Project[];
+  availableAssets: ContextAssetSummary[];
+  linkedAssets: ContextAssetSummary[];
   onClose: () => void;
   onSubmit: (data: TestCaseFormData) => void;
   isLoading: boolean;
 };
 
-function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: TestCaseModalProps) {
-  const [formData, setFormData] = useState<TestCaseFormData>(() => getInitialFormData(testCase));
-  const [selectedContextAssetId, setSelectedContextAssetId] = useState<number | null>(null);
+function TestCaseModal({
+  testCase,
+  defaultProjectId,
+  initialProjectIds,
+  projects,
+  availableAssets,
+  linkedAssets,
+  onClose,
+  onSubmit,
+  isLoading,
+}: TestCaseModalProps) {
+  const [formData, setFormData] = useState<TestCaseFormData>(() =>
+    getInitialFormData(
+      testCase,
+      defaultProjectId,
+      linkedAssets.map((asset) => asset.id),
+    ),
+  );
+  const [selectedImportId, setSelectedImportId] = useState<number | null>(null);
   const [importNotice, setImportNotice] = useState<string | null>(null);
-  const isEdit = !!testCase;
-
-  const contextAssetsQuery = useQuery({
-    queryKey: ["context-assets", { project_id: projectId }],
-    queryFn: () => getContextAssets({ project_id: projectId }),
-    enabled: !Number.isNaN(projectId),
-  });
+  const isEdit = Boolean(testCase);
 
   useEffect(() => {
-    const assets = contextAssetsQuery.data ?? [];
-    if (assets.length === 0) {
-      setSelectedContextAssetId(null);
+    setFormData(
+      getInitialFormData(
+        testCase,
+        defaultProjectId,
+        linkedAssets.map((asset) => asset.id),
+      ),
+    );
+  }, [defaultProjectId, linkedAssets, testCase]);
+
+  useEffect(() => {
+    setFormData((prev) => ({ ...prev, project_ids: initialProjectIds }));
+  }, [initialProjectIds]);
+
+  useEffect(() => {
+    if (availableAssets.length === 0) {
+      setSelectedImportId(null);
       return;
     }
-    if (!selectedContextAssetId || !assets.some((a) => a.id === selectedContextAssetId)) {
-      setSelectedContextAssetId(assets[0]?.id ?? null);
+
+    if (!selectedImportId || !availableAssets.some((asset) => asset.id === selectedImportId)) {
+      setSelectedImportId(availableAssets[0]?.id ?? null);
     }
-  }, [contextAssetsQuery.data, selectedContextAssetId]);
+  }, [availableAssets, selectedImportId]);
 
   const importContextMutation = useMutation({
     mutationFn: (assetId: number) => getContextAsset(assetId),
     onSuccess: (asset) => {
-      setFormData((prev) => ({ ...prev, context_content: asset.content }));
+      setFormData((prev) => ({
+        ...prev,
+        context_content: asset.content,
+        context_asset_ids: prev.context_asset_ids.includes(asset.id)
+          ? prev.context_asset_ids
+          : [...prev.context_asset_ids, asset.id],
+      }));
       setImportNotice(
         `${asset.name} の内容を取り込みました。保存するとこのスナップショットがテストケースに保存されます。`,
       );
     },
   });
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
     const trimmedTitle = formData.title.trim();
     if (!trimmedTitle) return;
-    const validTurns = formData.turns.filter((t) => t.content.trim());
+
     onSubmit({
       ...formData,
       title: trimmedTitle,
-      turns: validTurns,
+      turns: formData.turns.filter((turn) => turn.content.trim()),
       context_content: formData.context_content.trim(),
+      expected_description: formData.expected_description.trim(),
+      project_ids: [...new Set(formData.project_ids)].sort((a, b) => a - b),
+      context_asset_ids: [...new Set(formData.context_asset_ids)].sort((a, b) => a - b),
     });
+  }
+
+  function handleToggleAsset(assetId: number) {
+    setImportNotice(null);
+    setFormData((prev) => ({
+      ...prev,
+      context_asset_ids: prev.context_asset_ids.includes(assetId)
+        ? prev.context_asset_ids.filter((id) => id !== assetId)
+        : [...prev.context_asset_ids, assetId],
+    }));
   }
 
   const isSubmittable = formData.title.trim() !== "";
@@ -211,11 +429,11 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
   return (
     <div
       className={styles.modalOverlay}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
       }}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") onClose();
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
       }}
     >
       <div className={styles.modalContent}>
@@ -223,7 +441,6 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
           {isEdit ? "テストケースを編集" : "テストケースを作成"}
         </h3>
         <form onSubmit={handleSubmit}>
-          {/* タイトル */}
           <div className={styles.fieldGroup}>
             <label htmlFor="test-case-title" className={styles.fieldLabel}>
               タイトル
@@ -233,9 +450,23 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
               id="test-case-title"
               type="text"
               value={formData.title}
-              onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+              onChange={(event) =>
+                setFormData((prev) => ({ ...prev, title: event.target.value }))
+              }
               placeholder="例: 基本的な挨拶テスト"
               className={styles.fieldInput}
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <p className={styles.fieldLabel}>プロジェクトラベル</p>
+            <p className={styles.modeHint}>
+              project 親子ではなく独立資産として管理しつつ、必要な project にタグ付けできます。
+            </p>
+            <ProjectTagEditor
+              projects={projects}
+              selectedProjectIds={formData.project_ids}
+              onChange={(projectIds) => setFormData((prev) => ({ ...prev, project_ids: projectIds }))}
             />
           </div>
 
@@ -243,61 +474,28 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
             <label htmlFor="test-case-context" className={styles.fieldLabel}>
               コンテキスト（任意）
             </label>
-            <div className={styles.contextImportRow}>
-              <div className={styles.contextImportControls}>
-                <select
-                  value={selectedContextAssetId ?? ""}
-                  onChange={(e) => {
-                    setImportNotice(null);
-                    setSelectedContextAssetId(e.target.value ? Number(e.target.value) : null);
-                  }}
-                  disabled={
-                    (contextAssetsQuery.data?.length ?? 0) === 0 || importContextMutation.isPending
-                  }
-                  className={styles.contextFileSelect}
-                >
-                  {(contextAssetsQuery.data?.length ?? 0) === 0 ? (
-                    <option value="">利用可能なコンテキスト素材はありません</option>
-                  ) : (
-                    (contextAssetsQuery.data ?? []).map((asset) => (
-                      <option key={asset.id} value={asset.id}>
-                        {asset.name}
-                      </option>
-                    ))
-                  )}
-                </select>
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (!selectedContextAssetId) return;
-                    importContextMutation.mutate(selectedContextAssetId);
-                  }}
-                  disabled={!selectedContextAssetId || importContextMutation.isPending}
-                  className={`${styles.btnSecondary} ${styles.contextImportButton}`}
-                >
-                  {importContextMutation.isPending ? "取込中..." : "取り込む"}
-                </button>
-              </div>
-              <p className={styles.modeHint}>
-                コンテキスト素材管理で登録した素材をここへコピーします。取り込み後に編集して保存できます。
-              </p>
-              {contextAssetsQuery.isError && (
-                <p className={styles.contextImportError}>
-                  コンテキスト素材一覧の取得に失敗しました。
-                </p>
-              )}
-              {importContextMutation.isError && (
-                <p className={styles.contextImportError}>
-                  選択したコンテキストファイルの取り込みに失敗しました。
-                </p>
-              )}
-              {importNotice && <p className={styles.contextImportNotice}>{importNotice}</p>}
-            </div>
+            <ContextAssetPicker
+              selectedIds={formData.context_asset_ids}
+              availableAssets={availableAssets}
+              linkedAssets={linkedAssets}
+              selectedImportId={selectedImportId}
+              isImporting={importContextMutation.isPending}
+              onImportSelectionChange={setSelectedImportId}
+              onImport={() => {
+                if (!selectedImportId) return;
+                importContextMutation.mutate(selectedImportId);
+              }}
+              onToggleLink={handleToggleAsset}
+            />
+            {importContextMutation.isError && (
+              <p className={styles.contextImportError}>選択したコンテキスト素材の取り込みに失敗しました。</p>
+            )}
+            {importNotice && <p className={styles.contextImportNotice}>{importNotice}</p>}
             <textarea
               id="test-case-context"
               value={formData.context_content}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, context_content: e.target.value }))
+              onChange={(event) =>
+                setFormData((prev) => ({ ...prev, context_content: event.target.value }))
               }
               placeholder="参照テキストや前提条件を入力..."
               rows={6}
@@ -308,7 +506,7 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
           <div className={styles.fieldGroup}>
             <p className={styles.fieldLabel}>会話ターン（任意）</p>
             <p className={styles.modeHint}>
-              実行時の補足情報は上のコンテキスト欄に入力し、会話として固定したい内容はターンで入力します。
+              実行時の補足情報は上のコンテキスト欄へ、会話として固定したい内容はターンで入力します。
             </p>
             <TurnEditor
               turns={formData.turns}
@@ -316,7 +514,6 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
             />
           </div>
 
-          {/* 期待記述 */}
           <div className={styles.fieldGroupLg}>
             <label htmlFor="test-case-expected" className={styles.fieldLabel}>
               期待記述（任意）
@@ -324,8 +521,8 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
             <textarea
               id="test-case-expected"
               value={formData.expected_description}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, expected_description: e.target.value }))
+              onChange={(event) =>
+                setFormData((prev) => ({ ...prev, expected_description: event.target.value }))
               }
               placeholder="期待するアシスタントの振る舞いを記述..."
               rows={3}
@@ -351,7 +548,6 @@ function TestCaseModal({ projectId, testCase, onClose, onSubmit, isLoading }: Te
   );
 }
 
-// 削除確認ダイアログ
 type DeleteDialogProps = {
   testCase: TestCase;
   onClose: () => void;
@@ -363,11 +559,11 @@ function DeleteDialog({ testCase, onClose, onConfirm, isLoading }: DeleteDialogP
   return (
     <div
       className={styles.modalOverlayCentered}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
       }}
-      onKeyDown={(e) => {
-        if (e.key === "Escape") onClose();
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
       }}
     >
       <div className={styles.modalContentSm}>
@@ -393,21 +589,57 @@ function DeleteDialog({ testCase, onClose, onConfirm, isLoading }: DeleteDialogP
   );
 }
 
-// テストケースカードコンポーネント
 type TestCaseCardProps = {
   testCase: TestCase;
+  projects: Project[];
+  linkedAssets: ContextAssetSummary[];
+  linkedProjectIds: number[];
   onEdit: (testCase: TestCase) => void;
   onDelete: (testCase: TestCase) => void;
 };
 
-function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
-  const userTurns = testCase.turns.filter((t) => t.role === "user").length;
-  const assistantTurns = testCase.turns.filter((t) => t.role === "assistant").length;
+function TestCaseCard({
+  testCase,
+  projects,
+  linkedAssets,
+  linkedProjectIds,
+  onEdit,
+  onDelete,
+}: TestCaseCardProps) {
+  const userTurns = testCase.turns.filter((turn) => turn.role === "user").length;
+  const assistantTurns = testCase.turns.filter((turn) => turn.role === "assistant").length;
+  const projectNames = formatProjectNames(linkedProjectIds, projects);
 
   return (
     <div className={styles.card}>
       <div className={styles.cardHeader}>
-        <h3 className={styles.cardTitle}>{testCase.title}</h3>
+        <div>
+          <h3 className={styles.cardTitle}>{testCase.title}</h3>
+          <div className={styles.badgeRow}>
+            <span className={`${styles.badge} ${styles.badgeTurnCount}`}>
+              計 {testCase.turns.length} ターン
+            </span>
+            {userTurns > 0 && (
+              <span className={`${styles.badge} ${styles.badgeUser}`}>user × {userTurns}</span>
+            )}
+            {assistantTurns > 0 && (
+              <span className={`${styles.badge} ${styles.badgeAssistant}`}>
+                assistant × {assistantTurns}
+              </span>
+            )}
+            {testCase.context_content && (
+              <span className={`${styles.badge} ${styles.badgeTextMode}`}>コンテキストあり</span>
+            )}
+            {linkedAssets.length > 0 && (
+              <span className={`${styles.badge} ${styles.badgeLinkedAsset}`}>
+                素材関連付け {linkedAssets.length} 件
+              </span>
+            )}
+            {testCase.expected_description && (
+              <span className={`${styles.badge} ${styles.badgeExpected}`}>期待記述あり</span>
+            )}
+          </div>
+        </div>
         <div className={styles.cardActions}>
           <button type="button" onClick={() => onEdit(testCase)} className={styles.btnCardEdit}>
             編集
@@ -418,28 +650,32 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
         </div>
       </div>
 
-      {/* ターン情報バッジ */}
-      <div className={styles.badgeRow}>
-        <span className={`${styles.badge} ${styles.badgeTurnCount}`}>
-          計 {testCase.turns.length} ターン
-        </span>
-        {userTurns > 0 && (
-          <span className={`${styles.badge} ${styles.badgeUser}`}>user × {userTurns}</span>
-        )}
-        {assistantTurns > 0 && (
-          <span className={`${styles.badge} ${styles.badgeAssistant}`}>
-            assistant × {assistantTurns}
-          </span>
-        )}
-        {testCase.context_content && (
-          <span className={`${styles.badge} ${styles.badgeTextMode}`}>コンテキストあり</span>
-        )}
-        {testCase.expected_description && (
-          <span className={`${styles.badge} ${styles.badgeExpected}`}>期待記述あり</span>
-        )}
-      </div>
+      {projectNames.length > 0 && (
+        <div className={styles.metaGroup}>
+          <span className={styles.metaLabel}>プロジェクト</span>
+          <div className={styles.assetTagList}>
+            {projectNames.map((projectName) => (
+              <span key={`${testCase.id}-${projectName}`} className={styles.projectPill}>
+                {projectName}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
-      {/* プレビュー */}
+      {linkedAssets.length > 0 && (
+        <div className={styles.metaGroup}>
+          <span className={styles.metaLabel}>関連素材</span>
+          <div className={styles.assetTagList}>
+            {linkedAssets.map((asset) => (
+              <span key={`${testCase.id}-asset-${asset.id}`} className={styles.assetPill}>
+                {asset.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
       {testCase.turns[0] ? (
         <p className={styles.preview}>{testCase.turns[0].content}</p>
       ) : testCase.context_content ? (
@@ -449,59 +685,218 @@ function TestCaseCard({ testCase, onEdit, onDelete }: TestCaseCardProps) {
   );
 }
 
-// メインページコンポーネント
-export function TestCasesPage() {
-  const { id } = useParams<{ id: string }>();
-  const projectId = Number(id);
-  const queryClient = useQueryClient();
+type ProjectMembershipMap = Record<number, number[]>;
+type LinkedAssetMap = Record<number, ContextAssetSummary[]>;
 
+export function TestCasesPage() {
+  const queryClient = useQueryClient();
+  const { id } = useParams<{ id?: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<TestCase | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<TestCase | null>(null);
+  const [searchInput, setSearchInput] = useState(searchParams.get("q") ?? "");
 
-  const {
-    data: testCases,
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
-    queryKey: ["test-cases", projectId],
-    queryFn: () => getTestCases(projectId),
-    enabled: !Number.isNaN(projectId),
+  const legacyProjectId = id !== undefined ? Number(id) : null;
+  const selectedProjectId =
+    searchParams.get("project_id") !== null
+      ? Number(searchParams.get("project_id"))
+      : legacyProjectId !== null && !Number.isNaN(legacyProjectId)
+        ? legacyProjectId
+        : null;
+  const selectedUnclassified = searchParams.get("unclassified") === "true";
+  const searchQuery = searchParams.get("q")?.trim() ?? "";
+
+  useEffect(() => {
+    setSearchInput(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (
+      legacyProjectId === null ||
+      Number.isNaN(legacyProjectId) ||
+      searchParams.get("project_id") !== null
+    ) {
+      return;
+    }
+
+    const next = new URLSearchParams(searchParams);
+    next.set("project_id", String(legacyProjectId));
+    setSearchParams(next, { replace: true });
+  }, [legacyProjectId, searchParams, setSearchParams]);
+
+  const filters: TestCaseFilters = {
+    q: searchQuery || undefined,
+    project_id: selectedProjectId !== null && !Number.isNaN(selectedProjectId) ? selectedProjectId : undefined,
+    unclassified: selectedUnclassified || undefined,
+  };
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects"],
+    queryFn: getProjects,
   });
 
+  const testCasesQuery = useQuery({
+    queryKey: ["independent-test-cases", filters],
+    queryFn: () => getIndependentTestCases(filters),
+  });
+
+  const projects = projectsQuery.data ?? [];
+  const testCases = testCasesQuery.data ?? [];
+
+  const projectMembershipQueries = useQueries({
+    queries: projects.map((project) => ({
+      queryKey: ["test-case-membership", project.id],
+      queryFn: () => getIndependentTestCases({ project_id: project.id }),
+      staleTime: 1000 * 60,
+    })),
+  });
+
+  const linkedAssetQueries = useQueries({
+    queries: testCases.map((testCase) => ({
+      queryKey: ["test-case-linked-assets", testCase.id],
+      queryFn: () => getContextAssets({ linked_to: `test_case:${testCase.id}` }),
+      staleTime: 1000 * 60,
+    })),
+  });
+
+  const editLinkedAssetsQuery = useQuery({
+    queryKey: ["test-case-linked-assets", editTarget?.id ?? null, "edit"],
+    queryFn: () => {
+      if (!editTarget) throw new Error("testCase is required");
+      return getContextAssets({ linked_to: `test_case:${editTarget.id}` });
+    },
+    enabled: editTarget !== null,
+  });
+
+  const availableAssetsQuery = useQuery({
+    queryKey: ["test-case-available-assets", selectedProjectId],
+    queryFn: () =>
+      getContextAssets(
+        selectedProjectId !== null && !Number.isNaN(selectedProjectId)
+          ? { project_id: selectedProjectId }
+          : undefined,
+      ),
+  });
+
+  const projectMembershipMap: ProjectMembershipMap = {};
+  projects.forEach((project, index) => {
+    const linkedCases = projectMembershipQueries[index]?.data ?? [];
+    for (const linkedCase of linkedCases) {
+      projectMembershipMap[linkedCase.id] = [
+        ...(projectMembershipMap[linkedCase.id] ?? []),
+        project.id,
+      ];
+    }
+  });
+
+  const linkedAssetMap: LinkedAssetMap = {};
+  testCases.forEach((testCase, index) => {
+    linkedAssetMap[testCase.id] = linkedAssetQueries[index]?.data ?? [];
+  });
+
+  function updateSearchParams(nextValues: {
+    project_id?: number | null;
+    unclassified?: boolean;
+    q?: string;
+  }) {
+    const next = new URLSearchParams(searchParams);
+
+    if (nextValues.project_id === null || nextValues.project_id === undefined) {
+      next.delete("project_id");
+    } else {
+      next.set("project_id", String(nextValues.project_id));
+    }
+
+    if (!nextValues.unclassified) {
+      next.delete("unclassified");
+    } else {
+      next.set("unclassified", "true");
+    }
+
+    if (!nextValues.q) {
+      next.delete("q");
+    } else {
+      next.set("q", nextValues.q);
+    }
+
+    setSearchParams(next, { replace: true });
+  }
+
+  function handleProjectFilterChange(projectId: number) {
+    updateSearchParams({
+      project_id: selectedProjectId === projectId ? null : projectId,
+      unclassified: false,
+      q: searchQuery || undefined,
+    });
+  }
+
+  function handleUnclassifiedToggle() {
+    updateSearchParams({
+      project_id: null,
+      unclassified: !selectedUnclassified,
+      q: searchQuery || undefined,
+    });
+  }
+
+  function handleSearchSubmit() {
+    updateSearchParams({
+      project_id: selectedProjectId,
+      unclassified: selectedUnclassified,
+      q: searchInput.trim() || undefined,
+    });
+  }
+
+  async function saveRelationships(testCaseId: number, data: TestCaseFormData) {
+    await setTestCaseProjects(testCaseId, { project_ids: data.project_ids });
+    await setTestCaseContextAssets(testCaseId, { context_asset_ids: data.context_asset_ids });
+  }
+
   const createMutation = useMutation({
-    mutationFn: (data: TestCaseFormData) =>
-      createTestCase(projectId, {
+    mutationFn: async (data: TestCaseFormData) => {
+      const created = await createIndependentTestCase({
         title: data.title,
         turns: data.turns,
         context_content: data.context_content || undefined,
         expected_description: data.expected_description || undefined,
-      }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+        project_ids: data.project_ids,
+      });
+      await saveRelationships(created.id, data);
+      return created;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["independent-test-cases"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-membership"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-linked-assets"] });
       setIsCreateOpen(false);
     },
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id: tcId, data }: { id: number; data: TestCaseFormData }) =>
-      updateTestCase(projectId, tcId, {
+    mutationFn: async ({ id, data }: { id: number; data: TestCaseFormData }) => {
+      const updated = await updateIndependentTestCase(id, {
         title: data.title,
         turns: data.turns,
         context_content: data.context_content,
         expected_description: data.expected_description || null,
-      }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+      });
+      await saveRelationships(id, data);
+      return updated;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["independent-test-cases"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-membership"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-linked-assets"] });
       setEditTarget(null);
     },
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (tcId: number) => deleteTestCase(projectId, tcId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["test-cases", projectId] });
+    mutationFn: (testCaseId: number) => deleteIndependentTestCase(testCaseId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["independent-test-cases"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-membership"] });
+      await queryClient.invalidateQueries({ queryKey: ["test-case-linked-assets"] });
       setDeleteTarget(null);
     },
   });
@@ -509,39 +904,85 @@ export function TestCasesPage() {
   return (
     <div className={styles.root}>
       <div className={styles.pageHeader}>
-        <h2 className={styles.pageTitle}>テストケース管理</h2>
+        <div>
+          <h2 className={styles.pageTitle}>テストケース管理</h2>
+          <p className={styles.pageDescription}>
+            独立資産としてテストケースを管理し、必要な project や context assets をあとから関連付けます。
+          </p>
+        </div>
         <button type="button" onClick={() => setIsCreateOpen(true)} className={styles.btnPrimary}>
           + 新規作成
         </button>
       </div>
 
-      <p className={styles.pageDescription}>
-        プロジェクトのテストケース一覧です。会話ターン、コンテキスト、期待記述をまとめて管理します。
-      </p>
+      <div className={styles.filterBar}>
+        <div className={styles.searchRow}>
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                handleSearchSubmit();
+              }
+            }}
+            placeholder="タイトルで検索"
+            className={styles.fieldInput}
+          />
+          <button type="button" onClick={handleSearchSubmit} className={styles.btnSecondary}>
+            検索
+          </button>
+        </div>
 
-      {isLoading && <p className={`${styles.statusText} ${styles.loading}`}>読み込み中...</p>}
+        <div className={styles.filterTags}>
+          <button
+            type="button"
+            onClick={handleUnclassifiedToggle}
+            className={`${styles.filterTag} ${selectedUnclassified ? styles.filterTagActive : ""}`}
+          >
+            未分類のみ
+          </button>
+          {projects.map((project) => (
+            <button
+              key={project.id}
+              type="button"
+              onClick={() => handleProjectFilterChange(project.id)}
+              className={`${styles.filterTag} ${selectedProjectId === project.id ? styles.filterTagActive : ""}`}
+            >
+              {project.name}
+            </button>
+          ))}
+        </div>
+      </div>
 
-      {isError && (
+      {testCasesQuery.isLoading && (
+        <p className={`${styles.statusText} ${styles.loading}`}>読み込み中...</p>
+      )}
+
+      {testCasesQuery.isError && (
         <p className={`${styles.statusText} ${styles.error}`}>
-          エラーが発生しました: {error instanceof Error ? error.message : "不明なエラー"}
+          エラーが発生しました。テストケース一覧を取得できませんでした。
         </p>
       )}
 
-      {!isLoading && !isError && testCases && testCases.length === 0 && (
+      {!testCasesQuery.isLoading && !testCasesQuery.isError && testCases.length === 0 && (
         <div className={styles.emptyState}>
-          <p className={styles.emptyStateTitle}>テストケースがまだありません</p>
+          <p className={styles.emptyStateTitle}>条件に合うテストケースがありません</p>
           <p className={styles.emptyStateSubtext}>
-            「新規作成」ボタンから最初のテストケースを作成してください。
+            フィルタを変えるか、「新規作成」から最初のテストケースを追加してください。
           </p>
         </div>
       )}
 
-      {!isLoading && !isError && testCases && testCases.length > 0 && (
+      {!testCasesQuery.isLoading && !testCasesQuery.isError && testCases.length > 0 && (
         <div className={styles.listContainer}>
-          {testCases.map((tc) => (
+          {testCases.map((testCase) => (
             <TestCaseCard
-              key={tc.id}
-              testCase={tc}
+              key={testCase.id}
+              testCase={testCase}
+              projects={projects}
+              linkedAssets={linkedAssetMap[testCase.id] ?? []}
+              linkedProjectIds={projectMembershipMap[testCase.id] ?? []}
               onEdit={setEditTarget}
               onDelete={setDeleteTarget}
             />
@@ -551,7 +992,13 @@ export function TestCasesPage() {
 
       {isCreateOpen && (
         <TestCaseModal
-          projectId={projectId}
+          defaultProjectId={selectedProjectId}
+          initialProjectIds={
+            selectedProjectId !== null && !Number.isNaN(selectedProjectId) ? [selectedProjectId] : []
+          }
+          projects={projects}
+          availableAssets={availableAssetsQuery.data ?? []}
+          linkedAssets={[]}
           onClose={() => setIsCreateOpen(false)}
           onSubmit={(data) => createMutation.mutate(data)}
           isLoading={createMutation.isPending}
@@ -560,11 +1007,15 @@ export function TestCasesPage() {
 
       {editTarget && (
         <TestCaseModal
-          projectId={projectId}
           testCase={editTarget}
+          defaultProjectId={selectedProjectId}
+          initialProjectIds={projectMembershipMap[editTarget.id] ?? []}
+          projects={projects}
+          availableAssets={availableAssetsQuery.data ?? []}
+          linkedAssets={editLinkedAssetsQuery.data ?? []}
           onClose={() => setEditTarget(null)}
           onSubmit={(data) => updateMutation.mutate({ id: editTarget.id, data })}
-          isLoading={updateMutation.isPending}
+          isLoading={updateMutation.isPending || editLinkedAssetsQuery.isLoading}
         />
       )}
 

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -41,6 +41,7 @@ type TestCaseFormData = {
 function getInitialFormData(
   testCase?: TestCase,
   defaultProjectId?: number | null,
+  initialProjectIds: number[] = [],
   initialContextAssetIds: number[] = [],
 ): TestCaseFormData {
   if (testCase) {
@@ -49,7 +50,7 @@ function getInitialFormData(
       turns: testCase.turns,
       context_content: testCase.context_content ?? "",
       expected_description: testCase.expected_description ?? "",
-      project_ids: [],
+      project_ids: initialProjectIds,
       context_asset_ids: initialContextAssetIds,
     };
   }
@@ -350,6 +351,7 @@ function TestCaseModal({
     getInitialFormData(
       testCase,
       defaultProjectId,
+      initialProjectIds,
       linkedAssets.map((asset) => asset.id),
     ),
   );
@@ -362,14 +364,11 @@ function TestCaseModal({
       getInitialFormData(
         testCase,
         defaultProjectId,
+        initialProjectIds,
         linkedAssets.map((asset) => asset.id),
       ),
     );
-  }, [defaultProjectId, linkedAssets, testCase]);
-
-  useEffect(() => {
-    setFormData((prev) => ({ ...prev, project_ids: initialProjectIds }));
-  }, [initialProjectIds]);
+  }, [defaultProjectId, initialProjectIds, testCase?.id]);
 
   useEffect(() => {
     if (availableAssets.length === 0) {
@@ -795,6 +794,12 @@ export function TestCasesPage() {
     linkedAssetMap[testCase.id] = linkedAssetQueries[index]?.data ?? [];
   });
 
+  const isEditAssociationsLoading =
+    editTarget !== null &&
+    (projectsQuery.isLoading ||
+      projectMembershipQueries.some((query) => query.isPending) ||
+      editLinkedAssetsQuery.isLoading);
+
   function updateSearchParams(nextValues: {
     project_id?: number | null;
     unclassified?: boolean;
@@ -1006,7 +1011,16 @@ export function TestCasesPage() {
       )}
 
       {editTarget && (
+        isEditAssociationsLoading ? (
+          <div className={styles.modalOverlay}>
+            <div className={styles.modalContentSm}>
+              <h3 className={styles.modalTitle}>テストケースを編集</h3>
+              <p className={styles.statusText}>関連情報を読み込み中...</p>
+            </div>
+          </div>
+        ) : (
         <TestCaseModal
+          key={`edit-${editTarget.id}`}
           testCase={editTarget}
           defaultProjectId={selectedProjectId}
           initialProjectIds={projectMembershipMap[editTarget.id] ?? []}
@@ -1015,8 +1029,9 @@ export function TestCasesPage() {
           linkedAssets={editLinkedAssetsQuery.data ?? []}
           onClose={() => setEditTarget(null)}
           onSubmit={(data) => updateMutation.mutate({ id: editTarget.id, data })}
-          isLoading={updateMutation.isPending || editLinkedAssetsQuery.isLoading}
+          isLoading={updateMutation.isPending}
         />
+        )
       )}
 
       {deleteTarget && (


### PR DESCRIPTION
## 概要
- テストケース画面を `/test-cases` 基準の独立資産管理に移行
- project タグ編集と `context_assets` からの取り込み・関連付け UI を追加
- 既存の project 詳細やサイドバーから新画面へ遷移する導線に更新

## 変更理由
- Issue #124 の要件である project 親子依存の解消と context asset 連携を UI 上で完結させるため

## 影響
- テストケースをプロジェクト配下ではなく横断的に管理できるようになる
- context content のスナップショット保存を維持したまま、関連素材の管理も同じ画面で扱える

## 確認内容
- `pnpm --filter @prompt-reviewer/ui typecheck`
- `pnpm typecheck`
