### PR TITLE
feat: Projects画面をラベル管理UIへ再設計する

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4,10 +4,12 @@ import { Layout } from "./components/Layout";
 import { AnnotationReviewPage } from "./pages/AnnotationReviewPage";
 import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
 import { ContextAssetsPage } from "./pages/ContextAssetsPage";
+import { ContextFilesPage } from "./pages/ContextFilesPage";
 import { ExecutionProfilesPage } from "./pages/ExecutionProfilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { ProjectDetailPage } from "./pages/ProjectDetailPage";
+import { ProjectSettingsPage } from "./pages/ProjectSettingsPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
 import { PromptsPage } from "./pages/PromptsPage";
 import { RunsPage } from "./pages/RunsPage";
@@ -44,6 +46,16 @@ export function App() {
             <Route path="annotation-tasks" element={<AnnotationTaskSettingsPage />} />
             <Route path="execution-profiles" element={<ExecutionProfilesPage />} />
             <Route path="context-assets" element={<ContextAssetsPage />} />
+            {/* 後方互換: 旧 project 配下ルート */}
+            <Route path="projects/:id/context-files" element={<ContextFilesPage />} />
+            <Route path="projects/:id/test-cases" element={<TestCasesPage />} />
+            <Route path="projects/:id/prompts" element={<PromptsPage />} />
+            <Route path="projects/:id/runs" element={<RunsPage />} />
+            <Route path="projects/:id/score" element={<ScorePage />} />
+            <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
+            <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
+            <Route path="projects/:id/annotation-tasks" element={<AnnotationTaskSettingsPage />} />
+            <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             {/* ユーティリティ */}
             <Route path="health" element={<HealthPage />} />
             {/* 404 */}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4,12 +4,10 @@ import { Layout } from "./components/Layout";
 import { AnnotationReviewPage } from "./pages/AnnotationReviewPage";
 import { AnnotationTaskSettingsPage } from "./pages/AnnotationTaskSettingsPage";
 import { ContextAssetsPage } from "./pages/ContextAssetsPage";
-import { ContextFilesPage } from "./pages/ContextFilesPage";
 import { ExecutionProfilesPage } from "./pages/ExecutionProfilesPage";
 import { HealthPage } from "./pages/HealthPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { ProjectDetailPage } from "./pages/ProjectDetailPage";
-import { ProjectSettingsPage } from "./pages/ProjectSettingsPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
 import { PromptsPage } from "./pages/PromptsPage";
 import { RunsPage } from "./pages/RunsPage";
@@ -32,26 +30,18 @@ export function App() {
       <BrowserRouter>
         <Routes>
           <Route element={<Layout />}>
-            {/* トップ: プロジェクト一覧 */}
+            {/* ラベル管理 */}
             <Route index element={<ProjectsPage />} />
-            {/* プロジェクト詳細 */}
+            {/* 後方互換: /projects/:id はトップにリダイレクト */}
             <Route path="projects/:id" element={<ProjectDetailPage />} />
-            <Route path="projects/:id/context-files" element={<ContextFilesPage />} />
+            {/* 資産管理（ラベルフィルタはクエリパラメータで対応） */}
             <Route path="test-cases" element={<TestCasesPage />} />
-            <Route path="projects/:id/test-cases" element={<TestCasesPage />} />
             <Route path="prompts" element={<PromptsPage />} />
-            <Route path="projects/:id/prompts" element={<PromptsPage />} />
             <Route path="runs" element={<RunsPage />} />
-            <Route path="projects/:id/runs" element={<RunsPage />} />
             <Route path="score" element={<ScorePage />} />
-            <Route path="projects/:id/score" element={<ScorePage />} />
             <Route path="score-progression" element={<ScoreProgressionPage />} />
-            <Route path="projects/:id/score-progression" element={<ScoreProgressionPage />} />
             <Route path="annotation-review" element={<AnnotationReviewPage />} />
             <Route path="annotation-tasks" element={<AnnotationTaskSettingsPage />} />
-            <Route path="projects/:id/annotation-tasks" element={<AnnotationTaskSettingsPage />} />
-            <Route path="projects/:id/annotation-review" element={<AnnotationReviewPage />} />
-            <Route path="projects/:id/settings" element={<ProjectSettingsPage />} />
             <Route path="execution-profiles" element={<ExecutionProfilesPage />} />
             <Route path="context-assets" element={<ContextAssetsPage />} />
             {/* ユーティリティ */}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -1,9 +1,4 @@
-import { NavLink, Outlet, useLocation, useParams } from "react-router";
-import {
-  buildAnnotationReviewPath,
-  getAnnotationReviewContextFromSearch,
-  loadLastAnnotationReviewContext,
-} from "../lib/annotationReviewNavigation";
+import { NavLink, Outlet } from "react-router";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
@@ -17,70 +12,9 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
   fontSize: "14px",
 });
 
-function ProjectSubNav({ projectId }: { projectId: string }) {
-  const location = useLocation();
-  const reviewContext =
-    getAnnotationReviewContextFromSearch(location.search) ??
-    loadLastAnnotationReviewContext(projectId);
-  const annotationReviewPath = buildAnnotationReviewPath(projectId, reviewContext);
-
-  const subNavItems = [
-    { to: `/projects/${projectId}`, label: "ホーム", end: true },
-    { to: `/projects/${projectId}/context-files`, label: "コンテキスト" },
-    { to: `/test-cases?project_id=${projectId}`, label: "テストケース" },
-    { to: `/projects/${projectId}/prompts`, label: "プロンプト" },
-    { to: `/projects/${projectId}/runs`, label: "Run" },
-    { to: `/projects/${projectId}/score`, label: "採点" },
-    {
-      to: annotationReviewPath,
-      label: "抽出",
-      matchPaths: [
-        `/projects/${projectId}/annotation-review`,
-        `/projects/${projectId}/annotation-tasks`,
-      ],
-    },
-    { to: "/execution-profiles", label: "実行設定" },
-  ];
-
-  return (
-    <div style={{ marginTop: "8px" }}>
-      <div
-        style={{
-          padding: "4px 16px",
-          fontSize: "11px",
-          color: "#6c7086",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          marginBottom: "4px",
-        }}
-      >
-        プロジェクト
-      </div>
-      {subNavItems.map(({ to, label, end, matchPaths }) => (
-        <NavLink
-          key={to}
-          to={to}
-          end={end}
-          style={
-            matchPaths
-              ? navLinkStyle({
-                  isActive: matchPaths.some((path) => location.pathname.startsWith(path)),
-                })
-              : navLinkStyle
-          }
-        >
-          {label}
-        </NavLink>
-      ))}
-    </div>
-  );
-}
-
 function SidebarNav() {
-  const { id } = useParams<{ id?: string }>();
-
   const topNavItems = [
-    { to: "/", label: "プロジェクト一覧", end: true },
+    { to: "/", label: "ラベル管理", end: true },
     { to: "/test-cases", label: "テストケース", end: false },
     { to: "/prompts", label: "プロンプト", end: false },
     { to: "/context-assets", label: "コンテキスト素材", end: false },
@@ -98,7 +32,6 @@ function SidebarNav() {
           {label}
         </NavLink>
       ))}
-      {id && <ProjectSubNav projectId={id} />}
     </nav>
   );
 }

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -217,6 +217,13 @@ export function createProject(data: {
   return api.post<Project>("/projects", data);
 }
 
+export function updateProject(
+  id: number,
+  data: { name?: string; description?: string },
+): Promise<Project> {
+  return api.patch<Project>(`/projects/${id}`, data);
+}
+
 export function deleteProject(id: number): Promise<void> {
   return api.delete<void>(`/projects/${id}`);
 }

--- a/packages/ui/src/lib/useActiveLabel.ts
+++ b/packages/ui/src/lib/useActiveLabel.ts
@@ -2,6 +2,14 @@ import { useState } from "react";
 
 const STORAGE_KEY = "prompt_reviewer_active_label_id";
 
+export function clearStoredActiveLabelId() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
 export function getStoredActiveLabelId(): number | null {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -17,14 +25,14 @@ export function useActiveLabel() {
   const [activeLabelId, setActiveLabelIdState] = useState<number | null>(getStoredActiveLabelId);
 
   function setActiveLabelId(id: number | null) {
-    try {
-      if (id === null) {
-        localStorage.removeItem(STORAGE_KEY);
-      } else {
+    if (id === null) {
+      clearStoredActiveLabelId();
+    } else {
+      try {
         localStorage.setItem(STORAGE_KEY, String(id));
+      } catch {
+        // localStorage unavailable
       }
-    } catch {
-      // localStorage unavailable
     }
     setActiveLabelIdState(id);
   }

--- a/packages/ui/src/lib/useActiveLabel.ts
+++ b/packages/ui/src/lib/useActiveLabel.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+const STORAGE_KEY = "prompt_reviewer_active_label_id";
+
+export function getStoredActiveLabelId(): number | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    const parsed = Number(stored);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function useActiveLabel() {
+  const [activeLabelId, setActiveLabelIdState] = useState<number | null>(getStoredActiveLabelId);
+
+  function setActiveLabelId(id: number | null) {
+    try {
+      if (id === null) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        localStorage.setItem(STORAGE_KEY, String(id));
+      }
+    } catch {
+      // localStorage unavailable
+    }
+    setActiveLabelIdState(id);
+  }
+
+  return { activeLabelId, setActiveLabelId };
+}

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -573,7 +573,7 @@ function AnnotationReviewContent({
 }
 
 export function AnnotationReviewPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id?: string }>();
   const [searchParams] = useSearchParams();
   const projectId = Number(id);
   const runIdParam = searchParams.get("runId");

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -114,7 +114,7 @@ function buildLabelForm(label?: AnnotationLabel): LabelFormState {
 }
 
 export function AnnotationTaskSettingsPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id?: string }>();
   const projectId = Number(id);
   const queryClient = useQueryClient();
 
@@ -403,7 +403,7 @@ export function AnnotationTaskSettingsPage() {
           <p className={styles.eyebrow}>Annotation Task Settings</p>
           <h2 className={styles.pageTitle}>抽出</h2>
           <p className={styles.pageDescription}>
-            {project?.name ?? "プロジェクト"} で使う annotation task と label を準備します。
+            {project?.name ?? "全体"} で使う annotation task と label を準備します。
             現在の初期実装では output mode は <code>span_label</code> 固定です。
           </p>
           <AnnotationSectionTabs />

--- a/packages/ui/src/pages/ContextAssetsPage.module.css
+++ b/packages/ui/src/pages/ContextAssetsPage.module.css
@@ -195,14 +195,14 @@
 }
 
 .projectBadge {
-  composes: badge from '../styles/shared.module.css';
-  padding: 4px 10px;
+  padding: 6px 12px;
   font-size: 12px;
   color: var(--c-subtext);
   cursor: pointer;
-  background: var(--c-overlay);
+  background: transparent;
   border: 1px solid var(--c-border);
-  border-radius: 4px;
+  border-radius: 6px;
+  white-space: nowrap;
 }
 
 .projectBadgeActive {

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -9,6 +9,7 @@ import { EditorView } from "@codemirror/view";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import CodeMirror from "@uiw/react-codemirror";
 import { useEffect, useRef, useState } from "react";
+import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import {
   type ContextAssetDetail,
   type ContextAssetFilters,
@@ -97,7 +98,10 @@ export function ContextAssetsPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [createForm, setCreateForm] = useState<CreateFormState>(EMPTY_CREATE_FORM);
   const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
-  const [filters, setFilters] = useState<ContextAssetFilters>({});
+  const [filters, setFilters] = useState<ContextAssetFilters>(() => {
+    const activeId = getStoredActiveLabelId();
+    return activeId !== null ? { project_id: activeId } : {};
+  });
   const [searchInput, setSearchInput] = useState("");
   const [selectedProjectIds, setSelectedProjectIds] = useState<number[]>([]);
 

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -235,6 +235,7 @@ export function ContextAssetsPage() {
   function handleProjectFilterChange(projectId: number) {
     setFilters((prev) => ({
       ...prev,
+      unclassified: undefined,
       project_id: prev.project_id === projectId ? undefined : projectId,
     }));
   }
@@ -242,6 +243,7 @@ export function ContextAssetsPage() {
   function handleUnclassifiedToggle() {
     setFilters((prev) => ({
       ...prev,
+      project_id: undefined,
       unclassified: prev.unclassified ? undefined : true,
     }));
   }

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -1,69 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link, useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import { getProject } from "../lib/api";
 
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const projectId = Number(id);
 
-  const {
-    data: project,
-    isLoading,
-    isError,
-  } = useQuery({
+  const { data: project, isLoading } = useQuery({
     queryKey: ["project", projectId],
     queryFn: () => getProject(projectId),
     enabled: !Number.isNaN(projectId),
   });
 
-  const title = isLoading
-    ? "読み込み中..."
-    : isError
-      ? "プロジェクト詳細"
-      : (project?.name ?? "プロジェクト詳細");
+  // ラベル管理画面にリダイレクト（後方互換のためルートは残す）
+  if (!isLoading && project) {
+    void navigate("/", { replace: true });
+    return null;
+  }
 
-  return (
-    <div>
-      <h2 style={{ margin: "0 0 16px", fontSize: "20px" }}>{title}</h2>
-      <p style={{ marginBottom: "16px", color: "#a6adc8" }}>
-        プロジェクト ID: <code style={{ color: "#cba6f7" }}>{id}</code>
-      </p>
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-          gap: "12px",
-        }}
-      >
-        {[
-          { to: "context-files", label: "コンテキスト管理" },
-          { to: `/test-cases?project_id=${id}`, label: "テストケース管理" },
-          { to: `/prompts?project_id=${id}`, label: "プロンプト管理" },
-          { to: "runs", label: "Run 実行・管理" },
-          { to: "score", label: "採点" },
-          { to: "annotation-tasks", label: "アノテーション設定" },
-          { to: "settings", label: "実行設定" },
-        ].map(({ to, label }) => (
-          <Link
-            key={to}
-            to={to}
-            style={{
-              display: "block",
-              padding: "16px",
-              backgroundColor: "#313244",
-              borderRadius: "8px",
-              textDecoration: "none",
-              color: "#cdd6f4",
-              border: "1px solid #45475a",
-            }}
-          >
-            {label}
-          </Link>
-        ))}
-      </div>
-      <p style={{ marginTop: "16px", color: "#a6adc8", fontSize: "13px" }}>
-        Review 用の task / label 準備は「アノテーション設定」から行えます。
-      </p>
-    </div>
-  );
+  return null;
 }

--- a/packages/ui/src/pages/ProjectDetailPage.tsx
+++ b/packages/ui/src/pages/ProjectDetailPage.tsx
@@ -1,22 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
-import { useNavigate, useParams } from "react-router";
+import { Navigate, useParams } from "react-router";
 import { getProject } from "../lib/api";
 
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const projectId = Number(id);
 
-  const { data: project, isLoading } = useQuery({
+  const { isLoading } = useQuery({
     queryKey: ["project", projectId],
     queryFn: () => getProject(projectId),
     enabled: !Number.isNaN(projectId),
   });
 
-  // ラベル管理画面にリダイレクト（後方互換のためルートは残す）
-  if (!isLoading && project) {
-    void navigate("/", { replace: true });
-    return null;
+  if (Number.isNaN(projectId)) {
+    return <Navigate to="/" replace />;
+  }
+
+  // 既存 ID でも無効 ID でも、読み込み完了後はトップへ戻す。
+  if (!isLoading) {
+    return <Navigate to="/" replace />;
   }
 
   return null;

--- a/packages/ui/src/pages/ProjectsPage.module.css
+++ b/packages/ui/src/pages/ProjectsPage.module.css
@@ -1,0 +1,301 @@
+.root {
+  --c-bg: #1e1e2e;
+  --c-card: #313244;
+  --c-border: #45475a;
+  --c-text: #cdd6f4;
+  --c-subtext: #a6adc8;
+  --c-accent: #cba6f7;
+  --c-danger: #f38ba8;
+  --c-overlay: #181825;
+  --c-muted: #6c7086;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  color: var(--c-text);
+}
+
+.description {
+  color: var(--c-subtext);
+  margin: 0 0 24px;
+  font-size: 14px;
+}
+
+.createButton {
+  padding: 8px 18px;
+  background: var(--c-accent);
+  border: none;
+  border-radius: 8px;
+  color: var(--c-overlay);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.createButton:hover {
+  opacity: 0.9;
+}
+
+.labelList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.labelRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  transition: border-color 0.15s;
+}
+
+.labelRow:hover {
+  border-color: var(--c-accent);
+}
+
+.labelTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  background: rgba(203, 166, 247, 0.15);
+  border: 1px solid rgba(203, 166, 247, 0.3);
+  border-radius: 99px;
+  color: var(--c-accent);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.labelName {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--c-text);
+}
+
+.labelDescription {
+  flex: 2;
+  font-size: 13px;
+  color: var(--c-subtext);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.labelDate {
+  font-size: 12px;
+  color: var(--c-muted);
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+}
+
+.editButton {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.editButton:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.deleteButton {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-danger);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.deleteButton:hover {
+  background: rgba(243, 139, 168, 0.1);
+}
+
+.emptyState {
+  text-align: center;
+  padding: 60px 0;
+  color: var(--c-muted);
+}
+
+.emptyState p {
+  margin: 0 0 8px;
+}
+
+.loadingText {
+  color: var(--c-muted);
+  text-align: center;
+  padding: 40px 0;
+}
+
+.errorText {
+  color: var(--c-danger);
+  text-align: center;
+  padding: 40px 0;
+}
+
+/* Modal */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modalBox {
+  background: var(--c-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  padding: 28px;
+  width: 480px;
+  max-width: 90vw;
+}
+
+.modalTitle {
+  margin: 0 0 20px;
+  font-size: 18px;
+  color: var(--c-text);
+}
+
+.formField {
+  margin-bottom: 16px;
+}
+
+.formFieldLast {
+  margin-bottom: 24px;
+}
+
+.label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 14px;
+  color: var(--c-subtext);
+}
+
+.required {
+  color: var(--c-danger);
+  margin-left: 4px;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-text);
+  font-size: 14px;
+  outline: none;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-text);
+  font-size: 14px;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.modalFooter {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.cancelButton {
+  padding: 8px 20px;
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  color: var(--c-subtext);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.submitButton {
+  padding: 8px 20px;
+  background: var(--c-accent);
+  border: none;
+  border-radius: 8px;
+  color: var(--c-overlay);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.submitButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dangerButton {
+  padding: 8px 20px;
+  background: var(--c-danger);
+  border: none;
+  border-radius: 8px;
+  color: var(--c-overlay);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dangerButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.deleteWarning {
+  margin: 0 0 8px;
+  color: var(--c-subtext);
+  font-size: 14px;
+}
+
+.deleteTarget {
+  margin: 0 0 12px;
+  color: var(--c-text);
+  font-weight: 600;
+  font-size: 15px;
+  padding: 8px 12px;
+  background: var(--c-card);
+  border-radius: 6px;
+}
+
+.deleteNote {
+  margin: 0 0 24px;
+  color: var(--c-danger);
+  font-size: 13px;
+}

--- a/packages/ui/src/pages/ProjectsPage.module.css
+++ b/packages/ui/src/pages/ProjectsPage.module.css
@@ -58,11 +58,17 @@
   background: var(--c-card);
   border: 1px solid var(--c-border);
   border-radius: 8px;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.15s;
+  cursor: pointer;
 }
 
 .labelRow:hover {
   border-color: var(--c-accent);
+}
+
+.labelRowActive {
+  border-color: var(--c-accent);
+  background: rgba(203, 166, 247, 0.06);
 }
 
 .labelTag {
@@ -76,6 +82,32 @@
   font-size: 13px;
   font-weight: 500;
   white-space: nowrap;
+}
+
+.labelTagActive {
+  background: rgba(203, 166, 247, 0.3);
+  border-color: var(--c-accent);
+}
+
+.activeBadge {
+  padding: 2px 8px;
+  background: rgba(166, 227, 161, 0.15);
+  border: 1px solid rgba(166, 227, 161, 0.4);
+  border-radius: 99px;
+  color: #a6e3a1;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.activeHint {
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  background: rgba(203, 166, 247, 0.08);
+  border: 1px solid rgba(203, 166, 247, 0.2);
+  border-radius: 6px;
+  color: var(--c-subtext);
+  font-size: 13px;
 }
 
 .labelName {

--- a/packages/ui/src/pages/ProjectsPage.tsx
+++ b/packages/ui/src/pages/ProjectsPage.tsx
@@ -245,7 +245,7 @@ export function ProjectsPage() {
       </div>
 
       <p className={styles.description}>
-        プロジェクトラベルを管理します。ラベルはテストケース・プロンプト・Run などの資産を分類するために使用します。
+        プロジェクトラベルを管理します。ラベルをクリックして選択すると、テストケース・プロンプト・コンテキスト素材のページでそのラベルで絞り込まれます。再クリックで解除できます。
       </p>
 
       {isLoading && <p className={styles.loadingText}>読み込み中...</p>}
@@ -265,7 +265,7 @@ export function ProjectsPage() {
 
       {activeLabelId !== null && (
         <p className={styles.activeHint}>
-          ラベルを選択中です。テストケース・プロンプト・コンテキスト素材のページでこのラベルで絞り込まれます。
+          ラベルを選択中です。テストケース・プロンプト・コンテキスト素材のページでこのラベルで絞り込まれます。同じラベルを再クリックすると解除できます。
         </p>
       )}
 

--- a/packages/ui/src/pages/ProjectsPage.tsx
+++ b/packages/ui/src/pages/ProjectsPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   type Project,
   createProject,
@@ -7,7 +7,7 @@ import {
   getProjects,
   updateProject,
 } from "../lib/api";
-import { useActiveLabel } from "../lib/useActiveLabel";
+import { clearStoredActiveLabelId, useActiveLabel } from "../lib/useActiveLabel";
 import styles from "./ProjectsPage.module.css";
 
 function formatDate(timestamp: number): string {
@@ -229,11 +229,24 @@ export function ProjectsPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteProject(id),
-    onSuccess: () => {
+    onSuccess: (_, deletedId) => {
+      if (activeLabelId === deletedId) {
+        setActiveLabelId(null);
+      }
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
       setDeleteTarget(null);
     },
   });
+
+  useEffect(() => {
+    if (!projects || activeLabelId === null) {
+      return;
+    }
+    if (!projects.some((project) => project.id === activeLabelId)) {
+      clearStoredActiveLabelId();
+      setActiveLabelId(null);
+    }
+  }, [activeLabelId, projects, setActiveLabelId]);
 
   return (
     <div className={styles.root}>

--- a/packages/ui/src/pages/ProjectsPage.tsx
+++ b/packages/ui/src/pages/ProjectsPage.tsx
@@ -1,20 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { useNavigate } from "react-router";
-import { type Project, createProject, deleteProject, getProjects } from "../lib/api";
-
-const colors = {
-  bg: "#1e1e2e",
-  card: "#313244",
-  border: "#45475a",
-  text: "#cdd6f4",
-  subtext: "#a6adc8",
-  accent: "#cba6f7",
-  danger: "#f38ba8",
-  overlay: "#181825",
-  surface: "#45475a",
-  muted: "#6c7086",
-};
+import {
+  type Project,
+  createProject,
+  deleteProject,
+  getProjects,
+  updateProject,
+} from "../lib/api";
+import styles from "./ProjectsPage.module.css";
 
 function formatDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString("ja-JP", {
@@ -24,36 +17,35 @@ function formatDate(timestamp: number): string {
   });
 }
 
-type CreateModalProps = {
+type LabelFormModalProps = {
+  initial?: { name: string; description: string };
+  title: string;
+  submitLabel: string;
   onClose: () => void;
   onSubmit: (data: { name: string; description?: string }) => void;
   isLoading: boolean;
 };
 
-function CreateModal({ onClose, onSubmit, isLoading }: CreateModalProps) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
+function LabelFormModal({
+  initial,
+  title,
+  submitLabel,
+  onClose,
+  onSubmit,
+  isLoading,
+}: LabelFormModalProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) return;
-    onSubmit({
-      name: name.trim(),
-      description: description.trim() || undefined,
-    });
+    onSubmit({ name: name.trim(), description: description.trim() || undefined });
   }
 
   return (
     <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.6)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 100,
-      }}
+      className={styles.modalOverlay}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -61,123 +53,45 @@ function CreateModal({ onClose, onSubmit, isLoading }: CreateModalProps) {
         if (e.key === "Escape") onClose();
       }}
     >
-      <div
-        style={{
-          background: colors.overlay,
-          border: `1px solid ${colors.border}`,
-          borderRadius: "12px",
-          padding: "28px",
-          width: "480px",
-          maxWidth: "90vw",
-        }}
-      >
-        <h3
-          style={{
-            margin: "0 0 20px",
-            fontSize: "18px",
-            color: colors.text,
-          }}
-        >
-          新規プロジェクト作成
-        </h3>
+      <div className={styles.modalBox}>
+        <h3 className={styles.modalTitle}>{title}</h3>
         <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: "16px" }}>
-            <label
-              htmlFor="create-project-name"
-              style={{
-                display: "block",
-                marginBottom: "6px",
-                fontSize: "14px",
-                color: colors.subtext,
-              }}
-            >
-              プロジェクト名
-              <span style={{ color: colors.danger, marginLeft: "4px" }}>*</span>
+          <div className={styles.formField}>
+            <label htmlFor="label-name" className={styles.label}>
+              ラベル名<span className={styles.required}>*</span>
             </label>
             <input
-              id="create-project-name"
+              id="label-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="例: 顧客サポートBot"
-              style={{
-                width: "100%",
-                padding: "10px 12px",
-                background: colors.card,
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.text,
-                fontSize: "14px",
-                outline: "none",
-                boxSizing: "border-box",
-              }}
+              className={styles.input}
             />
           </div>
-          <div style={{ marginBottom: "24px" }}>
-            <label
-              htmlFor="create-project-description"
-              style={{
-                display: "block",
-                marginBottom: "6px",
-                fontSize: "14px",
-                color: colors.subtext,
-              }}
-            >
+          <div className={styles.formFieldLast}>
+            <label htmlFor="label-description" className={styles.label}>
               説明（任意）
             </label>
             <textarea
-              id="create-project-description"
+              id="label-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="プロジェクトの目的や概要を記入..."
+              placeholder="ラベルの用途や目的を記入..."
               rows={3}
-              style={{
-                width: "100%",
-                padding: "10px 12px",
-                background: colors.card,
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.text,
-                fontSize: "14px",
-                outline: "none",
-                resize: "vertical",
-                boxSizing: "border-box",
-                fontFamily: "inherit",
-              }}
+              className={styles.textarea}
             />
           </div>
-          <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
-            <button
-              type="button"
-              onClick={onClose}
-              style={{
-                padding: "8px 20px",
-                background: "transparent",
-                border: `1px solid ${colors.border}`,
-                borderRadius: "8px",
-                color: colors.subtext,
-                fontSize: "14px",
-                cursor: "pointer",
-              }}
-            >
+          <div className={styles.modalFooter}>
+            <button type="button" onClick={onClose} className={styles.cancelButton}>
               キャンセル
             </button>
             <button
               type="submit"
               disabled={!name.trim() || isLoading}
-              style={{
-                padding: "8px 20px",
-                background: colors.accent,
-                border: "none",
-                borderRadius: "8px",
-                color: colors.overlay,
-                fontSize: "14px",
-                fontWeight: 600,
-                cursor: !name.trim() || isLoading ? "not-allowed" : "pointer",
-                opacity: !name.trim() || isLoading ? 0.6 : 1,
-              }}
+              className={styles.submitButton}
             >
-              {isLoading ? "作成中..." : "作成"}
+              {isLoading ? "保存中..." : submitLabel}
             </button>
           </div>
         </form>
@@ -196,15 +110,7 @@ type DeleteDialogProps = {
 function DeleteDialog({ project, onClose, onConfirm, isLoading }: DeleteDialogProps) {
   return (
     <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.6)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 100,
-      }}
+      className={styles.modalOverlay}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -212,75 +118,22 @@ function DeleteDialog({ project, onClose, onConfirm, isLoading }: DeleteDialogPr
         if (e.key === "Escape") onClose();
       }}
     >
-      <div
-        style={{
-          background: colors.overlay,
-          border: `1px solid ${colors.border}`,
-          borderRadius: "12px",
-          padding: "28px",
-          width: "420px",
-          maxWidth: "90vw",
-        }}
-      >
-        <h3
-          style={{
-            margin: "0 0 12px",
-            fontSize: "18px",
-            color: colors.text,
-          }}
-        >
-          プロジェクトを削除
-        </h3>
-        <p style={{ margin: "0 0 8px", color: colors.subtext, fontSize: "14px" }}>
-          以下のプロジェクトを削除してもよいですか？
+      <div className={styles.modalBox}>
+        <h3 className={styles.modalTitle}>ラベルを削除</h3>
+        <p className={styles.deleteWarning}>以下のラベルを削除してもよいですか？</p>
+        <p className={styles.deleteTarget}>{project.name}</p>
+        <p className={styles.deleteNote}>
+          この操作は取り消せません。関連するテストケースやプロンプトとの紐付けも解除されます。
         </p>
-        <p
-          style={{
-            margin: "0 0 20px",
-            color: colors.text,
-            fontWeight: 600,
-            fontSize: "15px",
-            padding: "8px 12px",
-            background: colors.card,
-            borderRadius: "6px",
-          }}
-        >
-          {project.name}
-        </p>
-        <p style={{ margin: "0 0 24px", color: colors.danger, fontSize: "13px" }}>
-          この操作は取り消せません。関連するテストケースやプロンプトもすべて削除されます。
-        </p>
-        <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
-          <button
-            type="button"
-            onClick={onClose}
-            style={{
-              padding: "8px 20px",
-              background: "transparent",
-              border: `1px solid ${colors.border}`,
-              borderRadius: "8px",
-              color: colors.subtext,
-              fontSize: "14px",
-              cursor: "pointer",
-            }}
-          >
+        <div className={styles.modalFooter}>
+          <button type="button" onClick={onClose} className={styles.cancelButton}>
             キャンセル
           </button>
           <button
             type="button"
             onClick={onConfirm}
             disabled={isLoading}
-            style={{
-              padding: "8px 20px",
-              background: colors.danger,
-              border: "none",
-              borderRadius: "8px",
-              color: colors.overlay,
-              fontSize: "14px",
-              fontWeight: 600,
-              cursor: isLoading ? "not-allowed" : "pointer",
-              opacity: isLoading ? 0.6 : 1,
-            }}
+            className={styles.dangerButton}
           >
             {isLoading ? "削除中..." : "削除する"}
           </button>
@@ -290,115 +143,44 @@ function DeleteDialog({ project, onClose, onConfirm, isLoading }: DeleteDialogPr
   );
 }
 
-type ProjectCardProps = {
+type LabelRowProps = {
   project: Project;
+  onEdit: (project: Project) => void;
   onDelete: (project: Project) => void;
 };
 
-function ProjectCard({ project, onDelete }: ProjectCardProps) {
-  const navigate = useNavigate();
-
+function LabelRow({ project, onEdit, onDelete }: LabelRowProps) {
   return (
-    <button
-      type="button"
-      style={{
-        background: colors.card,
-        border: `1px solid ${colors.border}`,
-        borderRadius: "12px",
-        padding: "20px",
-        cursor: "pointer",
-        transition: "border-color 0.15s",
-        display: "flex",
-        flexDirection: "column",
-        gap: "8px",
-        textAlign: "left",
-        width: "100%",
-        fontFamily: "inherit",
-      }}
-      onClick={() => navigate(`/projects/${project.id}`)}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.borderColor = colors.accent;
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.borderColor = colors.border;
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "flex-start",
-          gap: "12px",
-        }}
-      >
-        <h3
-          style={{
-            margin: 0,
-            fontSize: "16px",
-            fontWeight: 600,
-            color: colors.text,
-            wordBreak: "break-word",
-          }}
-        >
-          {project.name}
-        </h3>
+    <div className={styles.labelRow}>
+      <span className={styles.labelTag}>{project.name}</span>
+      {project.description && (
+        <span className={styles.labelDescription}>{project.description}</span>
+      )}
+      <span className={styles.labelDate}>{formatDate(project.created_at)}</span>
+      <div className={styles.actions}>
         <button
           type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete(project);
-          }}
-          style={{
-            flexShrink: 0,
-            padding: "4px 10px",
-            background: "transparent",
-            border: `1px solid ${colors.border}`,
-            borderRadius: "6px",
-            color: colors.danger,
-            fontSize: "12px",
-            cursor: "pointer",
-            transition: "background 0.15s",
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = "rgba(243,139,168,0.1)";
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = "transparent";
-          }}
+          onClick={() => onEdit(project)}
+          className={styles.editButton}
+        >
+          編集
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(project)}
+          className={styles.deleteButton}
         >
           削除
         </button>
       </div>
-      {project.description && (
-        <p
-          style={{
-            margin: 0,
-            fontSize: "14px",
-            color: colors.subtext,
-            lineHeight: 1.5,
-            wordBreak: "break-word",
-          }}
-        >
-          {project.description}
-        </p>
-      )}
-      <p
-        style={{
-          margin: 0,
-          fontSize: "12px",
-          color: colors.muted,
-          marginTop: "4px",
-        }}
-      >
-        作成日: {formatDate(project.created_at)}
-      </p>
-    </button>
+    </div>
   );
 }
 
 export function ProjectsPage() {
   const queryClient = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Project | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
 
   const {
@@ -419,6 +201,15 @@ export function ProjectsPage() {
     },
   });
 
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: { name?: string; description?: string } }) =>
+      updateProject(id, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+      setEditTarget(null);
+    },
+  });
+
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteProject(id),
     onSuccess: () => {
@@ -428,82 +219,64 @@ export function ProjectsPage() {
   });
 
   return (
-    <div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: "16px",
-        }}
-      >
-        <h2 style={{ margin: 0, fontSize: "20px", color: colors.text }}>プロジェクト一覧</h2>
-        <button
-          type="button"
-          onClick={() => setIsCreateOpen(true)}
-          style={{
-            padding: "8px 18px",
-            background: colors.accent,
-            border: "none",
-            borderRadius: "8px",
-            color: colors.overlay,
-            fontSize: "14px",
-            fontWeight: 600,
-            cursor: "pointer",
-          }}
-        >
-          + 新規作成
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>ラベル管理</h2>
+        <button type="button" onClick={() => setIsCreateOpen(true)} className={styles.createButton}>
+          + 新規ラベル作成
         </button>
       </div>
 
-      <p style={{ color: colors.subtext, marginBottom: "24px", margin: "0 0 24px" }}>
-        システムプロンプトを管理するプロジェクトを選択してください。
+      <p className={styles.description}>
+        プロジェクトラベルを管理します。ラベルはテストケース・プロンプト・Run などの資産を分類するために使用します。
       </p>
 
-      {isLoading && (
-        <p style={{ color: colors.muted, textAlign: "center", padding: "40px 0" }}>読み込み中...</p>
-      )}
+      {isLoading && <p className={styles.loadingText}>読み込み中...</p>}
 
       {isError && (
-        <p style={{ color: colors.danger, textAlign: "center", padding: "40px 0" }}>
+        <p className={styles.errorText}>
           エラーが発生しました: {error instanceof Error ? error.message : "不明なエラー"}
         </p>
       )}
 
       {!isLoading && !isError && projects && projects.length === 0 && (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "60px 0",
-            color: colors.muted,
-          }}
-        >
-          <p style={{ margin: "0 0 8px", fontSize: "16px" }}>プロジェクトがまだありません</p>
-          <p style={{ margin: 0, fontSize: "14px" }}>
-            「新規作成」ボタンから最初のプロジェクトを作成してください。
-          </p>
+        <div className={styles.emptyState}>
+          <p style={{ fontSize: "16px" }}>ラベルがまだありません</p>
+          <p style={{ fontSize: "14px" }}>「新規ラベル作成」ボタンから最初のラベルを作成してください。</p>
         </div>
       )}
 
       {!isLoading && !isError && projects && projects.length > 0 && (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-            gap: "16px",
-          }}
-        >
+        <div className={styles.labelList}>
           {projects.map((project) => (
-            <ProjectCard key={project.id} project={project} onDelete={setDeleteTarget} />
+            <LabelRow
+              key={project.id}
+              project={project}
+              onEdit={setEditTarget}
+              onDelete={setDeleteTarget}
+            />
           ))}
         </div>
       )}
 
       {isCreateOpen && (
-        <CreateModal
+        <LabelFormModal
+          title="新規ラベル作成"
+          submitLabel="作成"
           onClose={() => setIsCreateOpen(false)}
           onSubmit={(data) => createMutation.mutate(data)}
           isLoading={createMutation.isPending}
+        />
+      )}
+
+      {editTarget && (
+        <LabelFormModal
+          title="ラベルを編集"
+          submitLabel="保存"
+          initial={{ name: editTarget.name, description: editTarget.description ?? "" }}
+          onClose={() => setEditTarget(null)}
+          onSubmit={(data) => updateMutation.mutate({ id: editTarget.id, data })}
+          isLoading={updateMutation.isPending}
         />
       )}
 

--- a/packages/ui/src/pages/ProjectsPage.tsx
+++ b/packages/ui/src/pages/ProjectsPage.tsx
@@ -7,6 +7,7 @@ import {
   getProjects,
   updateProject,
 } from "../lib/api";
+import { useActiveLabel } from "../lib/useActiveLabel";
 import styles from "./ProjectsPage.module.css";
 
 function formatDate(timestamp: number): string {
@@ -145,14 +146,25 @@ function DeleteDialog({ project, onClose, onConfirm, isLoading }: DeleteDialogPr
 
 type LabelRowProps = {
   project: Project;
+  isActive: boolean;
+  onSelect: (project: Project) => void;
   onEdit: (project: Project) => void;
   onDelete: (project: Project) => void;
 };
 
-function LabelRow({ project, onEdit, onDelete }: LabelRowProps) {
+function LabelRow({ project, isActive, onSelect, onEdit, onDelete }: LabelRowProps) {
   return (
-    <div className={styles.labelRow}>
-      <span className={styles.labelTag}>{project.name}</span>
+    <div
+      className={`${styles.labelRow} ${isActive ? styles.labelRowActive : ""}`}
+      onClick={() => onSelect(project)}
+      onKeyDown={(e) => e.key === "Enter" && onSelect(project)}
+      role="button"
+      tabIndex={0}
+    >
+      <span className={`${styles.labelTag} ${isActive ? styles.labelTagActive : ""}`}>
+        {project.name}
+      </span>
+      {isActive && <span className={styles.activeBadge}>絞り込み中</span>}
       {project.description && (
         <span className={styles.labelDescription}>{project.description}</span>
       )}
@@ -160,14 +172,14 @@ function LabelRow({ project, onEdit, onDelete }: LabelRowProps) {
       <div className={styles.actions}>
         <button
           type="button"
-          onClick={() => onEdit(project)}
+          onClick={(e) => { e.stopPropagation(); onEdit(project); }}
           className={styles.editButton}
         >
           編集
         </button>
         <button
           type="button"
-          onClick={() => onDelete(project)}
+          onClick={(e) => { e.stopPropagation(); onDelete(project); }}
           className={styles.deleteButton}
         >
           削除
@@ -179,9 +191,14 @@ function LabelRow({ project, onEdit, onDelete }: LabelRowProps) {
 
 export function ProjectsPage() {
   const queryClient = useQueryClient();
+  const { activeLabelId, setActiveLabelId } = useActiveLabel();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<Project | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
+
+  function handleSelectLabel(project: Project) {
+    setActiveLabelId(activeLabelId === project.id ? null : project.id);
+  }
 
   const {
     data: projects,
@@ -246,12 +263,20 @@ export function ProjectsPage() {
         </div>
       )}
 
+      {activeLabelId !== null && (
+        <p className={styles.activeHint}>
+          ラベルを選択中です。テストケース・プロンプト・コンテキスト素材のページでこのラベルで絞り込まれます。
+        </p>
+      )}
+
       {!isLoading && !isError && projects && projects.length > 0 && (
         <div className={styles.labelList}>
           {projects.map((project) => (
             <LabelRow
               key={project.id}
               project={project}
+              isActive={activeLabelId === project.id}
+              onSelect={handleSelectLabel}
               onEdit={setEditTarget}
               onDelete={setDeleteTarget}
             />

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import {
@@ -810,16 +810,20 @@ export function PromptsPage() {
   const routeProjectId = id ? Number(id) : null;
   const projectFilterParam = searchParams.get("project_id");
   const familyFilterParam = searchParams.get("family_id");
-  const selectedProjectId =
-    routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
   const isProjectScopedView = routeProjectId !== null;
 
-  // アクティブラベルをマウント時に一度だけ適用（family_idエフェクトと競合しないよう useRef で管理）
-  const activeLabelToApply = useRef<number | null>(
-    projectFilterParam === null && routeProjectId === null
-      ? getStoredActiveLabelId()
-      : null,
+  // URLに project_id が既にある場合はアクティブラベルを使わない（ユーザーが明示的に選択済み）
+  const [userSelectedProject, setUserSelectedProject] = useState<boolean>(
+    () => projectFilterParam !== null || routeProjectId !== null,
   );
+
+  const urlProjectId = routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
+  const selectedProjectId =
+    urlProjectId !== null
+      ? urlProjectId
+      : userSelectedProject
+        ? null
+        : getStoredActiveLabelId();
 
   const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
   const [compareVersion, setCompareVersion] = useState<PromptVersion | null>(null);
@@ -851,28 +855,15 @@ export function PromptsPage() {
 
   useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);
-    let changed = false;
-
-    // アクティブラベルを一度だけ適用（family_id同期と同一エフェクトで競合回避）
-    if (activeLabelToApply.current !== null && !nextParams.has("project_id")) {
-      nextParams.set("project_id", String(activeLabelToApply.current));
-      activeLabelToApply.current = null;
-      changed = true;
-    }
-
     if (selectedFamilyId === null) {
-      if (nextParams.has("family_id")) {
-        nextParams.delete("family_id");
-        changed = true;
-      }
-    } else if (nextParams.get("family_id") !== String(selectedFamilyId)) {
-      nextParams.set("family_id", String(selectedFamilyId));
-      changed = true;
-    }
-
-    if (changed) {
+      if (!nextParams.has("family_id")) return;
+      nextParams.delete("family_id");
       setSearchParams(nextParams, { replace: true });
+      return;
     }
+    if (searchParams.get("family_id") === String(selectedFamilyId)) return;
+    nextParams.set("family_id", String(selectedFamilyId));
+    setSearchParams(nextParams, { replace: true });
   }, [searchParams, selectedFamilyId, setSearchParams]);
 
   const {
@@ -966,6 +957,7 @@ export function PromptsPage() {
     } else {
       nextParams.delete("project_id");
     }
+    setUserSelectedProject(true);
     setSearchParams(nextParams);
   }
 

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import {
@@ -811,9 +811,15 @@ export function PromptsPage() {
   const projectFilterParam = searchParams.get("project_id");
   const familyFilterParam = searchParams.get("family_id");
   const selectedProjectId =
-    routeProjectId ??
-    (projectFilterParam ? Number(projectFilterParam) : getStoredActiveLabelId());
+    routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
   const isProjectScopedView = routeProjectId !== null;
+
+  // アクティブラベルをマウント時に一度だけ適用（family_idエフェクトと競合しないよう useRef で管理）
+  const activeLabelToApply = useRef<number | null>(
+    projectFilterParam === null && routeProjectId === null
+      ? getStoredActiveLabelId()
+      : null,
+  );
 
   const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
   const [compareVersion, setCompareVersion] = useState<PromptVersion | null>(null);
@@ -845,20 +851,28 @@ export function PromptsPage() {
 
   useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);
-    if (selectedFamilyId === null) {
-      if (!nextParams.has("family_id")) {
-        return;
-      }
-      nextParams.delete("family_id");
-      setSearchParams(nextParams, { replace: true });
-      return;
+    let changed = false;
+
+    // アクティブラベルを一度だけ適用（family_id同期と同一エフェクトで競合回避）
+    if (activeLabelToApply.current !== null && !nextParams.has("project_id")) {
+      nextParams.set("project_id", String(activeLabelToApply.current));
+      activeLabelToApply.current = null;
+      changed = true;
     }
 
-    if (searchParams.get("family_id") === String(selectedFamilyId)) {
-      return;
+    if (selectedFamilyId === null) {
+      if (nextParams.has("family_id")) {
+        nextParams.delete("family_id");
+        changed = true;
+      }
+    } else if (nextParams.get("family_id") !== String(selectedFamilyId)) {
+      nextParams.set("family_id", String(selectedFamilyId));
+      changed = true;
     }
-    nextParams.set("family_id", String(selectedFamilyId));
-    setSearchParams(nextParams, { replace: true });
+
+    if (changed) {
+      setSearchParams(nextParams, { replace: true });
+    }
   }, [searchParams, selectedFamilyId, setSearchParams]);
 
   const {

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -811,7 +811,8 @@ export function PromptsPage() {
   const projectFilterParam = searchParams.get("project_id");
   const familyFilterParam = searchParams.get("family_id");
   const selectedProjectId =
-    routeProjectId ?? (projectFilterParam ? Number(projectFilterParam) : null);
+    routeProjectId ??
+    (projectFilterParam ? Number(projectFilterParam) : getStoredActiveLabelId());
   const isProjectScopedView = routeProjectId !== null;
 
   const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
@@ -841,17 +842,6 @@ export function PromptsPage() {
       ? requestedFamilyId
       : (families[0]?.id ?? null);
   const selectedFamily = families.find((family) => family.id === selectedFamilyId) ?? null;
-
-  useEffect(() => {
-    if (searchParams.get("project_id") !== null || routeProjectId !== null) return;
-    const activeId = getStoredActiveLabelId();
-    if (activeId === null) return;
-    const next = new URLSearchParams(searchParams);
-    next.set("project_id", String(activeId));
-    setSearchParams(next, { replace: true });
-  // 初回マウント時のみ実行
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
+import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import {
   type Project,
   type PromptExecutionStepDefinition,
@@ -840,6 +841,17 @@ export function PromptsPage() {
       ? requestedFamilyId
       : (families[0]?.id ?? null);
   const selectedFamily = families.find((family) => family.id === selectedFamilyId) ?? null;
+
+  useEffect(() => {
+    if (searchParams.get("project_id") !== null || routeProjectId !== null) return;
+    const activeId = getStoredActiveLabelId();
+    if (activeId === null) return;
+    const next = new URLSearchParams(searchParams);
+    next.set("project_id", String(activeId));
+    setSearchParams(next, { replace: true });
+  // 初回マウント時のみ実行
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -709,7 +709,7 @@ export function TestCasesPage() {
       ? Number(searchParams.get("project_id"))
       : legacyProjectId !== null && !Number.isNaN(legacyProjectId)
         ? legacyProjectId
-        : null;
+        : getStoredActiveLabelId();
   const selectedUnclassified = searchParams.get("unclassified") === "true";
   const searchQuery = searchParams.get("q")?.trim() ?? "";
 
@@ -730,17 +730,6 @@ export function TestCasesPage() {
     next.set("project_id", String(legacyProjectId));
     setSearchParams(next, { replace: true });
   }, [legacyProjectId, searchParams, setSearchParams]);
-
-  useEffect(() => {
-    if (searchParams.get("project_id") !== null || legacyProjectId !== null) return;
-    const activeId = getStoredActiveLabelId();
-    if (activeId === null) return;
-    const next = new URLSearchParams(searchParams);
-    next.set("project_id", String(activeId));
-    setSearchParams(next, { replace: true });
-  // 初回マウント時のみ実行
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const filters: TestCaseFilters = {
     q: searchQuery || undefined,

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -709,7 +709,7 @@ export function TestCasesPage() {
       ? Number(searchParams.get("project_id"))
       : legacyProjectId !== null && !Number.isNaN(legacyProjectId)
         ? legacyProjectId
-        : getStoredActiveLabelId();
+        : null;
   const selectedUnclassified = searchParams.get("unclassified") === "true";
   const searchQuery = searchParams.get("q")?.trim() ?? "";
 
@@ -730,6 +730,24 @@ export function TestCasesPage() {
     next.set("project_id", String(legacyProjectId));
     setSearchParams(next, { replace: true });
   }, [legacyProjectId, searchParams, setSearchParams]);
+
+  // アクティブラベルをマウント時に URL へ反映（初回のみ、他のフィルタ優先）
+  useEffect(() => {
+    if (
+      searchParams.get("project_id") !== null ||
+      searchParams.get("unclassified") === "true" ||
+      legacyProjectId !== null
+    ) {
+      return;
+    }
+    const activeId = getStoredActiveLabelId();
+    if (activeId === null) return;
+    const next = new URLSearchParams(searchParams);
+    next.set("project_id", String(activeId));
+    setSearchParams(next, { replace: true });
+  // biome-ignore lint/react-hooks/exhaustive-deps: 初回マウント時のみ実行
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const filters: TestCaseFilters = {
     q: searchQuery || undefined,

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
+import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import {
   type ContextAssetSummary,
   type Project,
@@ -729,6 +730,17 @@ export function TestCasesPage() {
     next.set("project_id", String(legacyProjectId));
     setSearchParams(next, { replace: true });
   }, [legacyProjectId, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (searchParams.get("project_id") !== null || legacyProjectId !== null) return;
+    const activeId = getStoredActiveLabelId();
+    if (activeId === null) return;
+    const next = new URLSearchParams(searchParams);
+    next.set("project_id", String(activeId));
+    setSearchParams(next, { replace: true });
+  // 初回マウント時のみ実行
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const filters: TestCaseFilters = {
     q: searchQuery || undefined,


### PR DESCRIPTION
## Summary

- `ProjectsPage` をプロジェクト選択画面からラベル管理UI（作成/編集/削除）へ再設計
- `ProjectsPage.module.css` を新規作成しインラインスタイルを廃止
- `api.ts` に `updateProject` (PATCH /projects/:id) を追加
- `ProjectDetailPage` を後方互換用リダイレクトに簡略化（配下ページ導線を廃止）
- `Layout.tsx` からプロジェクト固有のサブナビゲーション (`ProjectSubNav`) を削除
- `App.tsx` のルーティングを資産中心に整理（`projects/:id/*` のサブルートを廃止）

Closes #126

## Test plan

- [ ] トップページ (`/`) でラベル一覧がタグ表示で表示されることを確認
- [ ] 「新規ラベル作成」モーダルでラベルを作成できることを確認
- [ ] 「編集」ボタンでラベル名/説明を更新できることを確認
- [ ] 「削除」ボタンで確認ダイアログ後に削除されることを確認
- [ ] `/projects/:id` にアクセスするとトップにリダイレクトされることを確認
- [ ] サイドバーのナビゲーションが資産中心（テストケース/プロンプト/Run等）になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)