### PR TITLE
[#202] UIの気になる点を反映

### DIFF
--- a/packages/ui/src/i18n/messages/en.ts
+++ b/packages/ui/src/i18n/messages/en.ts
@@ -18,14 +18,15 @@ export const enMessages = {
     tabs: {
       ariaLabel: "Extraction page tabs",
       settings: "Settings",
-      review: "Review",
-      goldAnnotations: "Gold Annotations",
+      review: "Review Results",
+      goldAnnotations: "Confirmed Labels",
     },
   },
   prompts: {
     title: "Prompt Management",
-    description: "Manage history by prompt family and filter by project label when needed.",
+    description: "Manage versions by prompt family and filter by project label when needed.",
     familyPanelLabel: "Prompt Families",
+    versionPanelLabel: "Prompt Versions",
     familySummaryLabel: "Family",
     projectFilterLabel: "Project Filter",
     createFamily: "+ Create Family",

--- a/packages/ui/src/i18n/messages/ja.ts
+++ b/packages/ui/src/i18n/messages/ja.ts
@@ -18,15 +18,16 @@ export const jaMessages = {
     tabs: {
       ariaLabel: "抽出ページ切り替え",
       settings: "設定",
-      review: "レビュー",
-      goldAnnotations: "ゴールドアノテーション",
+      review: "抽出結果確認",
+      goldAnnotations: "確定ラベル",
     },
   },
   prompts: {
     title: "プロンプト管理",
     description:
-      "プロンプトファミリー単位で履歴を管理し、必要に応じてプロジェクトラベルで絞り込みます。",
+      "プロンプトファミリー単位でバージョンを管理し、必要に応じてプロジェクトラベルで絞り込みます。",
     familyPanelLabel: "プロンプトファミリー",
+    versionPanelLabel: "プロンプトバージョン",
     familySummaryLabel: "ファミリー",
     projectFilterLabel: "プロジェクトフィルタ",
     createFamily: "+ ファミリー作成",

--- a/packages/ui/src/pages/AnnotationReviewPage.tsx
+++ b/packages/ui/src/pages/AnnotationReviewPage.tsx
@@ -460,7 +460,7 @@ function AnnotationReviewContent({
         <div className={styles.pageHeader}>
           <div>
             <Link to={runsPath} className={styles.backLink}>
-              ← Run 一覧に戻る
+              ← Run一覧に移動する
             </Link>
             <h2 className={styles.pageTitle}>抽出</h2>
           </div>
@@ -477,7 +477,7 @@ function AnnotationReviewContent({
       <div className={styles.pageHeader}>
         <div>
           <Link to={runsPath} className={styles.backLink}>
-            ← Run 一覧に戻る
+            ← Run一覧に移動する
           </Link>
           <h2 className={styles.pageTitle}>抽出</h2>
         </div>

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.module.css
@@ -1,19 +1,4 @@
 .root {
-  --c-bg: #1e1e2e;
-  --c-surface: #313244;
-  --c-border: #45475a;
-  --c-text: #cdd6f4;
-  --c-subtext: #a6adc8;
-  --c-muted: #6c7086;
-  --c-accent: #f9e2af;
-  --c-accent-strong: #fab387;
-  --c-card: #181825;
-  --c-danger: #f38ba8;
-  --c-success: #a6e3a1;
-  --c-input: #11111b;
-  --c-chip: rgba(249, 226, 175, 0.12);
-  --c-select: #cba6f7;
-
   color: var(--c-text);
 }
 
@@ -90,6 +75,14 @@
   gap: 16px;
 }
 
+.inlineForm {
+  margin-top: 8px;
+}
+
+.taskSummary {
+  margin-top: 8px;
+}
+
 .leftAlignedAction {
   display: flex;
   justify-content: flex-start;
@@ -160,6 +153,12 @@
   gap: 14px;
 }
 
+.stackedForm {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
 .taskCard,
 .taskCardActive {
   display: flex;
@@ -170,7 +169,7 @@
   padding: 10px 12px;
   border-radius: 8px;
   border: 1px solid var(--c-border);
-  background: var(--c-bg);
+  background: transparent;
   color: var(--c-text);
   cursor: pointer;
   transition:
@@ -179,12 +178,12 @@
 }
 
 .taskCard:hover {
-  border-color: var(--c-select);
+  border-color: var(--c-accent);
 }
 
 .taskCardActive {
-  border-color: var(--c-select);
-  background: color-mix(in srgb, var(--c-select) 10%, var(--c-card));
+  border-color: var(--c-accent);
+  background: color-mix(in srgb, var(--c-accent) 10%, var(--c-card));
 }
 
 .taskCardTitle {
@@ -231,9 +230,9 @@
   box-sizing: border-box;
   border: 1px solid var(--c-border);
   border-radius: 8px;
-  background: var(--c-surface);
+  background: var(--c-card);
   color: var(--c-text);
-  padding: 9px 12px;
+  padding: 10px 12px;
   font-size: 14px;
   font-family: inherit;
   -webkit-text-fill-color: var(--c-text);
@@ -243,20 +242,19 @@
 .fieldInput::placeholder,
 .fieldTextarea::placeholder {
   color: var(--c-subtext);
-  opacity: 0.6;
+  opacity: 0.45;
 }
 
 .fieldInput:focus,
 .fieldTextarea:focus {
   outline: none;
-  border-color: var(--c-accent);
 }
 
 .fieldInput:-webkit-autofill,
 .fieldInput:-webkit-autofill:hover,
 .fieldInput:-webkit-autofill:focus,
 .fieldInput:-webkit-autofill:active {
-  -webkit-box-shadow: 0 0 0 1000px var(--c-surface) inset !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--c-card) inset !important;
   -webkit-text-fill-color: var(--c-text) !important;
   caret-color: var(--c-text);
 }
@@ -273,7 +271,13 @@
 
 .fieldTextarea {
   resize: vertical;
-  min-height: 110px;
+  min-height: 124px;
+}
+
+.compactTextarea {
+  min-height: 64px;
+  max-height: 64px;
+  overflow-y: auto;
 }
 
 .colorFieldRow {
@@ -289,10 +293,10 @@
 .outputModeBox {
   display: grid;
   gap: 4px;
-  padding: 14px;
+  padding: 10px 12px;
   border-radius: 12px;
   border: 1px solid var(--c-border);
-  background: var(--c-chip);
+  background: var(--c-card);
 }
 
 .outputModeLabel,
@@ -313,50 +317,40 @@
   flex-wrap: wrap;
 }
 
+.formFooterDanger {
+  margin-left: auto;
+}
+
 .primaryButton,
 .secondaryButton,
 .ghostButton,
 .dangerButton {
-  border-radius: 999px;
-  padding: 10px 16px;
+  border-radius: 6px;
+  padding: 9px 16px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   transition:
     opacity 0.15s ease,
-    transform 0.15s ease,
     border-color 0.15s ease;
 }
 
-.primaryButton:hover,
-.secondaryButton:hover,
-.ghostButton:hover,
-.dangerButton:hover {
-  transform: translateY(-1px);
-}
-
 .primaryButton {
-  background: linear-gradient(135deg, var(--c-accent), var(--c-accent-strong));
-  color: #1e1e2e;
-  border: none;
+  composes: btnPrimary from '../styles/shared.module.css';
 }
 
 .secondaryButton {
-  background: var(--c-surface);
-  color: var(--c-text);
-  border: 1px solid var(--c-border);
+  composes: btnSecondary from '../styles/shared.module.css';
 }
 
 .ghostButton {
-  background: transparent;
-  color: var(--c-subtext);
-  border: 1px solid var(--c-border);
+  composes: btnSecondary from '../styles/shared.module.css';
 }
 
 .dangerButton {
-  background: rgba(243, 139, 168, 0.12);
+  background: transparent;
   color: var(--c-danger);
-  border: 1px solid rgba(243, 139, 168, 0.35);
+  border: 1px solid var(--c-danger);
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
+++ b/packages/ui/src/pages/AnnotationTaskSettingsPage.tsx
@@ -5,6 +5,7 @@ import { generateAnnotationPrompt } from "../lib/annotationPrompt";
 import {
   type AnnotationLabel,
   ApiError,
+  type PromptFamily,
   createAnnotationLabel,
   createAnnotationTask,
   createIndependentPromptVersion,
@@ -13,7 +14,6 @@ import {
   deleteAnnotationTask,
   getAnnotationTask,
   getAnnotationTasks,
-  getProject,
   getPromptFamilies,
   setPromptVersionProjects,
   updateAnnotationLabel,
@@ -113,6 +113,25 @@ function buildLabelForm(label?: AnnotationLabel): LabelFormState {
   };
 }
 
+function buildAutoPromptFamilyName(promptFamilies: PromptFamily[]): string {
+  const prefix = "自動カテゴリ抽出用";
+  const pattern = /^自動カテゴリ抽出用（(\d+)）$/;
+  const maxNumber = promptFamilies.reduce((currentMax, family) => {
+    const name = family.name?.trim() ?? "";
+    if (name === prefix) {
+      return Math.max(currentMax, 1);
+    }
+
+    const match = name.match(pattern);
+    if (!match) return currentMax;
+
+    const parsed = Number(match[1]);
+    return Number.isFinite(parsed) ? Math.max(currentMax, parsed) : currentMax;
+  }, 0);
+
+  return `${prefix}（${maxNumber + 1}）`;
+}
+
 export function AnnotationTaskSettingsPage() {
   const projectId = getStoredActiveLabelId() ?? Number.NaN;
   const queryClient = useQueryClient();
@@ -127,12 +146,6 @@ export function AnnotationTaskSettingsPage() {
   const [feedbackTone, setFeedbackTone] = useState<"success" | "error" | null>(null);
   const [taskFormMode, setTaskFormMode] = useState<"create" | "edit" | null>(null);
   const [labelCreateOpen, setLabelCreateOpen] = useState(false);
-
-  const { data: project } = useQuery({
-    queryKey: ["project", projectId],
-    queryFn: () => getProject(projectId),
-    enabled: !Number.isNaN(projectId),
-  });
 
   const tasksQuery = useQuery({
     queryKey: ["annotation-tasks"],
@@ -334,7 +347,8 @@ export function AnnotationTaskSettingsPage() {
 
       let familyId: number;
       if (saveTargetFamilyId === "new") {
-        const family = await createPromptFamily({ name: newFamilyName.trim() || undefined });
+        const familyName = newFamilyName.trim() || buildAutoPromptFamilyName(promptFamilies);
+        const family = await createPromptFamily({ name: familyName });
         await refetchPromptFamilies();
         setSaveTargetFamilyId(family.id);
         familyId = family.id;
@@ -365,10 +379,16 @@ export function AnnotationTaskSettingsPage() {
   function handleGeneratePrompt() {
     const labels = sortedLabels;
     const taskName = taskDetailQuery.data?.name ?? "";
+    const extractionTarget =
+      promptGenTarget.trim() ||
+      labels
+        .map((label) => label.name.trim())
+        .filter((name) => name.length > 0)
+        .join("、");
     const prompt = generateAnnotationPrompt({
       taskName,
       labels,
-      extractionTarget: promptGenTarget.trim(),
+      extractionTarget,
       criteria: promptGenCriteria.trim() || undefined,
     });
     setGeneratedPrompt(prompt);
@@ -399,11 +419,10 @@ export function AnnotationTaskSettingsPage() {
     <div className={styles.root}>
       <div className={styles.pageHeader}>
         <div>
-          <p className={styles.eyebrow}>Annotation Task Settings</p>
           <h2 className={styles.pageTitle}>抽出</h2>
           <p className={styles.pageDescription}>
-            {project?.name ?? "全体"} で使う annotation task と label を準備します。
-            現在の初期実装では output mode は <code>span_label</code> 固定です。
+            抽出タスクとラベルを準備します。
+            現在の初期実装では出力形式は <code>span_label</code> 固定です。
           </p>
           <AnnotationSectionTabs />
         </div>
@@ -419,7 +438,7 @@ export function AnnotationTaskSettingsPage() {
           <div className={styles.sectionHeader}>
             <div>
               <h3 className={styles.sectionTitle}>タスク一覧</h3>
-              <p className={styles.sectionHint}>Review 用に使う task を選択できます。</p>
+              <p className={styles.sectionHint}>自動抽出用に使うタスクを選択できます。</p>
             </div>
           </div>
 
@@ -430,7 +449,7 @@ export function AnnotationTaskSettingsPage() {
             )}
             {!tasksQuery.isLoading && (tasksQuery.data?.length ?? 0) === 0 && (
               <p className={styles.stateText}>
-                まだ task はありません。まず 1 件追加してください。
+                まだタスクはありません。まず 1 件追加してください。
               </p>
             )}
             {(tasksQuery.data ?? []).map((task) => {
@@ -464,17 +483,9 @@ export function AnnotationTaskSettingsPage() {
                   <div>
                     <h3 className={styles.sectionTitle}>タスク設定</h3>
                     <p className={styles.sectionHint}>
-                      Review に使う task 本体の名前と説明を編集します。
+                      レビューに使うタスク本体の名前と説明を編集します。
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    className={styles.dangerButton}
-                    onClick={() => deleteTaskMutation.mutate()}
-                    disabled={deleteTaskMutation.isPending}
-                  >
-                    {deleteTaskMutation.isPending ? "削除中..." : "削除"}
-                  </button>
                 </div>
 
                 {taskFormMode === "edit" ? (
@@ -489,6 +500,7 @@ export function AnnotationTaskSettingsPage() {
                       <div className={styles.fieldGroup}>
                         <label className={styles.fieldLabel} htmlFor="task-name">
                           タスク名
+                          <span className={styles.requiredMark}>*</span>
                         </label>
                         <input
                           id="task-name"
@@ -502,7 +514,7 @@ export function AnnotationTaskSettingsPage() {
 
                       <div className={styles.fieldGroup}>
                         <label className={styles.fieldLabel} htmlFor="task-output-mode">
-                          Output mode
+                          出力形式
                         </label>
                         <input
                           id="task-output-mode"
@@ -519,7 +531,7 @@ export function AnnotationTaskSettingsPage() {
                       </label>
                       <textarea
                         id="task-description"
-                        className={styles.fieldTextarea}
+                        className={`${styles.fieldTextarea} ${styles.compactTextarea}`}
                         value={taskForm.description}
                         onChange={(event) =>
                           setTaskForm((current) => ({
@@ -538,7 +550,7 @@ export function AnnotationTaskSettingsPage() {
                         className={styles.primaryButton}
                         disabled={!canUpdateTask}
                       >
-                        {updateTaskMutation.isPending ? "保存中..." : "タスク設定を保存"}
+                        {updateTaskMutation.isPending ? "保存中..." : "保存"}
                       </button>
                       <button
                         type="button"
@@ -547,6 +559,14 @@ export function AnnotationTaskSettingsPage() {
                         disabled={updateTaskMutation.isPending}
                       >
                         キャンセル
+                      </button>
+                      <button
+                        type="button"
+                        className={`${styles.dangerButton} ${styles.formFooterDanger}`}
+                        onClick={() => deleteTaskMutation.mutate()}
+                        disabled={deleteTaskMutation.isPending}
+                      >
+                        {deleteTaskMutation.isPending ? "削除中..." : "削除"}
                       </button>
                     </div>
                   </form>
@@ -558,7 +578,7 @@ export function AnnotationTaskSettingsPage() {
                         <dd className={styles.summaryValue}>{taskDetailQuery.data.name}</dd>
                       </div>
                       <div className={styles.summaryRow}>
-                        <dt className={styles.summaryLabel}>Output mode</dt>
+                        <dt className={styles.summaryLabel}>出力形式</dt>
                         <dd className={styles.summaryValue}>span_label</dd>
                       </div>
                       <div className={styles.summaryRow}>
@@ -571,59 +591,64 @@ export function AnnotationTaskSettingsPage() {
                   </div>
                 )}
 
-                <div className={styles.leftAlignedAction}>
-                  <button
-                    type="button"
-                    className={styles.secondaryButton}
-                    onClick={() =>
-                      setTaskFormMode((current) => (current === "edit" ? null : "edit"))
-                    }
-                    aria-expanded={taskFormMode === "edit"}
-                  >
-                    {taskFormMode === "edit" ? "タスク編集を閉じる" : "タスクを編集"}
-                  </button>
-                </div>
+                {taskFormMode !== "edit" && (
+                  <div className={styles.leftAlignedAction}>
+                    <button
+                      type="button"
+                      className={styles.secondaryButton}
+                      onClick={() => setTaskFormMode("edit")}
+                      aria-expanded={false}
+                    >
+                      タスクを編集
+                    </button>
+                  </div>
+                )}
               </section>
             )}
 
           <div className={styles.createTaskSection}>
             {taskFormMode === "create" && (
               <form
-                className={styles.panel}
+                className={`${styles.panel} ${styles.stackedForm}`}
                 onSubmit={(event) => {
                   event.preventDefault();
                   createTaskMutation.mutate();
                 }}
               >
-                <label className={styles.fieldLabel} htmlFor="new-task-name">
-                  新規タスク名
-                </label>
-                <input
-                  id="new-task-name"
-                  className={styles.fieldInput}
-                  value={newTaskForm.name}
-                  onChange={(event) =>
-                    setNewTaskForm((current) => ({ ...current, name: event.target.value }))
-                  }
-                  placeholder="例: 回答品質アノテーション"
-                />
+                <div className={styles.fieldGroup}>
+                  <label className={styles.fieldLabel} htmlFor="new-task-name">
+                    新規タスク名
+                    <span className={styles.requiredMark}>*</span>
+                  </label>
+                  <input
+                    id="new-task-name"
+                    className={styles.fieldInput}
+                    value={newTaskForm.name}
+                    onChange={(event) =>
+                      setNewTaskForm((current) => ({ ...current, name: event.target.value }))
+                    }
+                    placeholder="例: 回答品質アノテーション"
+                  />
+                </div>
 
-                <label className={styles.fieldLabel} htmlFor="new-task-description">
-                  説明
-                </label>
-                <textarea
-                  id="new-task-description"
-                  className={styles.fieldTextarea}
-                  value={newTaskForm.description}
-                  onChange={(event) =>
-                    setNewTaskForm((current) => ({ ...current, description: event.target.value }))
-                  }
-                  placeholder="任意: この task の目的や判定基準"
-                  rows={4}
-                />
+                <div className={styles.fieldGroup}>
+                  <label className={styles.fieldLabel} htmlFor="new-task-description">
+                    説明
+                  </label>
+                  <textarea
+                    id="new-task-description"
+                    className={`${styles.fieldTextarea} ${styles.compactTextarea}`}
+                    value={newTaskForm.description}
+                    onChange={(event) =>
+                      setNewTaskForm((current) => ({ ...current, description: event.target.value }))
+                    }
+                    placeholder="任意: このタスクの目的や判定基準"
+                    rows={4}
+                  />
+                </div>
 
                 <div className={styles.outputModeBox}>
-                  <span className={styles.outputModeLabel}>Output mode</span>
+                  <span className={styles.outputModeLabel}>出力形式</span>
                   <strong className={styles.outputModeValue}>span_label</strong>
                   <p className={styles.outputModeHint}>初期実装では固定です。</p>
                 </div>
@@ -664,7 +689,7 @@ export function AnnotationTaskSettingsPage() {
             <div className={styles.emptyState}>
               <h3 className={styles.sectionTitle}>タスクを選択してください</h3>
               <p className={styles.sectionHint}>
-                左側から task を選ぶと、説明や label を編集できます。
+                左側からタスクを選ぶと、説明やラベルを編集できます。
               </p>
             </div>
           ) : taskDetailQuery.isLoading ? (
@@ -681,7 +706,7 @@ export function AnnotationTaskSettingsPage() {
                 <div>
                   <h3 className={styles.sectionTitle}>ラベル設定</h3>
                   <p className={styles.sectionHint}>
-                    カテゴリキー・カテゴリ名・色・表示順を UI から管理できます。
+                    カテゴリキー・カテゴリ名・色・表示順を画面から管理できます。
                   </p>
                 </div>
               </div>
@@ -690,7 +715,7 @@ export function AnnotationTaskSettingsPage() {
                 {sortedLabels.length === 0 ? (
                   <div className={styles.emptyState}>
                     <p className={styles.stateText}>
-                      まだ label はありません。Review で選びたいラベルを追加してください。
+                      まだラベルはありません。自動抽出で選びたいラベルを追加してください。
                     </p>
                   </div>
                 ) : (
@@ -704,7 +729,7 @@ export function AnnotationTaskSettingsPage() {
                           <div>
                             <h4 className={styles.labelTitle}>{label.name}</h4>
                             <p className={styles.labelMeta}>
-                              key: <code>{label.key}</code>
+                              キー: <code>{label.key}</code>
                             </p>
                           </div>
                           <div className={styles.labelActions}>
@@ -760,7 +785,7 @@ export function AnnotationTaskSettingsPage() {
                             />
                             {isEditing && (
                               <p className={styles.fieldHint}>
-                                未入力ならカテゴリ名から自動生成します。
+                                未入力ならアイデアから自動生成します。
                               </p>
                             )}
                           </div>
@@ -871,9 +896,9 @@ export function AnnotationTaskSettingsPage() {
                           onChange={(event) =>
                             setNewLabelForm((current) => ({ ...current, key: event.target.value }))
                           }
-                          placeholder="例: missing_evidence"
+                          placeholder="例: idea"
                         />
-                        <p className={styles.fieldHint}>未入力ならカテゴリ名から自動生成します。</p>
+                        <p className={styles.fieldHint}>未入力ならアイデアから自動生成します。</p>
                       </div>
 
                       <div className={styles.fieldGroup}>
@@ -887,8 +912,9 @@ export function AnnotationTaskSettingsPage() {
                           onChange={(event) =>
                             setNewLabelForm((current) => ({ ...current, name: event.target.value }))
                           }
-                          placeholder="未入力ならカテゴリキーをそのまま使います"
+                          placeholder="例: アイデア"
                         />
+                        <p className={styles.fieldHint}>未入力ならカテゴリキーをそのまま使います。</p>
                       </div>
 
                       <div className={styles.fieldGroup}>
@@ -980,8 +1006,8 @@ export function AnnotationTaskSettingsPage() {
                   aria-expanded={promptGenOpen}
                 >
                   {promptGenOpen
-                    ? "▲ アノテーション用プロンプトを閉じる"
-                    : "▼ アノテーション用プロンプトを生成"}
+                    ? "▲ 自動抽出用プロンプトを閉じる"
+                    : "▼ 自動抽出用プロンプトを生成"}
                 </button>
 
                 {promptGenOpen && (
@@ -989,15 +1015,17 @@ export function AnnotationTaskSettingsPage() {
                     <div className={styles.fieldGroup}>
                       <label className={styles.fieldLabel} htmlFor="prompt-gen-target">
                         抽出対象
-                        <span className={styles.requiredMark}>*</span>
                       </label>
                       <input
                         id="prompt-gen-target"
                         className={styles.fieldInput}
                         value={promptGenTarget}
                         onChange={(e) => setPromptGenTarget(e.target.value)}
-                        placeholder="例: AIとの会話ログ、学習メモ、議事録"
+                        placeholder="例: アイデア"
                       />
+                      <p className={styles.fieldHint}>
+                        未入力の場合は、設定されたラベルのカテゴリ名を「、」区切りで使います。
+                      </p>
                     </div>
 
                     <div className={styles.fieldGroup}>
@@ -1012,6 +1040,9 @@ export function AnnotationTaskSettingsPage() {
                         placeholder="例: アイデアとは新しい発見や方針転換を含む記述を指す"
                         rows={3}
                       />
+                      <p className={styles.fieldHint}>
+                        必要なすべてのカテゴリに関する抽出判定条件を記述してください。
+                      </p>
                     </div>
 
                     <div className={styles.formFooter}>
@@ -1019,7 +1050,7 @@ export function AnnotationTaskSettingsPage() {
                         type="button"
                         className={styles.primaryButton}
                         onClick={handleGeneratePrompt}
-                        disabled={!promptGenTarget.trim() || sortedLabels.length === 0}
+                        disabled={sortedLabels.length === 0}
                       >
                         生成
                       </button>

--- a/packages/ui/src/pages/ExecutionProfilesPage.module.css
+++ b/packages/ui/src/pages/ExecutionProfilesPage.module.css
@@ -36,7 +36,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: var(--c-overlay);
+  background: var(--c-card);
   border: 1px solid var(--c-border);
   border-radius: 12px;
   padding: 20px;
@@ -90,7 +90,7 @@
 
 .profileCardActive {
   border-color: var(--c-accent);
-  background: color-mix(in srgb, var(--c-accent) 12%, var(--c-overlay));
+  background: color-mix(in srgb, var(--c-accent) 10%, var(--c-card));
 }
 
 .profileName {
@@ -131,7 +131,7 @@
 }
 
 .section {
-  background: var(--c-overlay);
+  background: var(--c-card);
   border: 1px solid var(--c-border);
   border-radius: 12px;
   padding: 24px;
@@ -202,11 +202,20 @@
   font: inherit;
   font-size: 14px;
   box-sizing: border-box;
+  -webkit-text-fill-color: var(--c-text);
+  caret-color: var(--c-text);
 }
 
 .fieldTextarea {
   resize: vertical;
   min-height: 88px;
+}
+
+.fieldInput::placeholder,
+.fieldTextarea::placeholder,
+.apiKeyInput::placeholder {
+  color: var(--c-subtext);
+  opacity: 0.45;
 }
 
 .fieldInput:focus,
@@ -215,6 +224,19 @@
 .apiKeyInput:focus {
   border-color: var(--c-accent);
   outline: none;
+}
+
+.fieldInput:-webkit-autofill,
+.fieldInput:-webkit-autofill:hover,
+.fieldInput:-webkit-autofill:focus,
+.fieldInput:-webkit-autofill:active,
+.apiKeyInput:-webkit-autofill,
+.apiKeyInput:-webkit-autofill:hover,
+.apiKeyInput:-webkit-autofill:focus,
+.apiKeyInput:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 1000px var(--c-card) inset !important;
+  -webkit-text-fill-color: var(--c-text) !important;
+  caret-color: var(--c-text);
 }
 
 .fieldHint,
@@ -264,12 +286,11 @@
 }
 
 .primaryButton {
-  padding: 10px 24px;
-  background: var(--c-accent);
-  border: none;
-  border-radius: 8px;
-  color: #1e1e2e;
-  font-size: 14px;
+  composes: btnPrimary from '../styles/shared.module.css';
+  padding: 9px 16px;
+  border-radius: 6px;
+  color: var(--c-overlay);
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   transition: opacity 0.15s;
@@ -285,10 +306,10 @@
 }
 
 .secondaryButton {
+  composes: btnSecondary from '../styles/shared.module.css';
   padding: 9px 16px;
-  background: var(--c-card);
-  border: 1px solid var(--c-border);
-  border-radius: 8px;
+  border-radius: 6px;
+  background: transparent;
   color: var(--c-subtext);
   font-size: 13px;
   cursor: pointer;
@@ -305,8 +326,8 @@
 .dangerButton {
   padding: 9px 16px;
   background: transparent;
-  border: 1px solid rgba(243, 139, 168, 0.45);
-  border-radius: 8px;
+  border: 1px solid var(--c-danger);
+  border-radius: 6px;
   color: var(--c-danger);
   font-size: 13px;
   cursor: pointer;

--- a/packages/ui/src/pages/ExecutionProfilesPage.tsx
+++ b/packages/ui/src/pages/ExecutionProfilesPage.tsx
@@ -47,6 +47,7 @@ export function ExecutionProfilesPage() {
 
   const [apiKeyInput, setApiKeyInput] = useState(apiKey);
   const [selectedProfileId, setSelectedProfileId] = useState<number | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [formState, setFormState] = useState<ProfileFormState>(DEFAULT_FORM_STATE);
   const [saveFeedback, setSaveFeedback] = useState<SaveFeedback>(null);
   const [apiKeySaved, setApiKeySaved] = useState(false);
@@ -95,6 +96,7 @@ export function ExecutionProfilesPage() {
       return;
     }
 
+    setIsCreateOpen(false);
     setFormState({
       name: selectedProfile.name,
       description: selectedProfile.description ?? "",
@@ -145,6 +147,7 @@ export function ExecutionProfilesPage() {
     },
     onSuccess: async (savedProfile) => {
       setSaveFeedback("success");
+      setIsCreateOpen(false);
       setSelectedProfileId(savedProfile.id);
       await queryClient.invalidateQueries({ queryKey: ["execution-profiles"] });
       setTimeout(() => setSaveFeedback(null), 3000);
@@ -159,6 +162,7 @@ export function ExecutionProfilesPage() {
     mutationFn: (id: number) => deleteExecutionProfile(id),
     onSuccess: async () => {
       setSelectedProfileId(null);
+      setIsCreateOpen(false);
       setFormState(DEFAULT_FORM_STATE);
       await queryClient.invalidateQueries({ queryKey: ["execution-profiles"] });
     },
@@ -172,9 +176,13 @@ export function ExecutionProfilesPage() {
   }
 
   function handleCreateNew() {
-    setSelectedProfileId(null);
-    setFormState(DEFAULT_FORM_STATE);
-    setSaveFeedback(null);
+    setIsCreateOpen((current) => {
+      const next = !current;
+      setSelectedProfileId(null);
+      setFormState(DEFAULT_FORM_STATE);
+      setSaveFeedback(null);
+      return next;
+    });
   }
 
   function handleDelete() {
@@ -219,11 +227,10 @@ export function ExecutionProfilesPage() {
     <div className={styles.root}>
       <div className={styles.pageHeader}>
         <div>
-          <p className={styles.eyebrow}>Execution Profiles</p>
           <h2 className={styles.pageTitle}>実行設定</h2>
         </div>
         <button type="button" onClick={handleCreateNew} className={styles.primaryButton}>
-          新規プロファイル
+          {isCreateOpen ? "新規プロファイル作成を閉じる" : "新規プロファイル"}
         </button>
       </div>
 
@@ -239,7 +246,11 @@ export function ExecutionProfilesPage() {
               <button
                 type="button"
                 key={profile.id}
-                onClick={() => setSelectedProfileId(profile.id)}
+                onClick={() => {
+                  setIsCreateOpen(false);
+                  setSelectedProfileId(profile.id);
+                  setSaveFeedback(null);
+                }}
                 className={`${styles.profileCard} ${selectedProfileId === profile.id ? styles.profileCardActive : ""}`}
               >
                 <span className={styles.profileName}>{profile.name}</span>
@@ -258,7 +269,19 @@ export function ExecutionProfilesPage() {
         </aside>
 
         <div className={styles.content}>
-          <section className={styles.section}>
+          {!(selectedProfile || isCreateOpen) && (
+            <section className={styles.section}>
+              <div className={styles.emptyCard}>
+                <p className={styles.emptyTitle}>新規プロファイルはまだ開いていません</p>
+                <p className={styles.emptyText}>
+                  新規プロファイルボタンを押すと作成フォームが開きます。
+                </p>
+              </div>
+            </section>
+          )}
+
+          {(selectedProfile || isCreateOpen) && (
+            <section className={styles.section}>
             <div className={styles.sectionHeader}>
               <div>
                 <h3 className={styles.sectionTitle}>
@@ -442,7 +465,8 @@ export function ExecutionProfilesPage() {
                 <span className={styles.feedbackError}>保存に失敗しました</span>
               )}
             </div>
-          </section>
+            </section>
+          )}
 
           <section className={styles.section}>
             <h3 className={styles.sectionTitle}>モデル候補取得用 API キー</h3>

--- a/packages/ui/src/pages/PromptsPage.module.css
+++ b/packages/ui/src/pages/PromptsPage.module.css
@@ -22,7 +22,7 @@
 }
 
 .pageDescription {
-  margin: 0;
+  margin: 8px 0 0;
   font-size: 13px;
   color: var(--c-muted);
 }

--- a/packages/ui/src/pages/PromptsPage.tsx
+++ b/packages/ui/src/pages/PromptsPage.tsx
@@ -1209,7 +1209,7 @@ export function PromptsPage() {
           </section>
 
           <section className={styles.treePanel}>
-            <div className={styles.treePanelLabel}>バージョン履歴</div>
+            <div className={styles.treePanelLabel}>{t("prompts.versionPanelLabel")}</div>
             {selectedFamily && (
               <p className={styles.treeFamilyName}>
                 {selectedFamily.name ?? `ファミリー ${selectedFamily.id}`}

--- a/packages/ui/src/styles/shared.module.css
+++ b/packages/ui/src/styles/shared.module.css
@@ -100,6 +100,12 @@
   font-family: inherit;
 }
 
+.fieldInput::placeholder,
+.fieldTextarea::placeholder {
+  color: var(--c-subtext);
+  opacity: 0.45;
+}
+
 .formActions {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## 概要
- UI で気になった点をまとめて調整
- 抽出ページと実行設定ページの文言・配色・フォーム挙動を整理
- 自動抽出用プロンプト生成まわりの挙動を改善

## 主な変更
- 抽出ページの文言見直し、タブ名変更、フォーム配置と色味の調整
- 実行設定ページの色味調整と新規プロファイルフォームの開閉化
- プロンプト管理ページの説明文・ラベル名の見直し
- 自動抽出用プロンプト生成で抽出対象未入力時の補完と保存先ファミリー名の自動設定を追加

## 確認
- pnpm --filter @prompt-reviewer/ui typecheck を実行
- 既存の packages/ui/src/pages/TestCasesPage.tsx の未使用 TurnEditor により失敗