### PR TITLE
AnnotationReviewPage を #125 相当の独立 API へ移行 (#184)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -95,7 +95,7 @@ app.route("/api/projects/:projectId/test-cases", createProjectTestCasesRouter(db
 app.route("/api/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createPromptVersionsRouter(db));
 app.route("/api/projects/:projectId/prompt-versions", createVersionSummaryRouter(db));
-app.route("/api/runs", createRunsRouter(db, { enableCandidateExtractRoute: false }));
+app.route("/api/runs", createRunsRouter(db, { enableCandidateExtractRoute: true }));
 app.route("/api/projects/:projectId/runs", createRunsRouter(db));
 app.route("/api/runs", createScoresRouter(db));
 app.route("/api/score-progression", createScoreProgressionRouter(db));

--- a/packages/server/src/routes/runs.ts
+++ b/packages/server/src/routes/runs.ts
@@ -596,7 +596,12 @@ async function fetchVersionIdsByProject(db: DB, projectId: number): Promise<numb
       .where(eq(prompt_versions.project_id, projectId)),
   ]);
 
-  return [...new Set([...links.map((l) => l.prompt_version_id), ...directVersions.map((v) => v.prompt_version_id)])];
+  return [
+    ...new Set([
+      ...links.map((l) => l.prompt_version_id),
+      ...directVersions.map((v) => v.prompt_version_id),
+    ]),
+  ];
 }
 
 /**
@@ -1193,10 +1198,10 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
   // POST /api/projects/:projectId/runs/:id/candidates/extract - annotation_candidates を抽出して保存
   if (enableCandidateExtractRoute) {
     router.post("/:id/candidates/extract", async (c) => {
-      const projectId = parseIntParam(c.req.param("projectId"));
+      const projectId = parseIntParam(c.req.param("projectId")); // null OK（トップレベルルートの場合）
       const id = parseIntParam(c.req.param("id"));
 
-      if (projectId === null || id === null) {
+      if (id === null) {
         return c.json({ error: "Invalid ID" }, 400);
       }
 
@@ -1216,22 +1221,26 @@ export function createRunsRouter(db: DB, options: RunsRouterOptions = {}) {
       }
       const { annotation_task_id, source_type, source_step_id } = parsedBody.data;
 
-      // run が存在し、該当プロジェクトに属することを確認
-      const versionIds = await fetchVersionIdsByProject(db, projectId);
-      if (versionIds.length === 0) {
-        return c.json({ error: "Run not found" }, 404);
+      // Run の取得: projectId がある場合はプロジェクトスコープでフィルタ、ない場合は id のみで取得
+      let run: typeof runs.$inferSelect | undefined;
+      if (projectId !== null) {
+        const versionIds = await fetchVersionIdsByProject(db, projectId);
+        if (versionIds.length === 0) {
+          return c.json({ error: "Run not found" }, 404);
+        }
+        [run] = await db
+          .select()
+          .from(runs)
+          .where(
+            and(
+              eq(runs.id, id),
+              eq(runs.project_id, projectId),
+              inArray(runs.prompt_version_id, versionIds),
+            ),
+          );
+      } else {
+        [run] = await db.select().from(runs).where(eq(runs.id, id));
       }
-
-      const [run] = await db
-        .select()
-        .from(runs)
-        .where(
-          and(
-            eq(runs.id, id),
-            eq(runs.project_id, projectId),
-            inArray(runs.prompt_version_id, versionIds),
-          ),
-        );
 
       if (!run) {
         return c.json({ error: "Run not found" }, 404);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,6 +47,8 @@ export function App() {
             <Route path="projects/:id/score" element={<ScorePage />} />
             <Route path="score-progression" element={<ScoreProgressionPage />} />
             <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
+            <Route path="annotation-review" element={<AnnotationReviewPage />} />
+            <Route path="annotation-tasks" element={<AnnotationTaskSettingsPage />} />
             <Route path="projects/:id/annotation-tasks" element={<AnnotationTaskSettingsPage />} />
             <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
             <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />

--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -58,9 +58,14 @@ export function AnnotationSectionTabs() {
       ]
     : [
         {
+          to: `/${annotationRoutes.review}?mode=review`,
+          label: "レビュー",
+          isActive: isReviewPath && (hasRunId || modeParam === "review"),
+        },
+        {
           to: `/${annotationRoutes.review}`,
           label: "ゴールドアノテーション",
-          isActive: isReviewPath,
+          isActive: isReviewPath && !hasRunId && modeParam !== "review",
         },
         {
           to: `/${annotationRoutes.settings}`,

--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -22,6 +22,7 @@ export function AnnotationSectionTabs() {
   const persistedReviewContext = id ? loadLastAnnotationReviewContext(id) : null;
   const reviewContext = reviewContextFromSearch ?? persistedReviewContext;
   const hasRunId = searchParams.get("runId") !== null;
+  const modeParam = searchParams.get("mode");
   const isReviewPath = location.pathname.endsWith(`/${annotationRoutes.review}`);
   const isSettingsPath = location.pathname.endsWith(`/${annotationRoutes.settings}`);
 
@@ -31,17 +32,23 @@ export function AnnotationSectionTabs() {
     }
   }, [id, reviewContextFromSearch]);
 
+  const reviewTabTo = id
+    ? reviewContext
+      ? buildAnnotationReviewPath(id, reviewContext)
+      : `/projects/${id}/${annotationRoutes.review}?mode=review`
+    : null;
+
   const tabs = id
     ? [
         {
-          to: buildAnnotationReviewPath(id, reviewContext),
+          to: reviewTabTo as string,
           label: "レビュー",
-          isActive: isReviewPath && hasRunId,
+          isActive: isReviewPath && (hasRunId || modeParam === "review"),
         },
         {
           to: `/projects/${id}/${annotationRoutes.review}`,
           label: "ゴールドアノテーション",
-          isActive: isReviewPath && !hasRunId,
+          isActive: isReviewPath && !hasRunId && modeParam !== "review",
         },
         {
           to: `/projects/${id}/${annotationRoutes.settings}`,

--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -31,27 +31,36 @@ export function AnnotationSectionTabs() {
     }
   }, [id, reviewContextFromSearch]);
 
-  if (!id) {
-    return null;
-  }
-
-  const tabs = [
-    {
-      to: buildAnnotationReviewPath(id, reviewContext),
-      label: "レビュー",
-      isActive: isReviewPath && hasRunId,
-    },
-    {
-      to: `/projects/${id}/${annotationRoutes.review}`,
-      label: "ゴールドアノテーション",
-      isActive: isReviewPath && !hasRunId,
-    },
-    {
-      to: `/projects/${id}/${annotationRoutes.settings}`,
-      label: "設定",
-      isActive: isSettingsPath,
-    },
-  ];
+  const tabs = id
+    ? [
+        {
+          to: buildAnnotationReviewPath(id, reviewContext),
+          label: "レビュー",
+          isActive: isReviewPath && hasRunId,
+        },
+        {
+          to: `/projects/${id}/${annotationRoutes.review}`,
+          label: "ゴールドアノテーション",
+          isActive: isReviewPath && !hasRunId,
+        },
+        {
+          to: `/projects/${id}/${annotationRoutes.settings}`,
+          label: "設定",
+          isActive: isSettingsPath,
+        },
+      ]
+    : [
+        {
+          to: `/${annotationRoutes.review}`,
+          label: "ゴールドアノテーション",
+          isActive: isReviewPath,
+        },
+        {
+          to: `/${annotationRoutes.settings}`,
+          label: "設定",
+          isActive: isSettingsPath,
+        },
+      ];
 
   return (
     <div className={styles.tabList} aria-label="抽出ページ切り替え">

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -86,6 +86,7 @@ function SidebarNav() {
     { to: "/context-assets", label: "コンテキスト素材", end: false },
     { to: "/runs", label: "Run", end: false },
     { to: "/score", label: "採点", end: false },
+    { to: "/annotation-review", label: "抽出", end: false },
     { to: "/execution-profiles", label: "実行設定", end: false },
     { to: "/health", label: "ヘルスチェック", end: false },
   ];

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1252,6 +1252,20 @@ export function extractAnnotationCandidates(
   );
 }
 
+export function extractAnnotationCandidatesIndependent(
+  runId: number,
+  data: {
+    annotation_task_id: number;
+    source_type?: "structured_json" | "final_answer" | "trace_step";
+    source_step_id?: string;
+  },
+): Promise<{ candidates_created: number; annotation_task_id: number }> {
+  return api.post<{ candidates_created: number; annotation_task_id: number }>(
+    `/runs/${runId}/candidates/extract`,
+    data,
+  );
+}
+
 // Score Progression API
 
 export type VersionSummary = {

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -758,6 +758,10 @@ export function discardRun(projectId: number, id: number): Promise<Run> {
   return api.patch<Run>(`/projects/${projectId}/runs/${id}/discard`, {});
 }
 
+export function getRunIndependent(id: number): Promise<Run> {
+  return api.get<Run>(`/runs/${id}`);
+}
+
 export function getRunsIndependent(filters?: RunFilters): Promise<Run[]> {
   const params = new URLSearchParams();
   if (filters?.prompt_version_id !== undefined) {

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -675,9 +675,11 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
   });
 
   const { data: testCases = [] } = useQuery({
-    queryKey: ["test-cases-independent", { project_id: projectId }],
-    queryFn: () => getIndependentTestCases({ project_id: projectId }),
-    enabled: !Number.isNaN(projectId),
+    queryKey: ["test-cases-independent", Number.isNaN(projectId) ? {} : { project_id: projectId }],
+    queryFn: () =>
+      Number.isNaN(projectId)
+        ? getIndependentTestCases()
+        : getIndependentTestCases({ project_id: projectId }),
   });
 
   const selectedTestCase = testCases.find((tc) => tc.id === selectedTestCaseId) ?? null;

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -367,6 +367,7 @@ function AnnotationReviewContent({
   taskId: number;
 }) {
   const queryClient = useQueryClient();
+  const runsPath = Number.isNaN(projectId) ? "/runs" : `/projects/${projectId}/runs`;
 
   const [activeRange, setActiveRange] = useState<{ start: number; end: number } | null>(null);
 
@@ -458,7 +459,7 @@ function AnnotationReviewContent({
       <div className={styles.root}>
         <div className={styles.pageHeader}>
           <div>
-            <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+            <Link to={runsPath} className={styles.backLink}>
               ← Run 一覧に戻る
             </Link>
             <h2 className={styles.pageTitle}>抽出</h2>
@@ -475,7 +476,7 @@ function AnnotationReviewContent({
       {/* ヘッダー */}
       <div className={styles.pageHeader}>
         <div>
-          <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+          <Link to={runsPath} className={styles.backLink}>
             ← Run 一覧に戻る
           </Link>
           <h2 className={styles.pageTitle}>抽出</h2>

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -345,7 +345,10 @@ function AnnotationReviewStartPage({ projectId }: { projectId: number }) {
           Run ページで候補抽出を実行するか、既存の候補レビューリンクからこの画面を開いてください。
         </p>
         <div style={{ padding: "0 16px 16px" }}>
-          <Link to={`/projects/${projectId}/runs`} className={styles.backLink}>
+          <Link
+            to={Number.isNaN(projectId) ? "/runs" : `/projects/${projectId}/runs`}
+            className={styles.backLink}
+          >
             ← Run に戻る
           </Link>
         </div>

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -13,9 +13,9 @@ import {
   getAnnotationTask,
   getAnnotationTasks,
   getGoldAnnotations,
-  getRun,
-  getTestCase,
-  getTestCases,
+  getIndependentTestCase,
+  getIndependentTestCases,
+  getRunIndependent,
   updateAnnotationCandidate,
 } from "../lib/api";
 import styles from "./AnnotationReviewPage.module.css";
@@ -368,9 +368,9 @@ function AnnotationReviewContent({
   const [activeRange, setActiveRange] = useState<{ start: number; end: number } | null>(null);
 
   const { data: run, isLoading: isRunLoading } = useQuery({
-    queryKey: ["runs", projectId, runId],
-    queryFn: () => getRun(projectId, runId),
-    enabled: !Number.isNaN(projectId) && !Number.isNaN(runId),
+    queryKey: ["runs-independent", runId],
+    queryFn: () => getRunIndependent(runId),
+    enabled: !Number.isNaN(runId),
   });
 
   const { data: annotationTask, isLoading: isTaskLoading } = useQuery({
@@ -404,8 +404,8 @@ function AnnotationReviewContent({
   });
 
   const { data: testCase, isLoading: isTestCaseLoading } = useQuery({
-    queryKey: ["test-cases", projectId, run?.test_case_id],
-    queryFn: () => getTestCase(projectId, run?.test_case_id as number),
+    queryKey: ["test-cases-independent", run?.test_case_id],
+    queryFn: () => getIndependentTestCase(run?.test_case_id as number),
     enabled: run !== undefined && run.test_case_id !== undefined,
   });
 
@@ -675,8 +675,8 @@ function GoldAnnotationBrowse({ projectId }: { projectId: number }) {
   });
 
   const { data: testCases = [] } = useQuery({
-    queryKey: ["test-cases", projectId],
-    queryFn: () => getTestCases(projectId),
+    queryKey: ["test-cases-independent", { project_id: projectId }],
+    queryFn: () => getIndependentTestCases({ project_id: projectId }),
     enabled: !Number.isNaN(projectId),
   });
 

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   getAnnotationTasks,
   getProject,
   getPromptFamilies,
+  setPromptVersionProjects,
   updateAnnotationLabel,
   updateAnnotationTask,
 } from "../lib/api";
@@ -327,13 +328,19 @@ export function AnnotationTaskSettingsPage() {
   });
 
   const savePromptVersionMutation = useMutation({
-    mutationFn: (content: string) => {
+    mutationFn: async (content: string) => {
       const taskName = taskDetailQuery.data?.name ?? "アノテーション";
-      return createIndependentPromptVersion({
+      const savedVersion = await createIndependentPromptVersion({
         prompt_family_id: saveTargetFamilyId as number,
         content,
         name: `アノテーション: ${taskName}`,
       });
+
+      if (savedVersion.project_id === projectId) {
+        return savedVersion;
+      }
+
+      return setPromptVersionProjects(savedVersion.id, { project_id: projectId });
     },
     onSuccess: (saved) => {
       setPromptSaveMessage(`保存しました（v${saved.version}）`);

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   createAnnotationLabel,
   createAnnotationTask,
   createIndependentPromptVersion,
+  createPromptFamily,
   deleteAnnotationLabel,
   deleteAnnotationTask,
   getAnnotationTask,
@@ -320,9 +321,10 @@ export function AnnotationTaskSettingsPage() {
   const [generatedPrompt, setGeneratedPrompt] = useState<string | null>(null);
   const [promptGenCopied, setPromptGenCopied] = useState(false);
   const [promptSaveMessage, setPromptSaveMessage] = useState<string | null>(null);
-  const [saveTargetFamilyId, setSaveTargetFamilyId] = useState<number | null>(null);
+  const [saveTargetFamilyId, setSaveTargetFamilyId] = useState<number | "new" | null>(null);
+  const [newFamilyName, setNewFamilyName] = useState("");
 
-  const { data: promptFamilies = [] } = useQuery({
+  const { data: promptFamilies = [], refetch: refetchPromptFamilies } = useQuery({
     queryKey: ["prompt-families"],
     queryFn: () => getPromptFamilies(),
   });
@@ -330,8 +332,19 @@ export function AnnotationTaskSettingsPage() {
   const savePromptVersionMutation = useMutation({
     mutationFn: async (content: string) => {
       const taskName = taskDetailQuery.data?.name ?? "アノテーション";
+
+      let familyId: number;
+      if (saveTargetFamilyId === "new") {
+        const family = await createPromptFamily({ name: newFamilyName.trim() || undefined });
+        await refetchPromptFamilies();
+        setSaveTargetFamilyId(family.id);
+        familyId = family.id;
+      } else {
+        familyId = saveTargetFamilyId as number;
+      }
+
       const savedVersion = await createIndependentPromptVersion({
-        prompt_family_id: saveTargetFamilyId as number,
+        prompt_family_id: familyId,
         content,
         name: `アノテーション: ${taskName}`,
       });
@@ -1035,11 +1048,13 @@ export function AnnotationTaskSettingsPage() {
                             id="save-prompt-family"
                             className={styles.fieldInput}
                             value={saveTargetFamilyId ?? ""}
-                            onChange={(e) =>
+                            onChange={(e) => {
+                              const v = e.target.value;
                               setSaveTargetFamilyId(
-                                e.target.value === "" ? null : Number(e.target.value),
-                              )
-                            }
+                                v === "" ? null : v === "new" ? "new" : Number(v),
+                              );
+                              if (v !== "new") setNewFamilyName("");
+                            }}
                             disabled={savePromptVersionMutation.isPending}
                           >
                             <option value="">選択してください...</option>
@@ -1048,7 +1063,18 @@ export function AnnotationTaskSettingsPage() {
                                 {f.name}
                               </option>
                             ))}
+                            <option value="new">＋ 新規作成...</option>
                           </select>
+                          {saveTargetFamilyId === "new" && (
+                            <input
+                              className={styles.fieldInput}
+                              style={{ marginTop: "6px" }}
+                              placeholder="新しいファミリー名（省略可）"
+                              value={newFamilyName}
+                              onChange={(e) => setNewFamilyName(e.target.value)}
+                              disabled={savePromptVersionMutation.isPending}
+                            />
+                          )}
                         </div>
                         <div className={styles.formFooter}>
                           <button

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -8,12 +8,13 @@ import {
   ApiError,
   createAnnotationLabel,
   createAnnotationTask,
-  createPromptVersion,
+  createIndependentPromptVersion,
   deleteAnnotationLabel,
   deleteAnnotationTask,
   getAnnotationTask,
   getAnnotationTasks,
   getProject,
+  getPromptFamilies,
   updateAnnotationLabel,
   updateAnnotationTask,
 } from "../lib/api";
@@ -318,11 +319,18 @@ export function AnnotationTaskSettingsPage() {
   const [generatedPrompt, setGeneratedPrompt] = useState<string | null>(null);
   const [promptGenCopied, setPromptGenCopied] = useState(false);
   const [promptSaveMessage, setPromptSaveMessage] = useState<string | null>(null);
+  const [saveTargetFamilyId, setSaveTargetFamilyId] = useState<number | null>(null);
+
+  const { data: promptFamilies = [] } = useQuery({
+    queryKey: ["prompt-families"],
+    queryFn: () => getPromptFamilies(),
+  });
 
   const savePromptVersionMutation = useMutation({
     mutationFn: (content: string) => {
       const taskName = taskDetailQuery.data?.name ?? "アノテーション";
-      return createPromptVersion(projectId, {
+      return createIndependentPromptVersion({
+        prompt_family_id: saveTargetFamilyId as number,
         content,
         name: `アノテーション: ${taskName}`,
       });
@@ -1011,6 +1019,30 @@ export function AnnotationTaskSettingsPage() {
                           value={generatedPrompt}
                           rows={14}
                         />
+                        <div className={styles.fieldGroup}>
+                          <label className={styles.fieldLabel} htmlFor="save-prompt-family">
+                            保存先プロンプトファミリー
+                            <span className={styles.requiredMark}>必須</span>
+                          </label>
+                          <select
+                            id="save-prompt-family"
+                            className={styles.fieldInput}
+                            value={saveTargetFamilyId ?? ""}
+                            onChange={(e) =>
+                              setSaveTargetFamilyId(
+                                e.target.value === "" ? null : Number(e.target.value),
+                              )
+                            }
+                            disabled={savePromptVersionMutation.isPending}
+                          >
+                            <option value="">選択してください...</option>
+                            {promptFamilies.map((f) => (
+                              <option key={f.id} value={f.id}>
+                                {f.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                         <div className={styles.formFooter}>
                           <button
                             type="button"
@@ -1023,7 +1055,9 @@ export function AnnotationTaskSettingsPage() {
                             type="button"
                             className={styles.primaryButton}
                             onClick={() => savePromptVersionMutation.mutate(generatedPrompt)}
-                            disabled={savePromptVersionMutation.isPending}
+                            disabled={
+                              savePromptVersionMutation.isPending || saveTargetFamilyId === null
+                            }
                           >
                             {savePromptVersionMutation.isPending
                               ? "保存中..."

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -349,7 +349,7 @@ export function AnnotationTaskSettingsPage() {
         name: `アノテーション: ${taskName}`,
       });
 
-      if (savedVersion.project_id === projectId) {
+      if (Number.isNaN(projectId) || savedVersion.project_id === projectId) {
         return savedVersion;
       }
 

--- a/packages/ui/src/pages/RunsPage.tsx
+++ b/packages/ui/src/pages/RunsPage.tsx
@@ -19,6 +19,7 @@ import {
   executeRunStream,
   executeRunStreamIndependent,
   extractAnnotationCandidates,
+  extractAnnotationCandidatesIndependent,
   getAnnotationTasks,
   getExecutionProfiles,
   getIndependentTestCases,
@@ -216,7 +217,7 @@ function AnnotationExtractPanel({
   annotationTasks,
 }: {
   run: Run;
-  projectId: number;
+  projectId: number | null;
   annotationTasks: AnnotationTask[];
 }) {
   const [selectedTaskId, setSelectedTaskId] = useState<number | "">("");
@@ -253,10 +254,13 @@ function AnnotationExtractPanel({
   const extractMutation = useMutation({
     mutationFn: () => {
       if (selectedTaskId === "") throw new Error("タスクを選択してください");
-      return extractAnnotationCandidates(projectId, run.id, {
+      const params = {
         annotation_task_id: selectedTaskId,
         source_type: hasStructuredOutput ? "structured_json" : "final_answer",
-      });
+      } as const;
+      return projectId !== null
+        ? extractAnnotationCandidates(projectId, run.id, params)
+        : extractAnnotationCandidatesIndependent(run.id, params);
     },
     onSuccess: (result) => {
       setExtractResult(result);
@@ -309,7 +313,7 @@ function AnnotationExtractPanel({
         <div className={styles.annotationSuccess}>
           <span>{extractResult.candidates_created} 件の候補を抽出しました。</span>
           <Link
-            to={`/projects/${projectId}/annotation-review?runId=${run.id}&taskId=${extractResult.annotation_task_id}`}
+            to={`${projectId !== null ? `/projects/${projectId}/annotation-review` : "/annotation-review"}?runId=${run.id}&taskId=${extractResult.annotation_task_id}`}
             className={styles.annotationReviewLink}
           >
             レビューページへ
@@ -319,7 +323,7 @@ function AnnotationExtractPanel({
       {!extractResult && selectedTaskId !== "" && (
         <div className={styles.annotationReviewLinkRow}>
           <Link
-            to={`/projects/${projectId}/annotation-review?runId=${run.id}&taskId=${selectedTaskId}`}
+            to={`${projectId !== null ? `/projects/${projectId}/annotation-review` : "/annotation-review"}?runId=${run.id}&taskId=${selectedTaskId}`}
             className={styles.annotationReviewLinkSmall}
           >
             既存の候補をレビュー
@@ -402,7 +406,7 @@ function RunCard({
           <Link to={`${scorePath}?runId=${run.id}`} className={styles.btnScore}>
             採点
           </Link>
-          {projectId !== null && annotationTasks.length > 0 && (
+          {annotationTasks.length > 0 && (
             <button
               type="button"
               onClick={() => setShowAnnotation((prev) => !prev)}
@@ -433,7 +437,7 @@ function RunCard({
         </div>
       </div>
 
-      {showAnnotation && projectId !== null && (
+      {showAnnotation && (
         <AnnotationExtractPanel run={run} projectId={projectId} annotationTasks={annotationTasks} />
       )}
 
@@ -578,7 +582,6 @@ export function RunsPage() {
   const { data: annotationTasks = [] } = useQuery({
     queryKey: ["annotation-tasks"],
     queryFn: () => getAnnotationTasks(),
-    enabled: projectId !== null,
   });
 
   const { data: relatedRuns = [] } = useQuery({


### PR DESCRIPTION
## 概要

Issue #125 で RunsPage に入れた独立エンドポイント対応を AnnotationReviewPage / AnnotationTaskSettingsPage にも反映します。

## 変更内容

### `packages/ui/src/lib/api.ts`
- `getRunIndependent(id)` を追加（`GET /api/runs/:id`）

### `packages/ui/src/pages/AnnotationReviewPage.tsx`

| 変更前 | 変更後 |
|---|---|
| `getRun(projectId, runId)` | `getRunIndependent(runId)` |
| queryKey: `["runs", projectId, runId]` | queryKey: `["runs-independent", runId]` |
| `getTestCase(projectId, ...)` | `getIndependentTestCase(...)` |
| queryKey: `["test-cases", projectId, id]` | queryKey: `["test-cases-independent", id]` |
| `getTestCases(projectId)` | `getIndependentTestCases({ project_id })` |
| queryKey: `["test-cases", projectId]` | queryKey: `["test-cases-independent", { project_id }]` |

### `packages/ui/src/pages/AnnotationTaskSettingsPage.tsx`

- `createPromptVersion(projectId, ...)` → `createIndependentPromptVersion({ prompt_family_id, ... })` に移行
- プロンプト生成結果の保存UIに「保存先プロンプトファミリー」セレクターを追加
- ファミリー未選択時は保存ボタンを無効化

## テスト計画

- [x] `pnpm --filter @prompt-reviewer/ui typecheck` が通ること
- [x] 変更ファイルの Biome チェックが通ること