### PR TITLE
feat: サイドバーのナビゲーションを階層構造に変更する

### DIFF
--- a/packages/ui/src/components/AnnotationSectionTabs.tsx
+++ b/packages/ui/src/components/AnnotationSectionTabs.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { NavLink, useLocation } from "react-router";
+import { useI18n } from "../i18n/I18nProvider";
 import {
   buildAnnotationReviewPath,
   getAnnotationReviewContextFromSearch,
@@ -14,6 +15,7 @@ const annotationRoutes = {
 } as const;
 
 export function AnnotationSectionTabs() {
+  const { t } = useI18n();
   const location = useLocation();
 
   const searchParams = new URLSearchParams(location.search);
@@ -37,24 +39,24 @@ export function AnnotationSectionTabs() {
 
   const tabs = [
     {
+      to: `/${annotationRoutes.settings}`,
+      label: t("annotation.tabs.settings"),
+      isActive: isSettingsPath,
+    },
+    {
       to: reviewTabTo,
-      label: "レビュー",
+      label: t("annotation.tabs.review"),
       isActive: isReviewPath && (hasRunId || modeParam === "review"),
     },
     {
       to: `/${annotationRoutes.review}`,
-      label: "ゴールドアノテーション",
+      label: t("annotation.tabs.goldAnnotations"),
       isActive: isReviewPath && !hasRunId && modeParam !== "review",
-    },
-    {
-      to: `/${annotationRoutes.settings}`,
-      label: "設定",
-      isActive: isSettingsPath,
     },
   ];
 
   return (
-    <div className={styles.tabList} aria-label="抽出ページ切り替え">
+    <div className={styles.tabList} aria-label={t("annotation.tabs.ariaLabel")}>
       {tabs.map(({ to, label, isActive }) => (
         <NavLink key={to} to={to} className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}>
           {label}

--- a/packages/ui/src/components/Layout.module.css
+++ b/packages/ui/src/components/Layout.module.css
@@ -1,0 +1,155 @@
+.root {
+  display: flex;
+  height: 100vh;
+  font-family:
+    "BIZ UDPGothic",
+    "Hiragino Sans",
+    "Yu Gothic UI",
+    sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(203, 166, 247, 0.12), transparent 28%),
+    var(--c-bg);
+}
+
+.sidebar {
+  width: 248px;
+  background:
+    linear-gradient(180deg, rgba(24, 24, 37, 0.98), rgba(30, 30, 46, 0.96));
+  color: var(--c-text);
+  padding: 20px 0 16px;
+  flex-shrink: 0;
+  border-right: 1px solid rgba(69, 71, 90, 0.9);
+  overflow-y: auto;
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.03);
+}
+
+.brand {
+  padding: 0 18px 18px;
+  border-bottom: 1px solid rgba(69, 71, 90, 0.85);
+}
+
+.brandTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--c-accent);
+}
+
+.nav {
+  margin-top: 12px;
+  padding: 0 10px;
+}
+
+.navGroup {
+  position: relative;
+  margin-bottom: 6px;
+}
+
+.navGroup::after {
+  content: "";
+  position: absolute;
+  left: 21px;
+  top: 38px;
+  bottom: 8px;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(137, 180, 250, 0.28), rgba(137, 180, 250, 0));
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.navGroupExpanded::after {
+  opacity: 1;
+}
+
+.navLink {
+  display: block;
+  padding: 10px 14px;
+  margin: 0;
+  border-radius: 10px;
+  color: var(--c-text);
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 1.35;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.navLink:hover {
+  background: rgba(69, 71, 90, 0.58);
+  color: #eef1ff;
+}
+
+.navLinkActive {
+  background: rgba(137, 180, 250, 0.12);
+  color: #f4ebff;
+  box-shadow: inset 0 0 0 1px rgba(203, 166, 247, 0.25);
+}
+
+.navLinkParent {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.navHint {
+  flex-shrink: 0;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--c-muted);
+}
+
+.subNavList {
+  margin-top: 3px;
+}
+
+.subNavLink {
+  position: relative;
+  display: block;
+  padding: 7px 14px 7px 38px;
+  margin: 0;
+  border-radius: 10px;
+  color: var(--c-subtext);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.3;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.subNavLink::before {
+  content: "";
+  position: absolute;
+  left: 21px;
+  top: 50%;
+  width: 11px;
+  height: 1px;
+  background: rgba(137, 180, 250, 0.35);
+  transform: translateY(-50%);
+}
+
+.subNavLink:hover {
+  background: rgba(69, 71, 90, 0.42);
+  color: var(--c-text);
+}
+
+.subNavLinkActive {
+  background: rgba(137, 180, 250, 0.1);
+  color: #dce9ff;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  color: var(--c-text);
+  padding: 24px;
+  overflow: auto;
+}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -41,9 +41,9 @@ const navItems: NavItem[] = [
     label: "テストケース",
     children: [{ to: "/context-assets", label: "コンテキスト素材" }],
   },
-  { to: "/", label: "ラベル管理", end: true },
   { to: "/runs", label: "Run" },
   { to: "/score", label: "採点" },
+  { to: "/", label: "ラベル管理", end: true },
   { to: "/execution-profiles", label: "実行設定" },
   { to: "/health", label: "ヘルスチェック" },
 ];

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -1,66 +1,78 @@
 import { NavLink, Outlet } from "react-router";
+import { useI18n } from "../i18n/I18nProvider";
 import { ErrorBoundary } from "./ErrorBoundary";
-
-const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
-  display: "block",
-  padding: "8px 16px",
-  textDecoration: "none",
-  color: isActive ? "#cba6f7" : "#cdd6f4",
-  backgroundColor: isActive ? "#313244" : "transparent",
-  borderRadius: "4px",
-  margin: "2px 8px",
-  fontSize: "14px",
-});
-
-const subNavLinkStyle = ({ isActive }: { isActive: boolean }) => ({
-  display: "block",
-  padding: "6px 16px 6px 32px",
-  textDecoration: "none",
-  color: isActive ? "#cba6f7" : "#a6adc8",
-  backgroundColor: isActive ? "#313244" : "transparent",
-  borderRadius: "4px",
-  margin: "2px 8px",
-  fontSize: "13px",
-});
+import styles from "./Layout.module.css";
 
 type NavItem = {
   to: string;
-  label: string;
+  labelKey: string;
   end?: boolean;
-  children?: { to: string; label: string }[];
+  children?: { to: string; labelKey: string }[];
 };
 
 const navItems: NavItem[] = [
   {
     to: "/prompts",
-    label: "プロンプト",
-    children: [{ to: "/annotation-review", label: "抽出" }],
+    labelKey: "layout.prompts",
+    children: [{ to: "/annotation-tasks", labelKey: "layout.extraction" }],
   },
   {
     to: "/test-cases",
-    label: "テストケース",
-    children: [{ to: "/context-assets", label: "コンテキスト素材" }],
+    labelKey: "layout.testCases",
+    children: [{ to: "/context-assets", labelKey: "layout.contextAssets" }],
   },
-  { to: "/runs", label: "Run" },
-  { to: "/score", label: "採点" },
-  { to: "/", label: "ラベル管理", end: true },
-  { to: "/execution-profiles", label: "実行設定" },
-  { to: "/health", label: "ヘルスチェック" },
+  { to: "/", labelKey: "layout.labels", end: true },
+  { to: "/runs", labelKey: "layout.runs" },
+  { to: "/score", labelKey: "layout.scoring" },
+  { to: "/execution-profiles", labelKey: "layout.executionProfiles" },
+  { to: "/health", labelKey: "layout.health" },
 ];
 
+function getNavLinkClassName(isActive: boolean) {
+  return [styles.navLink, isActive ? styles.navLinkActive : ""].filter(Boolean).join(" ");
+}
+
+function getSubNavLinkClassName(isActive: boolean) {
+  return [styles.subNavLink, isActive ? styles.subNavLinkActive : ""].filter(Boolean).join(" ");
+}
+
 function SidebarNav() {
+  const { t } = useI18n();
+
   return (
-    <nav style={{ marginTop: "8px" }}>
-      {navItems.map(({ to, label, end, children }) => (
-        <div key={to}>
-          <NavLink to={to} end={end} style={navLinkStyle}>
-            {label}
+    <nav className={styles.nav}>
+      {navItems.map(({ to, labelKey, end, children }) => (
+        <div
+          key={to}
+          className={[styles.navGroup, children?.length ? styles.navGroupExpanded : ""]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <NavLink
+            to={to}
+            end={end}
+            className={({ isActive }) => getNavLinkClassName(isActive)}
+          >
+            <span className={styles.navLinkParent}>
+              <span>{t(labelKey)}</span>
+              {children?.length ? (
+                <span className={styles.navHint}>{t("layout.navHintHasChildren")}</span>
+              ) : null}
+            </span>
           </NavLink>
-          {children?.map((child) => (
-            <NavLink key={child.to} to={child.to} style={subNavLinkStyle}>
-              {child.label}
-            </NavLink>
-          ))}
+          {children?.length ? (
+            <div className={styles.subNavList}>
+              {children.map((child) => (
+                <NavLink
+                  key={child.to}
+                  to={child.to}
+                  className={({ isActive }) => getSubNavLinkClassName(isActive)}
+                >
+                  {t(child.labelKey)}
+                </NavLink>
+              ))}
+            </div>
+          ) : null}
         </div>
       ))}
     </nav>
@@ -68,35 +80,17 @@ function SidebarNav() {
 }
 
 export function Layout() {
+  const { t } = useI18n();
+
   return (
-    <div style={{ display: "flex", height: "100vh", fontFamily: "sans-serif" }}>
-      <aside
-        style={{
-          width: "240px",
-          backgroundColor: "#181825",
-          color: "#cdd6f4",
-          padding: "16px 0",
-          flexShrink: 0,
-          borderRight: "1px solid #313244",
-          overflowY: "auto",
-        }}
-      >
-        <div style={{ padding: "0 16px 16px", borderBottom: "1px solid #313244" }}>
-          <h1 style={{ fontSize: "16px", fontWeight: "bold", margin: 0, color: "#cba6f7" }}>
-            Prompt Reviewer
-          </h1>
+    <div className={styles.root}>
+      <aside className={styles.sidebar}>
+        <div className={styles.brand}>
+          <h1 className={styles.brandTitle}>{t("common.appName")}</h1>
         </div>
         <SidebarNav />
       </aside>
-      <main
-        style={{
-          flex: 1,
-          backgroundColor: "#1e1e2e",
-          color: "#cdd6f4",
-          padding: "24px",
-          overflow: "auto",
-        }}
-      >
+      <main className={styles.main}>
         <ErrorBoundary>
           <Outlet />
         </ErrorBoundary>

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -12,25 +12,56 @@ const navLinkStyle = ({ isActive }: { isActive: boolean }) => ({
   fontSize: "14px",
 });
 
-function SidebarNav() {
-  const topNavItems = [
-    { to: "/", label: "ラベル管理", end: true },
-    { to: "/test-cases", label: "テストケース", end: false },
-    { to: "/prompts", label: "プロンプト", end: false },
-    { to: "/context-assets", label: "コンテキスト素材", end: false },
-    { to: "/runs", label: "Run", end: false },
-    { to: "/score", label: "採点", end: false },
-    { to: "/annotation-review", label: "抽出", end: false },
-    { to: "/execution-profiles", label: "実行設定", end: false },
-    { to: "/health", label: "ヘルスチェック", end: false },
-  ];
+const subNavLinkStyle = ({ isActive }: { isActive: boolean }) => ({
+  display: "block",
+  padding: "6px 16px 6px 32px",
+  textDecoration: "none",
+  color: isActive ? "#cba6f7" : "#a6adc8",
+  backgroundColor: isActive ? "#313244" : "transparent",
+  borderRadius: "4px",
+  margin: "2px 8px",
+  fontSize: "13px",
+});
 
+type NavItem = {
+  to: string;
+  label: string;
+  end?: boolean;
+  children?: { to: string; label: string }[];
+};
+
+const navItems: NavItem[] = [
+  {
+    to: "/prompts",
+    label: "プロンプト",
+    children: [{ to: "/annotation-review", label: "抽出" }],
+  },
+  {
+    to: "/test-cases",
+    label: "テストケース",
+    children: [{ to: "/context-assets", label: "コンテキスト素材" }],
+  },
+  { to: "/", label: "ラベル管理", end: true },
+  { to: "/runs", label: "Run" },
+  { to: "/score", label: "採点" },
+  { to: "/execution-profiles", label: "実行設定" },
+  { to: "/health", label: "ヘルスチェック" },
+];
+
+function SidebarNav() {
   return (
     <nav style={{ marginTop: "8px" }}>
-      {topNavItems.map(({ to, label, end }) => (
-        <NavLink key={to} to={to} end={end} style={navLinkStyle}>
-          {label}
-        </NavLink>
+      {navItems.map(({ to, label, end, children }) => (
+        <div key={to}>
+          <NavLink to={to} end={end} style={navLinkStyle}>
+            {label}
+          </NavLink>
+          {children?.map((child) => (
+            <NavLink key={child.to} to={child.to} style={subNavLinkStyle}>
+              {child.label}
+            </NavLink>
+          ))}
+        </div>
       ))}
     </nav>
   );

--- a/packages/ui/src/i18n/I18nProvider.tsx
+++ b/packages/ui/src/i18n/I18nProvider.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { enMessages } from "./messages/en";
+import { jaMessages } from "./messages/ja";
+
+type Locale = "ja" | "en";
+type TranslateValues = Record<string, string | number>;
+type MessageDictionary = {
+  [key: string]: string | MessageDictionary;
+};
+
+type I18nContextValue = {
+  locale: Locale;
+  t: (key: string, values?: TranslateValues) => string;
+};
+
+const dictionaries: Record<Locale, MessageDictionary> = {
+  ja: jaMessages,
+  en: enMessages,
+};
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function getMessage(dictionary: MessageDictionary, key: string): string | null {
+  const value = key.split(".").reduce<string | MessageDictionary | undefined>((current, part) => {
+    if (!current || typeof current === "string") {
+      return undefined;
+    }
+
+    return current[part];
+  }, dictionary);
+
+  return typeof value === "string" ? value : null;
+}
+
+function interpolate(message: string, values?: TranslateValues): string {
+  if (!values) {
+    return message;
+  }
+
+  return message.replace(/\{(\w+)\}/g, (_, token: string) => String(values[token] ?? `{${token}}`));
+}
+
+export function I18nProvider({
+  children,
+  locale = "ja",
+}: {
+  children: ReactNode;
+  locale?: Locale;
+}) {
+  const dictionary = dictionaries[locale];
+
+  const contextValue: I18nContextValue = {
+    locale,
+    t: (key, values) => {
+      const message = getMessage(dictionary, key) ?? getMessage(dictionaries.ja, key) ?? key;
+      return interpolate(message, values);
+    },
+  };
+
+  return <I18nContext.Provider value={contextValue}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+
+  if (!context) {
+    throw new Error("useI18n must be used within I18nProvider");
+  }
+
+  return context;
+}

--- a/packages/ui/src/i18n/messages/en.ts
+++ b/packages/ui/src/i18n/messages/en.ts
@@ -1,0 +1,32 @@
+export const enMessages = {
+  common: {
+    appName: "Prompt Reviewer",
+  },
+  layout: {
+    navHintHasChildren: "Has children",
+    prompts: "Prompts",
+    extraction: "Extraction",
+    testCases: "Test Cases",
+    contextAssets: "Context Assets",
+    labels: "Labels",
+    runs: "Runs",
+    scoring: "Scoring",
+    executionProfiles: "Execution Profiles",
+    health: "Health Check",
+  },
+  annotation: {
+    tabs: {
+      ariaLabel: "Extraction page tabs",
+      settings: "Settings",
+      review: "Review",
+      goldAnnotations: "Gold Annotations",
+    },
+  },
+  prompts: {
+    title: "Prompt Management",
+    description: "Manage history by prompt family and filter by project label when needed.",
+    familyPanelLabel: "Prompt Families",
+    familySummaryLabel: "Family",
+    projectFilterLabel: "Project Filter",
+  },
+} as const;

--- a/packages/ui/src/i18n/messages/ja.ts
+++ b/packages/ui/src/i18n/messages/ja.ts
@@ -1,0 +1,33 @@
+export const jaMessages = {
+  common: {
+    appName: "Prompt Reviewer",
+  },
+  layout: {
+    navHintHasChildren: "子項目あり",
+    prompts: "プロンプト",
+    extraction: "抽出",
+    testCases: "テストケース",
+    contextAssets: "コンテキスト素材",
+    labels: "ラベル管理",
+    runs: "Run",
+    scoring: "採点",
+    executionProfiles: "実行設定",
+    health: "ヘルスチェック",
+  },
+  annotation: {
+    tabs: {
+      ariaLabel: "抽出ページ切り替え",
+      settings: "設定",
+      review: "レビュー",
+      goldAnnotations: "ゴールドアノテーション",
+    },
+  },
+  prompts: {
+    title: "プロンプト管理",
+    description:
+      "プロンプトファミリー単位で履歴を管理し、必要に応じてプロジェクトラベルで絞り込みます。",
+    familyPanelLabel: "プロンプトファミリー",
+    familySummaryLabel: "ファミリー",
+    projectFilterLabel: "プロジェクトフィルタ",
+  },
+} as const;

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { I18nProvider } from "./i18n/I18nProvider";
 import "./styles/variables.css";
 import { App } from "./App";
 
@@ -11,6 +12,8 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </StrictMode>,
 );

--- a/packages/ui/src/pages/PromptsPage.module.css
+++ b/packages/ui/src/pages/PromptsPage.module.css
@@ -79,6 +79,8 @@
   color: var(--c-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .filterSelect {
@@ -754,12 +756,15 @@
 
 .btnWorkflowAdd {
   padding: 6px 12px;
+  min-width: 120px;
   background: transparent;
   border: 1px solid var(--c-blue);
   border-radius: 6px;
   color: var(--c-blue);
   font-size: 12px;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .workflowEmpty {

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -154,8 +154,13 @@ function FamilyModal({ family, onClose, onSubmit, isPending, isError }: FamilyMo
   const [name, setName] = useState(family?.name ?? "");
   const [description, setDescription] = useState(family?.description ?? "");
 
+  const isNew = family === null;
+  const isNameRequired = isNew;
+  const isSubmitDisabled = isPending || (isNameRequired && !name.trim());
+
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
+    if (isSubmitDisabled) return;
     onSubmit({
       name: name.trim() || null,
       description: description.trim() || null,
@@ -180,6 +185,7 @@ function FamilyModal({ family, onClose, onSubmit, isPending, isError }: FamilyMo
           <div>
             <label htmlFor="family-name" className={styles.fieldLabel}>
               名前
+              {isNameRequired && <span className={styles.requiredMark}>*</span>}
             </label>
             <input
               id="family-name"
@@ -188,6 +194,7 @@ function FamilyModal({ family, onClose, onSubmit, isPending, isError }: FamilyMo
               onChange={(event) => setName(event.target.value)}
               placeholder="例: FAQ 応答改善"
               className={styles.fieldInput}
+              required={isNameRequired}
             />
           </div>
           <div>
@@ -209,8 +216,8 @@ function FamilyModal({ family, onClose, onSubmit, isPending, isError }: FamilyMo
             </button>
             <button
               type="submit"
-              disabled={isPending}
-              className={`${styles.btnSave} ${isPending ? styles.btnDisabled : ""}`}
+              disabled={isSubmitDisabled}
+              className={`${styles.btnSave} ${isSubmitDisabled ? styles.btnDisabled : ""}`}
             >
               {isPending ? "保存中..." : family ? "更新" : "作成"}
             </button>

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -311,8 +311,12 @@ function VersionTreeItem({
   );
 }
 
+const NEW_FAMILY_VALUE = "__new__";
+
 type PromptEditorProps = {
-  familyId: number;
+  familyId?: number;
+  families: PromptFamily[];
+  initialFamilyId: number | null;
   projects: Project[];
   version: PromptVersion | null;
   defaultProjectId: number | null;
@@ -323,6 +327,8 @@ type PromptEditorProps = {
 
 function PromptEditor({
   familyId,
+  families,
+  initialFamilyId,
   projects,
   version,
   defaultProjectId,
@@ -344,14 +350,28 @@ function PromptEditor({
   const [workflowSteps, setWorkflowSteps] = useState<PromptExecutionStepDefinition[]>(
     version?.workflow_definition?.steps ?? [],
   );
+  const [familySelectValue, setFamilySelectValue] = useState(
+    isNew ? (initialFamilyId !== null ? String(initialFamilyId) : NEW_FAMILY_VALUE) : "",
+  );
+  const [newFamilyName, setNewFamilyName] = useState("");
+
+  const isCreatingNewFamily = isNew && familySelectValue === NEW_FAMILY_VALUE;
 
   const saveMutation = useMutation({
     mutationFn: async () => {
       const workflowDefinition = buildWorkflowDefinition(workflowSteps);
 
+      let actualFamilyId: number;
+      if (isCreatingNewFamily) {
+        const newFamily = await createPromptFamily({ name: newFamilyName.trim() });
+        actualFamilyId = newFamily.id;
+      } else {
+        actualFamilyId = isNew ? Number(familySelectValue) : (familyId ?? 0);
+      }
+
       const savedVersion = isNew
         ? await createIndependentPromptVersion({
-            prompt_family_id: familyId,
+            prompt_family_id: actualFamilyId,
             content: content.trim(),
             name: name.trim() || undefined,
             memo: memo.trim() || undefined,
@@ -373,14 +393,21 @@ function PromptEditor({
     },
     onSuccess: (savedVersion) => {
       void queryClient.invalidateQueries({ queryKey: ["promptFamilies"] });
-      void queryClient.invalidateQueries({ queryKey: ["promptVersionsByFamily", familyId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["promptVersionsByFamily", savedVersion.prompt_family_id],
+      });
       onSave(savedVersion);
     },
   });
 
   const workflowValidationMessage = getWorkflowValidationMessage(workflowSteps);
+  const isFamilyValid =
+    !isNew || (isCreatingNewFamily ? newFamilyName.trim().length > 0 : familySelectValue !== "");
   const isDisabled =
-    !content.trim() || saveMutation.isPending || workflowValidationMessage !== null;
+    !content.trim() ||
+    saveMutation.isPending ||
+    workflowValidationMessage !== null ||
+    !isFamilyValid;
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -392,6 +419,36 @@ function PromptEditor({
 
   return (
     <form onSubmit={handleSubmit} className={styles.editorForm}>
+      {isNew && (
+        <div>
+          <label htmlFor="editor-family" className={styles.fieldLabel}>
+            プロンプトファミリー<span className={styles.requiredMark}>*</span>
+          </label>
+          <select
+            id="editor-family"
+            value={familySelectValue}
+            onChange={(event) => setFamilySelectValue(event.target.value)}
+            className={styles.fieldInput}
+          >
+            {families.map((family) => (
+              <option key={family.id} value={String(family.id)}>
+                {family.name ?? `ファミリー ${family.id}`}
+              </option>
+            ))}
+            <option value={NEW_FAMILY_VALUE}>＋ 新しいファミリーを作成...</option>
+          </select>
+          {isCreatingNewFamily && (
+            <input
+              type="text"
+              value={newFamilyName}
+              onChange={(event) => setNewFamilyName(event.target.value)}
+              placeholder="新しいファミリー名を入力"
+              className={styles.fieldInput}
+              style={{ marginTop: "8px" }}
+            />
+          )}
+        </div>
+      )}
       <div>
         <label htmlFor="editor-name" className={styles.fieldLabel}>
           {isNew || version?.parent_version_id === null
@@ -1020,8 +1077,8 @@ export function PromptsPage() {
           <button
             type="button"
             onClick={() => setPanelMode({ type: "new" })}
-            disabled={!selectedFamily}
-            className={`${styles.btnPrimary} ${selectedFamily ? "" : styles.btnDisabled}`}
+            disabled={families.length === 0}
+            className={`${styles.btnPrimary} ${families.length === 0 ? styles.btnDisabled : ""}`}
           >
             + 新規バージョン
           </button>
@@ -1198,19 +1255,21 @@ export function PromptsPage() {
             </div>
           )}
 
-          {panelMode?.type === "new" && selectedFamily && (
+          {panelMode?.type === "new" && (
             <>
-              <div className={styles.panelHeaderTitle}>
-                {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`} に新規追加
-              </div>
+              <div className={styles.panelHeaderTitle}>新規バージョンを作成</div>
               <div className={styles.panelEditorBody}>
                 <PromptEditor
-                  familyId={selectedFamily.id}
+                  families={families}
+                  initialFamilyId={selectedFamilyId}
                   projects={projects}
                   version={null}
                   defaultProjectId={selectedProjectId}
                   isNew={true}
                   onSave={(version) => {
+                    const nextParams = new URLSearchParams(searchParams);
+                    nextParams.set("family_id", String(version.prompt_family_id));
+                    setSearchParams(nextParams, { replace: true });
                     setSelectedVersion(version);
                     setPanelMode({ type: "view", version });
                   }}
@@ -1321,6 +1380,8 @@ export function PromptsPage() {
               <div className={styles.panelEditorBody}>
                 <PromptEditor
                   familyId={selectedFamily.id}
+                  families={families}
+                  initialFamilyId={selectedFamily.id}
                   projects={projects}
                   version={panelMode.version}
                   defaultProjectId={selectedProjectId}

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -18,6 +18,7 @@ import {
   updateIndependentPromptVersion,
   updatePromptFamily,
 } from "../lib/api";
+import { useI18n } from "../i18n/I18nProvider";
 import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import styles from "./PromptsPage.module.css";
 
@@ -867,6 +868,7 @@ type PanelMode =
   | null;
 
 export function PromptsPage() {
+  const { t } = useI18n();
   const { id } = useParams<{ id?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -1056,10 +1058,8 @@ export function PromptsPage() {
     <div className={`${styles.root} ${styles.page}`}>
       <div className={styles.pageHeader}>
         <div>
-          <h2 className={styles.pageTitle}>プロンプト管理</h2>
-          <p className={styles.pageDescription}>
-            Prompt Family 単位で履歴を管理し、必要に応じてプロジェクトラベルで絞り込みます。
-          </p>
+          <h2 className={styles.pageTitle}>{t("prompts.title")}</h2>
+          <p className={styles.pageDescription}>{t("prompts.description")}</p>
         </div>
         <div className={styles.pageActions}>
           {selectedVersion && compareVersion && (
@@ -1088,7 +1088,7 @@ export function PromptsPage() {
       <div className={styles.filterBar}>
         <div className={styles.filterGroup}>
           <label htmlFor="project-filter" className={styles.filterLabel}>
-            プロジェクトフィルタ
+            {t("prompts.projectFilterLabel")}
           </label>
           <select
             id="project-filter"
@@ -1152,7 +1152,7 @@ export function PromptsPage() {
         <div className={styles.sidebarColumn}>
           <section className={styles.familyPanel}>
             <div className={styles.familyPanelHeader}>
-              <div className={styles.treePanelLabel}>Prompt Families</div>
+              <div className={styles.treePanelLabel}>{t("prompts.familyPanelLabel")}</div>
               <div className={styles.familyActions}>
                 <button
                   type="button"
@@ -1312,7 +1312,7 @@ export function PromptsPage() {
               <div className={styles.panelBody}>
                 {selectedFamily && (
                   <div className={styles.familySummaryCard}>
-                    <span className={styles.familySummaryLabel}>Family</span>
+                    <span className={styles.familySummaryLabel}>{t("prompts.familySummaryLabel")}</span>
                     <strong className={styles.familySummaryName}>
                       {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`}
                     </strong>

--- a/packages/ui/src/styles/shared.module.css
+++ b/packages/ui/src/styles/shared.module.css
@@ -19,6 +19,7 @@
   color: var(--c-overlay);
   font-weight: 600;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .btnSecondary {
@@ -27,6 +28,7 @@
   border-radius: 6px;
   color: var(--c-subtext);
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .btnDisabled {


### PR DESCRIPTION
fixes #195

## 変更内容

`Layout.tsx` の `SidebarNav` を階層構造に変更。

**変更後の構造:**
```
プロンプト
  └ 抽出
テストケース
  └ コンテキスト素材
ラベル管理
Run
採点
実行設定
ヘルスチェック
```

## 実装詳細

- `NavItem` 型に `children` フィールドを追加
- サブ項目は左パディング32pxのインデントと小さめフォントサイズ(13px)・薄めテキスト色(`#a6adc8`)で視覚的に区別