### PR TITLE
fix: UIの細部改善（文言・配置・開閉UI）

### DIFF
--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -21,9 +21,9 @@ const navItems: NavItem[] = [
     labelKey: "layout.testCases",
     children: [{ to: "/context-assets", labelKey: "layout.contextAssets" }],
   },
-  { to: "/", labelKey: "layout.labels", end: true },
   { to: "/runs", labelKey: "layout.runs" },
   { to: "/score", labelKey: "layout.scoring" },
+  { to: "/", labelKey: "layout.labels", end: true },
   { to: "/execution-profiles", labelKey: "layout.executionProfiles" },
   { to: "/health", labelKey: "layout.health" },
 ];

--- a/packages/ui/src/i18n/messages/en.ts
+++ b/packages/ui/src/i18n/messages/en.ts
@@ -28,5 +28,32 @@ export const enMessages = {
     familyPanelLabel: "Prompt Families",
     familySummaryLabel: "Family",
     projectFilterLabel: "Project Filter",
+    createFamily: "+ Create Family",
+  },
+  contextAssets: {
+    description: "Manage context assets used by test cases.",
+    properties: "Properties",
+    name: "Name",
+    path: "Path",
+    mimeType: "MIME Type",
+    projectAssignment: "Project Assignment",
+    save: "Save",
+    saving: "Saving...",
+    confirmDelete: "Are you sure you want to delete this?",
+    deleting: "Deleting...",
+    delete: "Delete",
+    cancel: "Cancel",
+  },
+  testCases: {
+    title: "Test Case Management",
+    description:
+      "Manage test cases and link context assets or projects later as needed.",
+    turnUser: "User",
+    turnAssistant: "Assistant",
+    contextImportHint:
+      "Import the selected asset content into the context field as a snapshot.",
+    titleHint:
+      "If the prompt does not reference anything else, you can create it by entering only a title.",
+    projectLabelHint: "Tag any projects you need.",
   },
 } as const;

--- a/packages/ui/src/i18n/messages/ja.ts
+++ b/packages/ui/src/i18n/messages/ja.ts
@@ -29,5 +29,32 @@ export const jaMessages = {
     familyPanelLabel: "プロンプトファミリー",
     familySummaryLabel: "ファミリー",
     projectFilterLabel: "プロジェクトフィルタ",
+    createFamily: "+ ファミリー作成",
+  },
+  contextAssets: {
+    description: "テストケースで利用するコンテキスト素材を管理します。",
+    properties: "プロパティ",
+    name: "名前",
+    path: "パス",
+    mimeType: "MIMEタイプ",
+    projectAssignment: "プロジェクト割り当て",
+    save: "保存",
+    saving: "保存中...",
+    confirmDelete: "本当に削除しますか？",
+    deleting: "削除中...",
+    delete: "削除",
+    cancel: "キャンセル",
+  },
+  testCases: {
+    title: "テストケース管理",
+    description:
+      "テストケースを管理します。必要なコンテキスト素材やプロジェクトをあとから関連付けられます。",
+    turnUser: "ユーザー",
+    turnAssistant: "アシスタント",
+    contextImportHint:
+      "選択した素材の内容をスナップショットとしてコンテキスト欄に取り込みます。",
+    titleHint:
+      "プロンプトのみで何も参照しない場合はタイトルだけ入力して作成してください。",
+    projectLabelHint: "必要なプロジェクトにタグ付けできます。",
   },
 } as const;

--- a/packages/ui/src/pages/ContextAssetsPage.module.css
+++ b/packages/ui/src/pages/ContextAssetsPage.module.css
@@ -12,11 +12,11 @@
 
 .pageTitle {
   composes: pageTitle from '../styles/shared.module.css';
-  margin: 0 0 4px;
+  margin: 0;
 }
 
 .pageDescription {
-  margin: 0;
+  margin: 6px 0 0;
   color: var(--c-subtext);
   font-size: 14px;
 }
@@ -392,6 +392,47 @@
 .noProjects {
   font-size: 12px;
   color: var(--c-muted);
+}
+
+.propertiesSection {
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.propertiesToggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: var(--c-subtext);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+.propertiesToggleIcon {
+  color: var(--c-subtext);
+  font-size: 16px;
+}
+
+.propertiesBody {
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.editorToolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
 }
 
 .editorArea {

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -104,6 +104,7 @@ export function ContextAssetsPage() {
   });
   const [searchInput, setSearchInput] = useState("");
   const [selectedProjectIds, setSelectedProjectIds] = useState<number[]>([]);
+  const [showProperties, setShowProperties] = useState(false);
 
   const projectsQuery = useQuery({
     queryKey: ["projects"],
@@ -283,7 +284,7 @@ export function ContextAssetsPage() {
       <div className={styles.pageHeader}>
         <div>
           <h2 className={styles.pageTitle}>コンテキスト素材</h2>
-          <p className={styles.pageDescription}>グローバルなコンテキスト素材を管理します。</p>
+          <p className={styles.pageDescription}>テストケースで利用するコンテキスト素材を管理します。</p>
         </div>
         <div className={styles.headerActions}>
           <input
@@ -298,7 +299,11 @@ export function ContextAssetsPage() {
           />
           <button
             type="button"
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() => {
+              setShowCreateForm(false);
+              setStatusMessage(null);
+              fileInputRef.current?.click();
+            }}
             className={styles.btnPrimary}
             disabled={uploadMutation.isPending}
           >
@@ -454,110 +459,127 @@ export function ContextAssetsPage() {
 
           {selectedId && selectedDetail && (
             <>
-              <div className={styles.panelHeader}>
-                <div className={styles.detailMeta}>
-                  <div className={styles.detailMetaRow}>
-                    <label htmlFor="detail-name" className={styles.metaLabel}>
-                      名前
-                    </label>
-                    <input
-                      id="detail-name"
-                      type="text"
-                      className={styles.textInput}
-                      value={draftName}
-                      onChange={(e) => setDraftName(e.target.value)}
-                    />
-                  </div>
-                  <div className={styles.detailMetaRow}>
-                    <label htmlFor="detail-path" className={styles.metaLabel}>
-                      パス
-                    </label>
-                    <input
-                      id="detail-path"
-                      type="text"
-                      className={styles.textInput}
-                      value={draftPath}
-                      onChange={(e) => setDraftPath(e.target.value)}
-                    />
-                  </div>
-                  <div className={styles.detailMetaRow}>
-                    <label htmlFor="detail-mime" className={styles.metaLabel}>
-                      MIMEタイプ
-                    </label>
-                    <input
-                      id="detail-mime"
-                      type="text"
-                      className={styles.textInput}
-                      value={draftMimeType}
-                      onChange={(e) => setDraftMimeType(e.target.value)}
-                    />
-                  </div>
-                  {selectedSummary && (
-                    <p className={styles.panelSubtitle}>
-                      {formatBytes(getContentSize(selectedDetail.content))} / 更新:{" "}
-                      {formatDate(selectedSummary.updated_at)}
-                    </p>
-                  )}
-                </div>
-                <div className={styles.panelActions}>
-                  <button
-                    type="button"
-                    onClick={() => saveMutation.mutate()}
-                    disabled={!isDetailDirty || saveMutation.isPending}
-                    className={`${styles.btnSave} ${!isDetailDirty || saveMutation.isPending ? styles.btnDisabled : ""}`}
-                  >
-                    {saveMutation.isPending ? "保存中..." : "保存"}
-                  </button>
-                  {deleteConfirmId === selectedId ? (
-                    <div className={styles.deleteConfirm}>
-                      <span className={styles.deleteConfirmText}>本当に削除しますか？</span>
-                      <button
-                        type="button"
-                        onClick={() => deleteMutation.mutate(selectedId)}
-                        disabled={deleteMutation.isPending}
-                        className={styles.btnDanger}
-                      >
-                        {deleteMutation.isPending ? "削除中..." : "削除"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setDeleteConfirmId(null)}
-                        className={styles.btnCancel}
-                      >
-                        キャンセル
-                      </button>
+              {/* プロパティ開閉セクション */}
+              <div className={styles.propertiesSection}>
+                <button
+                  type="button"
+                  onClick={() => setShowProperties((v) => !v)}
+                  className={styles.propertiesToggle}
+                >
+                  プロパティ
+                  <span className={styles.propertiesToggleIcon}>
+                    {showProperties ? "▾" : "▸"}
+                  </span>
+                </button>
+                {showProperties && (
+                  <div className={styles.propertiesBody}>
+                    <div className={styles.detailMetaRow}>
+                      <label htmlFor="detail-name" className={styles.metaLabel}>
+                        名前
+                      </label>
+                      <input
+                        id="detail-name"
+                        type="text"
+                        className={styles.textInput}
+                        value={draftName}
+                        onChange={(e) => setDraftName(e.target.value)}
+                      />
                     </div>
-                  ) : (
+                    <div className={styles.detailMetaRow}>
+                      <label htmlFor="detail-path" className={styles.metaLabel}>
+                        パス
+                      </label>
+                      <input
+                        id="detail-path"
+                        type="text"
+                        className={styles.textInput}
+                        value={draftPath}
+                        onChange={(e) => setDraftPath(e.target.value)}
+                      />
+                    </div>
+                    <div className={styles.detailMetaRow}>
+                      <label htmlFor="detail-mime" className={styles.metaLabel}>
+                        MIMEタイプ
+                      </label>
+                      <input
+                        id="detail-mime"
+                        type="text"
+                        className={styles.textInput}
+                        value={draftMimeType}
+                        onChange={(e) => setDraftMimeType(e.target.value)}
+                      />
+                    </div>
+
+                    <div>
+                      <p className={styles.projectAssignTitle}>プロジェクト割り当て</p>
+                      <div className={styles.projectAssignList}>
+                        {projects.length === 0 && (
+                          <span className={styles.noProjects}>プロジェクトがありません</span>
+                        )}
+                        {projects.map((p) => (
+                          <button
+                            key={p.id}
+                            type="button"
+                            onClick={() => handleProjectAssignToggle(p.id)}
+                            className={`${styles.projectBadge} ${selectedProjectIds.includes(p.id) ? styles.projectBadgeActive : ""}`}
+                          >
+                            {p.name}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {selectedSummary && (
+                      <p className={styles.panelSubtitle}>
+                        {formatBytes(getContentSize(selectedDetail.content))} / 更新:{" "}
+                        {formatDate(selectedSummary.updated_at)}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* 保存・削除ツールバー（エディタの外に独立） */}
+              <div className={styles.editorToolbar}>
+                <button
+                  type="button"
+                  onClick={() => saveMutation.mutate()}
+                  disabled={!isDetailDirty || saveMutation.isPending}
+                  className={`${styles.btnSave} ${!isDetailDirty || saveMutation.isPending ? styles.btnDisabled : ""}`}
+                >
+                  {saveMutation.isPending ? "保存中..." : "保存"}
+                </button>
+                {deleteConfirmId === selectedId ? (
+                  <div className={styles.deleteConfirm}>
+                    <span className={styles.deleteConfirmText}>本当に削除しますか？</span>
                     <button
                       type="button"
-                      onClick={() => setDeleteConfirmId(selectedId)}
+                      onClick={() => deleteMutation.mutate(selectedId)}
+                      disabled={deleteMutation.isPending}
                       className={styles.btnDanger}
                     >
-                      削除
+                      {deleteMutation.isPending ? "削除中..." : "削除"}
                     </button>
-                  )}
-                </div>
-              </div>
-
-              <div className={styles.projectAssignSection}>
-                <p className={styles.projectAssignTitle}>プロジェクト割り当て</p>
-                <div className={styles.projectAssignList}>
-                  {projects.length === 0 && (
-                    <span className={styles.noProjects}>プロジェクトがありません</span>
-                  )}
-                  {projects.map((p) => (
                     <button
-                      key={p.id}
                       type="button"
-                      onClick={() => handleProjectAssignToggle(p.id)}
-                      className={`${styles.projectBadge} ${selectedProjectIds.includes(p.id) ? styles.projectBadgeActive : ""}`}
+                      onClick={() => setDeleteConfirmId(null)}
+                      className={styles.btnCancel}
                     >
-                      {p.name}
+                      キャンセル
                     </button>
-                  ))}
-                </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setDeleteConfirmId(selectedId)}
+                    className={styles.btnDanger}
+                  >
+                    削除
+                  </button>
+                )}
               </div>
 
+              {/* CodeMirrorエディタ */}
               <div className={styles.editorArea}>
                 <CodeMirror
                   value={draftContent}

--- a/packages/ui/src/pages/ContextAssetsPage.tsx
+++ b/packages/ui/src/pages/ContextAssetsPage.tsx
@@ -22,6 +22,7 @@ import {
   setContextAssetProjects,
   updateContextAsset,
 } from "../lib/api";
+import { useI18n } from "../i18n/I18nProvider";
 import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import styles from "./ContextAssetsPage.module.css";
 
@@ -88,6 +89,7 @@ const EMPTY_CREATE_FORM: CreateFormState = {
 export function ContextAssetsPage() {
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { t } = useI18n();
 
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [draftContent, setDraftContent] = useState("");
@@ -284,7 +286,7 @@ export function ContextAssetsPage() {
       <div className={styles.pageHeader}>
         <div>
           <h2 className={styles.pageTitle}>コンテキスト素材</h2>
-          <p className={styles.pageDescription}>テストケースで利用するコンテキスト素材を管理します。</p>
+          <p className={styles.pageDescription}>{t("contextAssets.description")}</p>
         </div>
         <div className={styles.headerActions}>
           <input
@@ -466,7 +468,7 @@ export function ContextAssetsPage() {
                   onClick={() => setShowProperties((v) => !v)}
                   className={styles.propertiesToggle}
                 >
-                  プロパティ
+                  {t("contextAssets.properties")}
                   <span className={styles.propertiesToggleIcon}>
                     {showProperties ? "▾" : "▸"}
                   </span>
@@ -475,7 +477,7 @@ export function ContextAssetsPage() {
                   <div className={styles.propertiesBody}>
                     <div className={styles.detailMetaRow}>
                       <label htmlFor="detail-name" className={styles.metaLabel}>
-                        名前
+                        {t("contextAssets.name")}
                       </label>
                       <input
                         id="detail-name"
@@ -487,7 +489,7 @@ export function ContextAssetsPage() {
                     </div>
                     <div className={styles.detailMetaRow}>
                       <label htmlFor="detail-path" className={styles.metaLabel}>
-                        パス
+                        {t("contextAssets.path")}
                       </label>
                       <input
                         id="detail-path"
@@ -499,7 +501,7 @@ export function ContextAssetsPage() {
                     </div>
                     <div className={styles.detailMetaRow}>
                       <label htmlFor="detail-mime" className={styles.metaLabel}>
-                        MIMEタイプ
+                        {t("contextAssets.mimeType")}
                       </label>
                       <input
                         id="detail-mime"
@@ -511,7 +513,9 @@ export function ContextAssetsPage() {
                     </div>
 
                     <div>
-                      <p className={styles.projectAssignTitle}>プロジェクト割り当て</p>
+                      <p className={styles.projectAssignTitle}>
+                        {t("contextAssets.projectAssignment")}
+                      </p>
                       <div className={styles.projectAssignList}>
                         {projects.length === 0 && (
                           <span className={styles.noProjects}>プロジェクトがありません</span>
@@ -547,25 +551,29 @@ export function ContextAssetsPage() {
                   disabled={!isDetailDirty || saveMutation.isPending}
                   className={`${styles.btnSave} ${!isDetailDirty || saveMutation.isPending ? styles.btnDisabled : ""}`}
                 >
-                  {saveMutation.isPending ? "保存中..." : "保存"}
+                  {saveMutation.isPending ? t("contextAssets.saving") : t("contextAssets.save")}
                 </button>
                 {deleteConfirmId === selectedId ? (
                   <div className={styles.deleteConfirm}>
-                    <span className={styles.deleteConfirmText}>本当に削除しますか？</span>
+                    <span className={styles.deleteConfirmText}>
+                      {t("contextAssets.confirmDelete")}
+                    </span>
                     <button
                       type="button"
                       onClick={() => deleteMutation.mutate(selectedId)}
                       disabled={deleteMutation.isPending}
                       className={styles.btnDanger}
                     >
-                      {deleteMutation.isPending ? "削除中..." : "削除"}
+                      {deleteMutation.isPending
+                        ? t("contextAssets.deleting")
+                        : t("contextAssets.delete")}
                     </button>
                     <button
                       type="button"
                       onClick={() => setDeleteConfirmId(null)}
                       className={styles.btnCancel}
                     >
-                      キャンセル
+                      {t("contextAssets.cancel")}
                     </button>
                   </div>
                 ) : (
@@ -574,7 +582,7 @@ export function ContextAssetsPage() {
                     onClick={() => setDeleteConfirmId(selectedId)}
                     className={styles.btnDanger}
                   >
-                    削除
+                    {t("contextAssets.delete")}
                   </button>
                 )}
               </div>

--- a/packages/ui/src/pages/PromptsPage.module.css
+++ b/packages/ui/src/pages/PromptsPage.module.css
@@ -51,6 +51,18 @@
   cursor: pointer;
 }
 
+.btnAccentOutline {
+  padding: 7px 16px;
+  background: color-mix(in srgb, var(--c-accent) 18%, transparent);
+  border: 1px solid var(--c-accent);
+  border-radius: 6px;
+  color: var(--c-accent);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
 .btnDisabled {
   composes: btnDisabled from '../styles/shared.module.css';
 }

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1072,7 +1072,7 @@ export function PromptsPage() {
             onClick={() => setEditingFamily(null)}
             className={styles.btnAccentOutline}
           >
-            + ファミリー作成
+            {t("prompts.createFamily")}
           </button>
           <button
             type="button"

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1070,7 +1070,7 @@ export function PromptsPage() {
           <button
             type="button"
             onClick={() => setEditingFamily(null)}
-            className={styles.btnSecondary}
+            className={styles.btnAccentOutline}
           >
             + ファミリー作成
           </button>

--- a/packages/ui/src/pages/TestCasesPage.module.css
+++ b/packages/ui/src/pages/TestCasesPage.module.css
@@ -165,6 +165,19 @@
   composes: fieldLabel from '../styles/shared.module.css';
 }
 
+.fieldLabelRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.fieldLabelHint {
+  font-size: 12px;
+  color: var(--c-muted);
+}
+
 .requiredMark {
   composes: requiredMark from '../styles/shared.module.css';
 }
@@ -230,6 +243,14 @@
   line-height: 1.5;
 }
 
+.contextImportHint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--c-muted);
+  line-height: 1.5;
+  text-align: right;
+}
+
 .tagGroup {
   display: flex;
   gap: 8px;
@@ -256,8 +277,8 @@
 .assetSection {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 14px;
+  gap: 4px;
+  padding: 14px 14px 2px;
   border: 1px solid var(--c-border);
   border-radius: 12px;
   background: color-mix(in srgb, var(--c-bg) 55%, transparent);

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -134,8 +134,8 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
               }
               className={`${styles.turnSelect} ${turn.role === "user" ? styles.turnSelectUser : styles.turnSelectAssistant}`}
             >
-              <option value="user">user</option>
-              <option value="assistant">assistant</option>
+              <option value="user">ユーザー</option>
+              <option value="assistant">アシスタント</option>
             </select>
             <div className={styles.turnControls}>
               <button
@@ -217,38 +217,20 @@ function ProjectTagEditor({ projects, selectedProjectIds, onChange }: ProjectTag
 }
 
 type ContextAssetPickerProps = {
-  selectedIds: number[];
   availableAssets: ContextAssetSummary[];
-  linkedAssets: ContextAssetSummary[];
   selectedImportId: number | null;
   isImporting: boolean;
   onImportSelectionChange: (id: number | null) => void;
   onImport: () => void;
-  onToggleLink: (assetId: number) => void;
 };
 
 function ContextAssetPicker({
-  selectedIds,
   availableAssets,
-  linkedAssets,
   selectedImportId,
   isImporting,
   onImportSelectionChange,
   onImport,
-  onToggleLink,
 }: ContextAssetPickerProps) {
-  const assetMap = new Map<number, ContextAssetSummary>();
-  for (const asset of linkedAssets) {
-    assetMap.set(asset.id, asset);
-  }
-  for (const asset of availableAssets) {
-    assetMap.set(asset.id, asset);
-  }
-
-  const selectedAssets = selectedIds
-    .map((assetId) => assetMap.get(assetId))
-    .filter((asset): asset is ContextAssetSummary => Boolean(asset));
-
   return (
     <div className={styles.assetSection}>
       <div className={styles.contextImportControls}>
@@ -282,49 +264,9 @@ function ContextAssetPicker({
           {isImporting ? "取込中..." : "内容を取り込む"}
         </button>
       </div>
-
-      <p className={styles.modeHint}>
-        `context_assets` の内容をスナップショットとして `context_content`
-        に取り込みます。関連付けだけ残したい場合は下のタグを切り替えてください。
+      <p className={styles.contextImportHint}>
+        選択した素材の内容をスナップショットとしてコンテキスト欄に取り込みます。
       </p>
-
-      {selectedAssets.length > 0 ? (
-        <div className={styles.selectedAssets}>
-          <p className={styles.selectedAssetsLabel}>関連付け中の素材</p>
-          <div className={styles.assetTagList}>
-            {selectedAssets.map((asset) => (
-              <button
-                key={asset.id}
-                type="button"
-                onClick={() => onToggleLink(asset.id)}
-                className={`${styles.assetTag} ${styles.assetTagSelected}`}
-              >
-                {asset.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : (
-        <p className={styles.modeHint}>関連付け中の素材はありません。</p>
-      )}
-
-      {availableAssets.length > 0 && (
-        <div className={styles.availableAssets}>
-          <p className={styles.selectedAssetsLabel}>候補から関連付けを切り替える</p>
-          <div className={styles.assetTagList}>
-            {availableAssets.map((asset) => (
-              <button
-                key={asset.id}
-                type="button"
-                onClick={() => onToggleLink(asset.id)}
-                className={`${styles.assetTag} ${selectedIds.includes(asset.id) ? styles.assetTagSelected : ""}`}
-              >
-                {asset.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -418,15 +360,6 @@ function TestCaseModal({
     });
   }
 
-  function handleToggleAsset(assetId: number) {
-    setImportNotice(null);
-    setFormData((prev) => ({
-      ...prev,
-      context_asset_ids: prev.context_asset_ids.includes(assetId)
-        ? prev.context_asset_ids.filter((id) => id !== assetId)
-        : [...prev.context_asset_ids, assetId],
-    }));
-  }
 
   const isSubmittable = formData.title.trim() !== "";
 
@@ -446,10 +379,13 @@ function TestCaseModal({
         </h3>
         <form onSubmit={handleSubmit}>
           <div className={styles.fieldGroup}>
-            <label htmlFor="test-case-title" className={styles.fieldLabel}>
-              タイトル
-              <span className={styles.requiredMark}>*</span>
-            </label>
+            <div className={styles.fieldLabelRow}>
+              <label htmlFor="test-case-title" className={styles.fieldLabel}>
+                タイトル
+                <span className={styles.requiredMark}>*</span>
+              </label>
+              <span className={styles.fieldLabelHint}>プロンプトのみで何も参照しない場合はタイトルだけ入力して作成してください。</span>
+            </div>
             <input
               id="test-case-title"
               type="text"
@@ -461,27 +397,11 @@ function TestCaseModal({
           </div>
 
           <div className={styles.fieldGroup}>
-            <p className={styles.fieldLabel}>プロジェクトラベル</p>
-            <p className={styles.modeHint}>
-              project 親子ではなく独立資産として管理しつつ、必要な project にタグ付けできます。
-            </p>
-            <ProjectTagEditor
-              projects={projects}
-              selectedProjectIds={formData.project_ids}
-              onChange={(projectIds) =>
-                setFormData((prev) => ({ ...prev, project_ids: projectIds }))
-              }
-            />
-          </div>
-
-          <div className={styles.fieldGroup}>
             <label htmlFor="test-case-context" className={styles.fieldLabel}>
               コンテキスト（任意）
             </label>
             <ContextAssetPicker
-              selectedIds={formData.context_asset_ids}
               availableAssets={availableAssets}
-              linkedAssets={linkedAssets}
               selectedImportId={selectedImportId}
               isImporting={importContextMutation.isPending}
               onImportSelectionChange={setSelectedImportId}
@@ -489,7 +409,6 @@ function TestCaseModal({
                 if (!selectedImportId) return;
                 importContextMutation.mutate(selectedImportId);
               }}
-              onToggleLink={handleToggleAsset}
             />
             {importContextMutation.isError && (
               <p className={styles.contextImportError}>
@@ -509,16 +428,6 @@ function TestCaseModal({
             />
           </div>
 
-          <div className={styles.fieldGroup}>
-            <p className={styles.fieldLabel}>会話ターン（任意）</p>
-            <p className={styles.modeHint}>
-              実行時の補足情報は上のコンテキスト欄へ、会話として固定したい内容はターンで入力します。
-            </p>
-            <TurnEditor
-              turns={formData.turns}
-              onChange={(turns) => setFormData((prev) => ({ ...prev, turns }))}
-            />
-          </div>
 
           <div className={styles.fieldGroupLg}>
             <label htmlFor="test-case-expected" className={styles.fieldLabel}>
@@ -533,6 +442,20 @@ function TestCaseModal({
               placeholder="期待するアシスタントの振る舞いを記述..."
               rows={3}
               className={styles.fieldTextarea}
+            />
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <p className={styles.fieldLabel}>プロジェクトラベル</p>
+            <p className={styles.modeHint}>
+              必要なプロジェクトにタグ付けできます。
+            </p>
+            <ProjectTagEditor
+              projects={projects}
+              selectedProjectIds={formData.project_ids}
+              onChange={(projectIds) =>
+                setFormData((prev) => ({ ...prev, project_ids: projectIds }))
+              }
             />
           </div>
 
@@ -938,8 +861,7 @@ export function TestCasesPage() {
         <div>
           <h2 className={styles.pageTitle}>テストケース管理</h2>
           <p className={styles.pageDescription}>
-            独立資産としてテストケースを管理し、必要な project や context assets
-            をあとから関連付けます。
+            テストケースを管理します。必要なコンテキスト素材やプロジェクトをあとから関連付けられます。
           </p>
         </div>
         <button type="button" onClick={() => setIsCreateOpen(true)} className={styles.btnPrimary}>

--- a/packages/ui/src/pages/TestCasesPage.tsx
+++ b/packages/ui/src/pages/TestCasesPage.tsx
@@ -17,6 +17,7 @@ import {
   setTestCaseProjects,
   updateIndependentTestCase,
 } from "../lib/api";
+import { useI18n } from "../i18n/I18nProvider";
 import { getStoredActiveLabelId } from "../lib/useActiveLabel";
 import styles from "./TestCasesPage.module.css";
 
@@ -73,6 +74,8 @@ type TurnEditorProps = {
 };
 
 function TurnEditor({ turns, onChange }: TurnEditorProps) {
+  const { t } = useI18n();
+
   function handleRoleChange(index: number, role: "user" | "assistant") {
     onChange(
       turns.map((turn, currentIndex) => (currentIndex === index ? { ...turn, role } : turn)),
@@ -134,8 +137,8 @@ function TurnEditor({ turns, onChange }: TurnEditorProps) {
               }
               className={`${styles.turnSelect} ${turn.role === "user" ? styles.turnSelectUser : styles.turnSelectAssistant}`}
             >
-              <option value="user">ユーザー</option>
-              <option value="assistant">アシスタント</option>
+              <option value="user">{t("testCases.turnUser")}</option>
+              <option value="assistant">{t("testCases.turnAssistant")}</option>
             </select>
             <div className={styles.turnControls}>
               <button
@@ -231,6 +234,8 @@ function ContextAssetPicker({
   onImportSelectionChange,
   onImport,
 }: ContextAssetPickerProps) {
+  const { t } = useI18n();
+
   return (
     <div className={styles.assetSection}>
       <div className={styles.contextImportControls}>
@@ -265,7 +270,7 @@ function ContextAssetPicker({
         </button>
       </div>
       <p className={styles.contextImportHint}>
-        選択した素材の内容をスナップショットとしてコンテキスト欄に取り込みます。
+        {t("testCases.contextImportHint")}
       </p>
     </div>
   );
@@ -294,6 +299,7 @@ function TestCaseModal({
   onSubmit,
   isLoading,
 }: TestCaseModalProps) {
+  const { t } = useI18n();
   const [formData, setFormData] = useState<TestCaseFormData>(() =>
     getInitialFormData(
       testCase,
@@ -384,7 +390,7 @@ function TestCaseModal({
                 タイトル
                 <span className={styles.requiredMark}>*</span>
               </label>
-              <span className={styles.fieldLabelHint}>プロンプトのみで何も参照しない場合はタイトルだけ入力して作成してください。</span>
+              <span className={styles.fieldLabelHint}>{t("testCases.titleHint")}</span>
             </div>
             <input
               id="test-case-title"
@@ -447,9 +453,7 @@ function TestCaseModal({
 
           <div className={styles.fieldGroup}>
             <p className={styles.fieldLabel}>プロジェクトラベル</p>
-            <p className={styles.modeHint}>
-              必要なプロジェクトにタグ付けできます。
-            </p>
+            <p className={styles.modeHint}>{t("testCases.projectLabelHint")}</p>
             <ProjectTagEditor
               projects={projects}
               selectedProjectIds={formData.project_ids}
@@ -618,6 +622,7 @@ type ProjectMembershipMap = Record<number, number[]>;
 type LinkedAssetMap = Record<number, ContextAssetSummary[]>;
 
 export function TestCasesPage() {
+  const { t } = useI18n();
   const queryClient = useQueryClient();
   const { id } = useParams<{ id?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -859,10 +864,8 @@ export function TestCasesPage() {
     <div className={styles.root}>
       <div className={styles.pageHeader}>
         <div>
-          <h2 className={styles.pageTitle}>テストケース管理</h2>
-          <p className={styles.pageDescription}>
-            テストケースを管理します。必要なコンテキスト素材やプロジェクトをあとから関連付けられます。
-          </p>
+          <h2 className={styles.pageTitle}>{t("testCases.title")}</h2>
+          <p className={styles.pageDescription}>{t("testCases.description")}</p>
         </div>
         <button type="button" onClick={() => setIsCreateOpen(true)} className={styles.btnPrimary}>
           + 新規作成


### PR DESCRIPTION
## Summary

- プロンプト管理: ファミリー作成ボタンをアクセント色のアウトラインスタイルに変更し、有効状態が分かりやすくなった
- テストケース管理: ページ説明文の更新、会話ターンUI非表示、プロジェクトラベルをフォーム最下部に移動
- テストケース作成: タイトル横に補足説明を追加、英語文言を日本語化（user/assistant → ユーザー/アシスタント）、未使用の関連付けUIを削除
- コンテキスト素材: ページ説明文更新、プロパティ欄を開閉可能に（デフォルト閉じ）、保存ボタンをエディタ外へ移動、ファイル取込時にテキスト作成フォームを自動キャンセル
- サイドバー: ラベル管理を採点の下に移動

Closes #198

## Test plan

- [ ] プロンプト管理ページでファミリー作成ボタンのスタイルが目立つことを確認
- [ ] テストケース作成ウィンドウで会話ターン欄が非表示になっていることを確認
- [ ] コンテキスト素材ページでプロパティ欄がデフォルト閉じていることを確認
- [ ] サイドバーのラベル管理が採点の下にあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)